### PR TITLE
Migrate to the GOVC style variables.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -180,6 +180,14 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:53becd66889185091b58ea3fc49294996f2179fb05a89702f4de7d15e581b509"
+  name = "github.com/go-logr/logr"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "9fb12b3b21c5415d16ac18dc5cd42c1cfdd40c4e"
+  version = "v0.1.0"
+
+[[projects]]
   digest = "1:fcd8ddc48ce648d5fbb36029fe3dd98f29c03377eea5c4a3c436701b0e3f2774"
   name = "github.com/gobuffalo/envy"
   packages = ["."]
@@ -354,6 +362,23 @@
   version = "v1.4.0"
 
 [[projects]]
+  branch = "govmomi"
+  digest = "1:f49ed6cb2129e9a3ce9dde5037cb243b5849c0ec0c7973b9d1e987872d8b8cc6"
+  name = "github.com/kr/pretty"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "2ee9d7453c02ef7fa518a83ae23644eb8872186a"
+  source = "https://github.com/dougm/pretty"
+
+[[projects]]
+  digest = "1:c3a7836b5904db0f8b609595b619916a6831cb35b8b714aec39f96d00c6155d8"
+  name = "github.com/kr/text"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "702c74938df48b97370179f33ce2107bd7ff3b3e"
+  version = "v0.2.0"
+
+[[projects]]
   branch = "master"
   digest = "1:a12508addb76a16593d8a3cee41d782fdf738f727d421f0bcc2dd2ee76821c01"
   name = "github.com/lightstep/tracecontext.go"
@@ -499,12 +524,91 @@
   version = "v1.0.3"
 
 [[projects]]
-  digest = "1:c5336b58ab8612bdb24b05b581007d849112c78257df38511878ad6928e8a65c"
+  digest = "1:fc07dbc731c0cc53d669fe56f09819b8f342f90f8a2e3a8638817f21ddcb26ae"
   name = "github.com/vmware/govmomi"
   packages = [
     ".",
     "event",
     "find",
+    "govc",
+    "govc/about",
+    "govc/cli",
+    "govc/cluster",
+    "govc/cluster/group",
+    "govc/cluster/override",
+    "govc/cluster/rule",
+    "govc/datacenter",
+    "govc/datastore",
+    "govc/datastore/cluster",
+    "govc/datastore/disk",
+    "govc/datastore/maintenance",
+    "govc/datastore/vsan",
+    "govc/device",
+    "govc/device/cdrom",
+    "govc/device/floppy",
+    "govc/device/scsi",
+    "govc/device/serial",
+    "govc/device/usb",
+    "govc/disk",
+    "govc/disk/snapshot",
+    "govc/dvs",
+    "govc/dvs/portgroup",
+    "govc/env",
+    "govc/events",
+    "govc/export",
+    "govc/extension",
+    "govc/fields",
+    "govc/flags",
+    "govc/folder",
+    "govc/host",
+    "govc/host/account",
+    "govc/host/autostart",
+    "govc/host/cert",
+    "govc/host/date",
+    "govc/host/esxcli",
+    "govc/host/firewall",
+    "govc/host/maintenance",
+    "govc/host/option",
+    "govc/host/portgroup",
+    "govc/host/service",
+    "govc/host/storage",
+    "govc/host/vnic",
+    "govc/host/vswitch",
+    "govc/importx",
+    "govc/library",
+    "govc/library/session",
+    "govc/license",
+    "govc/logs",
+    "govc/ls",
+    "govc/metric",
+    "govc/metric/interval",
+    "govc/object",
+    "govc/option",
+    "govc/permissions",
+    "govc/pool",
+    "govc/role",
+    "govc/session",
+    "govc/sso",
+    "govc/sso/group",
+    "govc/sso/service",
+    "govc/sso/user",
+    "govc/tags",
+    "govc/tags/association",
+    "govc/tags/category",
+    "govc/task",
+    "govc/vapp",
+    "govc/version",
+    "govc/vm",
+    "govc/vm/disk",
+    "govc/vm/guest",
+    "govc/vm/network",
+    "govc/vm/option",
+    "govc/vm/rdm",
+    "govc/vm/snapshot",
+    "guest",
+    "guest/toolbox",
+    "internal",
+    "license",
     "list",
     "lookup",
     "lookup/methods",
@@ -517,20 +621,27 @@
     "pbm/methods",
     "pbm/simulator",
     "pbm/types",
+    "performance",
     "property",
     "session",
     "simulator",
     "simulator/esx",
     "simulator/internal",
     "simulator/vpx",
+    "ssoadmin",
+    "ssoadmin/methods",
+    "ssoadmin/types",
+    "sts",
     "sts/internal",
     "sts/simulator",
     "task",
+    "units",
     "vapi/cluster",
     "vapi/cluster/internal",
     "vapi/cluster/simulator",
     "vapi/internal",
     "vapi/library",
+    "vapi/library/finder",
     "vapi/rest",
     "vapi/simulator",
     "vapi/tags",
@@ -545,6 +656,10 @@
     "vim25/soap",
     "vim25/types",
     "vim25/xml",
+    "vmdk",
+    "vslm",
+    "vslm/methods",
+    "vslm/types",
   ]
   pruneopts = "NUT"
   revision = "e7df0c1118c15c0b35fe08f183ca084269ea6542"
@@ -1288,6 +1403,7 @@
     "apis/duck/v1",
     "apis/duck/v1alpha1",
     "apis/duck/v1beta1",
+    "apis/testing",
     "changeset",
     "client/injection/ducks/duck/v1/podspecable",
     "client/injection/kube/client",
@@ -1295,6 +1411,7 @@
     "client/injection/kube/informers/admissionregistration/v1beta1/validatingwebhookconfiguration",
     "client/injection/kube/informers/apps/v1/deployment",
     "client/injection/kube/informers/core/v1/configmap",
+    "client/injection/kube/informers/core/v1/serviceaccount",
     "client/injection/kube/informers/factory",
     "client/injection/kube/informers/rbac/v1/rolebinding",
     "codegen/cmd/injection-gen",
@@ -1321,6 +1438,12 @@
     "signals",
     "source",
     "system",
+    "test",
+    "test/ingress",
+    "test/logging",
+    "test/monitoring",
+    "test/spoof",
+    "test/zipkin",
     "tracing",
     "tracing/config",
     "tracker",
@@ -1361,9 +1484,12 @@
   analyzer-version = 1
   input-imports = [
     "github.com/cloudevents/sdk-go/v1",
+    "github.com/google/go-cmp/cmp",
     "github.com/kelseyhightower/envconfig",
     "github.com/vmware/govmomi",
     "github.com/vmware/govmomi/event",
+    "github.com/vmware/govmomi/govc",
+    "github.com/vmware/govmomi/vapi/rest",
     "github.com/vmware/govmomi/vcsim",
     "github.com/vmware/govmomi/vim25/soap",
     "github.com/vmware/govmomi/vim25/types",
@@ -1411,10 +1537,12 @@
     "knative.dev/pkg/apis/duck",
     "knative.dev/pkg/apis/duck/v1",
     "knative.dev/pkg/apis/duck/v1alpha1",
+    "knative.dev/pkg/apis/testing",
     "knative.dev/pkg/client/injection/ducks/duck/v1/podspecable",
     "knative.dev/pkg/client/injection/kube/client",
     "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment",
     "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap",
+    "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount",
     "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding",
     "knative.dev/pkg/codegen/cmd/injection-gen",
     "knative.dev/pkg/configmap",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -12,6 +12,7 @@ required = [
   "knative.dev/test-infra/tools/dep-collector",
   # For testing.
   "github.com/vmware/govmomi/vcsim",
+  "github.com/vmware/govmomi/govc",
 ]
 
 [[override]]

--- a/example.yaml
+++ b/example.yaml
@@ -1,85 +1,38 @@
-apiVersion: v1
-kind: Secret
+apiVersion: eventing.knative.dev/v1alpha1
+kind: Trigger
 metadata:
-  name: vsphere-credentials
-stringData:
-  username: user
-  password: pass
+  name: to-sockeye
+spec:
+  filter:
+    attributes:
+      type: com.vmware.vsphere.vmcreatedevent
+    # attributes:
+    #   type: dev.mattmoor.vsample
+  subscriber:
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: sockeye
 ---
-# apiVersion: apps/v1
-# kind: Deployment
-# metadata:
-#   name: adapter-test
-# spec:
-#   selector:
-#     matchLabels:
-#       app: adapter
-#   template:
-#     metadata:
-#       labels:
-#         app: adapter
-#     spec:
-#       containers:
-#       - name: adapter
-#         image: ko://github.com/mattmoor/vmware-sources/cmd/receive_adapter
-#         env:
-#         - name: NAMESPACE
-#           valueFrom:
-#             fieldRef:
-#               fieldPath: metadata.namespace
-#         - name: K_SINK
-#           value: http://sockeye.default.svc.cluster.local
-#         - name: K_METRICS_CONFIG
-#           value: '{}'
-#         - name: K_LOGGING_CONFIG
-#           value: '{}'
-#         - name: GOVMOMI_ADDRESS
-#           value: vcsim.default.svc.cluster.local
-#         - name: GOVMOMI_INSECURE
-#           value: "true"
 
-#         volumeMounts:
-#         - mountPath: /var/bindings/vsphere
-#           name: vsphere-binding
-#           readOnly: true
 
-#       volumes:
-#       - name: vsphere-binding
-#         secret:
-#           secretName: vsphere-credentials
+apiVersion: sources.knative.dev/v1alpha1
+kind: VSphereSource
+metadata:
+ name: vcsim
+spec:
+ sink:
+   ref:
+     apiVersion: eventing.knative.dev/v1beta1
+     kind: Broker
+     name: default
 
-#---
-#apiVersion: sources.knative.dev/v1alpha1
-#kind: VSphereSource
-#metadata:
-#  name: blah
-#  namespace: broker-test
-#spec:
-#  sink:
-#    ref:
-#      apiVersion: eventing.knative.dev/v1beta1
-#      kind: Broker
-#      name: ville-broker
+ address: https://vcsim.default.svc.cluster.local
+ skipTLSVerify: true
+ secretRef:
+   name: vsphere-credentials
+---
 
-#  address: vcsim.default.svc.cluster.local
-#  skipTLSVerify: true
-#  secretRef:
-#    name: vsphere-credentials
-# ---
-# apiVersion: eventing.knative.dev/v1alpha1
-# kind: Trigger
-# metadata:
-#   name: to-sockeye
-# spec:
-#   filter:
-#     # attributes:
-#     #   type: com.vmware.vsphere.datacentercreatedevent
-#   subscriber:
-#     ref:
-#       apiVersion: serving.knative.dev/v1
-#       kind: Service
-#       name: sockeye
-# ---
 # apiVersion: sources.knative.dev/v1alpha1
 # kind: VSphereBinding
 # metadata:

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -55,4 +55,5 @@ rm -rf $(find vendor/ -name '*_test.go')
 git apply ${REPO_ROOT_DIR}/vendor/knative.dev/eventing/hack/set-span-id.patch
 
 # Do this for every package under "cmd" except kodata and cmd itself.
-update_licenses third_party/VENDOR-LICENSE "$(find ./cmd -type d | grep -v kodata | grep -vE 'cmd$')"
+# TODO(mattmoor): Disabling this because govmomi has a directory named LICENSE this chokes on.
+# update_licenses third_party/VENDOR-LICENSE "$(find ./cmd -type d | grep -v kodata | grep -vE 'cmd$')"

--- a/pkg/apis/sources/v1alpha1/vspherebinding_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/vspherebinding_lifecycle.go
@@ -100,23 +100,61 @@ func (vsb *VSphereBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 	for i := range spec.InitContainers {
 		spec.InitContainers[i].VolumeMounts = append(spec.InitContainers[i].VolumeMounts, volumeMount)
 		spec.InitContainers[i].Env = append(spec.InitContainers[i].Env, corev1.EnvVar{
-			Name:  "GOVMOMI_ADDRESS",
+			Name:  "GOVC_URL",
 			Value: vsb.Spec.Address.String(),
-		})
-		spec.InitContainers[i].Env = append(spec.InitContainers[i].Env, corev1.EnvVar{
-			Name:  "GOVMOMI_INSECURE",
+		}, corev1.EnvVar{
+			Name:  "GOVC_INSECURE",
 			Value: fmt.Sprintf("%v", vsb.Spec.SkipTLSVerify),
+		}, corev1.EnvVar{
+			Name: "GOVC_USERNAME",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: vsb.Spec.SecretRef.Name,
+					},
+					Key: corev1.BasicAuthUsernameKey,
+				},
+			},
+		}, corev1.EnvVar{
+			Name: "GOVC_PASSWORD",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: vsb.Spec.SecretRef.Name,
+					},
+					Key: corev1.BasicAuthPasswordKey,
+				},
+			},
 		})
 	}
 	for i := range spec.Containers {
 		spec.Containers[i].VolumeMounts = append(spec.Containers[i].VolumeMounts, volumeMount)
 		spec.Containers[i].Env = append(spec.Containers[i].Env, corev1.EnvVar{
-			Name:  "GOVMOMI_ADDRESS",
+			Name:  "GOVC_URL",
 			Value: vsb.Spec.Address.String(),
-		})
-		spec.Containers[i].Env = append(spec.Containers[i].Env, corev1.EnvVar{
-			Name:  "GOVMOMI_INSECURE",
+		}, corev1.EnvVar{
+			Name:  "GOVC_INSECURE",
 			Value: fmt.Sprintf("%v", vsb.Spec.SkipTLSVerify),
+		}, corev1.EnvVar{
+			Name: "GOVC_USERNAME",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: vsb.Spec.SecretRef.Name,
+					},
+					Key: corev1.BasicAuthUsernameKey,
+				},
+			},
+		}, corev1.EnvVar{
+			Name: "GOVC_PASSWORD",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: vsb.Spec.SecretRef.Name,
+					},
+					Key: corev1.BasicAuthPasswordKey,
+				},
+			},
 		})
 	}
 }
@@ -145,7 +183,7 @@ func (vsb *VSphereBinding) Undo(ctx context.Context, ps *duckv1.WithPod) {
 		env := make([]corev1.EnvVar, 0, len(spec.InitContainers[i].Env))
 		for j, ev := range c.Env {
 			switch ev.Name {
-			case "GOVMOMI_ADDRESS", "GOVMOMI_INSECURE":
+			case "GOVC_URL", "GOVC_INSECURE", "GOVC_USERNAME", "GOVC_PASSWORD":
 				continue
 			default:
 				env = append(env, spec.InitContainers[i].Env[j])
@@ -167,7 +205,7 @@ func (vsb *VSphereBinding) Undo(ctx context.Context, ps *duckv1.WithPod) {
 		env := make([]corev1.EnvVar, 0, len(spec.Containers[i].Env))
 		for j, ev := range c.Env {
 			switch ev.Name {
-			case "GOVMOMI_ADDRESS", "GOVMOMI_INSECURE":
+			case "GOVC_URL", "GOVC_INSECURE", "GOVC_USERNAME", "GOVC_PASSWORD":
 				continue
 			default:
 				env = append(env, spec.Containers[i].Env[j])

--- a/pkg/apis/sources/v1alpha1/vspherebinding_lifecycle_test.go
+++ b/pkg/apis/sources/v1alpha1/vspherebinding_lifecycle_test.go
@@ -109,14 +109,17 @@ func TestVSphereBindingUndo(t *testing.T) {
 								Name:  "FOO",
 								Value: "BAR",
 							}, {
-								Name:  "GOVMOMI_ADDRESS",
+								Name:  "GOVC_URL",
 								Value: "http://localhost:8080",
 							}, {
 								Name:  "BAZ",
 								Value: "INGA",
 							}, {
-								Name:  "GOVMOMI_INSECURE",
+								Name:  "GOVC_INSECURE",
 								Value: "false",
+							}, {
+								Name:  "GOVC_USERNAME",
+								Value: "user",
 							}},
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      vsphere.VolumeName,
@@ -131,11 +134,14 @@ func TestVSphereBindingUndo(t *testing.T) {
 								Name:  "FOO",
 								Value: "BAR",
 							}, {
-								Name:  "GOVMOMI_ADDRESS",
+								Name:  "GOVC_URL",
 								Value: "http://localhost:8080",
 							}, {
 								Name:  "BAZ",
 								Value: "INGA",
+							}, {
+								Name:  "GOVC_PASSWORD",
+								Value: "pass",
 							}},
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      vsphere.VolumeName,
@@ -146,13 +152,13 @@ func TestVSphereBindingUndo(t *testing.T) {
 							Name:  "sidecar",
 							Image: "busybox",
 							Env: []corev1.EnvVar{{
-								Name:  "GOVMOMI_ADDRESS",
+								Name:  "GOVC_URL",
 								Value: "http://localhost:8080",
 							}, {
 								Name:  "BAZ",
 								Value: "INGA",
 							}, {
-								Name:  "GOVMOMI_INSECURE",
+								Name:  "GOVC_INSECURE",
 								Value: "true",
 							}},
 							VolumeMounts: []corev1.VolumeMount{{
@@ -260,11 +266,31 @@ func TestVSphereBindingDo(t *testing.T) {
 							Name:  "blah",
 							Image: "busybox",
 							Env: []corev1.EnvVar{{
-								Name:  "GOVMOMI_ADDRESS",
+								Name:  "GOVC_URL",
 								Value: url.String(),
 							}, {
-								Name:  "GOVMOMI_INSECURE",
+								Name:  "GOVC_INSECURE",
 								Value: "false",
+							}, {
+								Name: "GOVC_USERNAME",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: secretName,
+										},
+										Key: corev1.BasicAuthUsernameKey,
+									},
+								},
+							}, {
+								Name: "GOVC_PASSWORD",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: secretName,
+										},
+										Key: corev1.BasicAuthPasswordKey,
+									},
+								},
 							}},
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      vsphere.VolumeName,
@@ -292,11 +318,31 @@ func TestVSphereBindingDo(t *testing.T) {
 							Name:  "blah",
 							Image: "busybox",
 							Env: []corev1.EnvVar{{
-								Name:  "GOVMOMI_ADDRESS",
+								Name:  "GOVC_URL",
 								Value: url.String(),
 							}, {
-								Name:  "GOVMOMI_INSECURE",
+								Name:  "GOVC_INSECURE",
 								Value: "false",
+							}, {
+								Name: "GOVC_USERNAME",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: secretName,
+										},
+										Key: corev1.BasicAuthUsernameKey,
+									},
+								},
+							}, {
+								Name: "GOVC_PASSWORD",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: secretName,
+										},
+										Key: corev1.BasicAuthPasswordKey,
+									},
+								},
 							}},
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      vsphere.VolumeName,
@@ -326,11 +372,31 @@ func TestVSphereBindingDo(t *testing.T) {
 							Name:  "blah",
 							Image: "busybox",
 							Env: []corev1.EnvVar{{
-								Name:  "GOVMOMI_ADDRESS",
+								Name:  "GOVC_URL",
 								Value: "the wrong value",
 							}, {
-								Name:  "GOVMOMI_INSECURE",
+								Name:  "GOVC_INSECURE",
 								Value: `{"extensions":{"wrong":"value"}}`,
+							}, {
+								Name: "GOVC_USERNAME",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: secretName,
+										},
+										Key: corev1.BasicAuthUsernameKey,
+									},
+								},
+							}, {
+								Name: "GOVC_PASSWORD",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: secretName,
+										},
+										Key: corev1.BasicAuthPasswordKey,
+									},
+								},
 							}},
 						}},
 					},
@@ -345,11 +411,31 @@ func TestVSphereBindingDo(t *testing.T) {
 							Name:  "blah",
 							Image: "busybox",
 							Env: []corev1.EnvVar{{
-								Name:  "GOVMOMI_ADDRESS",
+								Name:  "GOVC_URL",
 								Value: url.String(),
 							}, {
-								Name:  "GOVMOMI_INSECURE",
+								Name:  "GOVC_INSECURE",
 								Value: "false",
+							}, {
+								Name: "GOVC_USERNAME",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: secretName,
+										},
+										Key: corev1.BasicAuthUsernameKey,
+									},
+								},
+							}, {
+								Name: "GOVC_PASSWORD",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: secretName,
+										},
+										Key: corev1.BasicAuthPasswordKey,
+									},
+								},
 							}},
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      vsphere.VolumeName,
@@ -409,11 +495,31 @@ func TestVSphereBindingDo(t *testing.T) {
 							Name:  "setup",
 							Image: "busybox",
 							Env: []corev1.EnvVar{{
-								Name:  "GOVMOMI_ADDRESS",
+								Name:  "GOVC_URL",
 								Value: url.String(),
 							}, {
-								Name:  "GOVMOMI_INSECURE",
+								Name:  "GOVC_INSECURE",
 								Value: "false",
+							}, {
+								Name: "GOVC_USERNAME",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: secretName,
+										},
+										Key: corev1.BasicAuthUsernameKey,
+									},
+								},
+							}, {
+								Name: "GOVC_PASSWORD",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: secretName,
+										},
+										Key: corev1.BasicAuthPasswordKey,
+									},
+								},
 							}},
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      vsphere.VolumeName,
@@ -431,11 +537,31 @@ func TestVSphereBindingDo(t *testing.T) {
 								Name:  "BAZ",
 								Value: "INGA",
 							}, {
-								Name:  "GOVMOMI_ADDRESS",
+								Name:  "GOVC_URL",
 								Value: url.String(),
 							}, {
-								Name:  "GOVMOMI_INSECURE",
+								Name:  "GOVC_INSECURE",
 								Value: "false",
+							}, {
+								Name: "GOVC_USERNAME",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: secretName,
+										},
+										Key: corev1.BasicAuthUsernameKey,
+									},
+								},
+							}, {
+								Name: "GOVC_PASSWORD",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: secretName,
+										},
+										Key: corev1.BasicAuthPasswordKey,
+									},
+								},
 							}},
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      vsphere.VolumeName,
@@ -449,11 +575,31 @@ func TestVSphereBindingDo(t *testing.T) {
 								Name:  "BAZ",
 								Value: "INGA",
 							}, {
-								Name:  "GOVMOMI_ADDRESS",
+								Name:  "GOVC_URL",
 								Value: url.String(),
 							}, {
-								Name:  "GOVMOMI_INSECURE",
+								Name:  "GOVC_INSECURE",
 								Value: "false",
+							}, {
+								Name: "GOVC_USERNAME",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: secretName,
+										},
+										Key: corev1.BasicAuthUsernameKey,
+									},
+								},
+							}, {
+								Name: "GOVC_PASSWORD",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: secretName,
+										},
+										Key: corev1.BasicAuthPasswordKey,
+									},
+								},
 							}},
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      vsphere.VolumeName,

--- a/pkg/vsphere/client.go
+++ b/pkg/vsphere/client.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vim25/soap"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -34,8 +35,8 @@ const (
 )
 
 type EnvConfig struct {
-	Insecure bool   `envconfig:"GOVMOMI_INSECURE" default:"false"`
-	Address  string `envconfig:"GOVMOMI_ADDRESS" required:"true"`
+	Insecure bool   `envconfig:"GOVC_INSECURE" default:"false"`
+	Address  string `envconfig:"GOVC_URL" required:"true"`
 }
 
 // ReadKey may be used to read keys from the secret.
@@ -70,6 +71,41 @@ func New(ctx context.Context) (*govmomi.Client, error) {
 	parsedURL.User = url.UserPassword(username, password)
 
 	return govmomi.NewClient(ctx, parsedURL, env.Insecure)
+}
+
+func NewREST(ctx context.Context) (*rest.Client, error) {
+	var env EnvConfig
+	if err := envconfig.Process("", &env); err != nil {
+		return nil, err
+	}
+
+	parsedURL, err := soap.ParseURL(env.Address)
+	if err != nil {
+		return nil, err
+	}
+
+	// Read the username and password from the filesystem.
+	username, err := ReadKey(corev1.BasicAuthUsernameKey)
+	if err != nil {
+		return nil, err
+	}
+	password, err := ReadKey(corev1.BasicAuthPasswordKey)
+	if err != nil {
+		return nil, err
+	}
+	parsedURL.User = url.UserPassword(username, password)
+
+	soapclient, err := govmomi.NewClient(ctx, parsedURL, env.Insecure)
+	if err != nil {
+		return nil, err
+	}
+
+	// For whatever reason the rest client doesn't inherit the SOAP client's auth.
+	restclient := rest.NewClient(soapclient.Client)
+	if err := restclient.Login(ctx, parsedURL.User); err != nil {
+		return nil, err
+	}
+	return restclient, nil
 }
 
 func Address(ctx context.Context) (string, error) {

--- a/tags.yaml
+++ b/tags.yaml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: vcsim-setup-tags-
+  labels:
+    vcsim: setup
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+      - name: create-category
+        image: ko://github.com/mattmoor/vmware-sources/vendor/github.com/vmware/govmomi/govc
+        args: ["tags.category.create", "testing"]
+      containers:
+      - name: create-tag
+        image: ko://github.com/mattmoor/vmware-sources/vendor/github.com/vmware/govmomi/govc
+        args: ["tags.create", "-c", "testing", "shrug"]

--- a/vcsim.yaml
+++ b/vcsim.yaml
@@ -39,3 +39,30 @@ spec:
   - name: https
     port: 443
     targetPort: 8989
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-credentials
+stringData:
+  username: user
+  password: pass
+---
+
+apiVersion: sources.knative.dev/v1alpha1
+kind: VSphereBinding
+metadata:
+  name: vcsim-setup
+spec:
+  subject:
+    apiVersion: batch/v1
+    kind: Job
+    selector:
+      matchLabels:
+        vcsim: setup
+
+  address: https://vcsim.default.svc.cluster.local
+  skipTLSVerify: true
+  secretRef:
+    name: vsphere-credentials

--- a/vendor/github.com/go-logr/logr/LICENSE
+++ b/vendor/github.com/go-logr/logr/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/go-logr/logr/logr.go
+++ b/vendor/github.com/go-logr/logr/logr.go
@@ -1,0 +1,151 @@
+// Package logr defines abstract interfaces for logging.  Packages can depend on
+// these interfaces and callers can implement logging in whatever way is
+// appropriate.
+//
+// This design derives from Dave Cheney's blog:
+//     http://dave.cheney.net/2015/11/05/lets-talk-about-logging
+//
+// This is a BETA grade API.  Until there is a significant 2nd implementation,
+// I don't really know how it will change.
+//
+// The logging specifically makes it non-trivial to use format strings, to encourage
+// attaching structured information instead of unstructured format strings.
+//
+// Usage
+//
+// Logging is done using a Logger.  Loggers can have name prefixes and named values
+// attached, so that all log messages logged with that Logger have some base context
+// associated.
+//
+// The term "key" is used to refer to the name associated with a particular value, to
+// disambiguate it from the general Logger name.
+//
+// For instance, suppose we're trying to reconcile the state of an object, and we want
+// to log that we've made some decision.
+//
+// With the traditional log package, we might write
+//  log.Printf(
+//      "decided to set field foo to value %q for object %s/%s",
+//       targetValue, object.Namespace, object.Name)
+//
+// With logr's structured logging, we'd write
+//  // elsewhere in the file, set up the logger to log with the prefix of "reconcilers",
+//  // and the named value target-type=Foo, for extra context.
+//  log := mainLogger.WithName("reconcilers").WithValues("target-type", "Foo")
+//
+//  // later on...
+//  log.Info("setting field foo on object", "value", targetValue, "object", object)
+//
+// Depending on our logging implementation, we could then make logging decisions based on field values
+// (like only logging such events for objects in a certain namespace), or copy the structured
+// information into a structured log store.
+//
+// For logging errors, Logger has a method called Error.  Suppose we wanted to log an
+// error while reconciling.  With the traditional log package, we might write
+//   log.Errorf("unable to reconcile object %s/%s: %v", object.Namespace, object.Name, err)
+//
+// With logr, we'd instead write
+//   // assuming the above setup for log
+//   log.Error(err, "unable to reconcile object", "object", object)
+//
+// This functions similarly to:
+//   log.Info("unable to reconcile object", "error", err, "object", object)
+//
+// However, it ensures that a standard key for the error value ("error") is used across all
+// error logging.  Furthermore, certain implementations may choose to attach additional
+// information (such as stack traces) on calls to Error, so it's preferred to use Error
+// to log errors.
+//
+// Parts of a log line
+//
+// Each log message from a Logger has four types of context:
+// logger name, log verbosity, log message, and the named values.
+//
+// The Logger name constists of a series of name "segments" added by successive calls to WithName.
+// These name segments will be joined in some way by the underlying implementation.  It is strongly
+// reccomended that name segements contain simple identifiers (letters, digits, and hyphen), and do
+// not contain characters that could muddle the log output or confuse the joining operation (e.g.
+// whitespace, commas, periods, slashes, brackets, quotes, etc).
+//
+// Log verbosity represents how little a log matters.  Level zero, the default, matters most.
+// Increasing levels matter less and less.  Try to avoid lots of different verbosity levels,
+// and instead provide useful keys, logger names, and log messages for users to filter on.
+// It's illegal to pass a log level below zero.
+//
+// The log message consists of a constant message attached to the the log line.  This
+// should generally be a simple description of what's occuring, and should never be a format string.
+//
+// Variable information can then be attached using named values (key/value pairs).  Keys are arbitrary
+// strings, while values may be any Go value.
+//
+// Key Naming Conventions
+//
+// While users are generally free to use key names of their choice, it's generally best to avoid
+// using the following keys, as they're frequently used by implementations:
+//
+// - `"error"`: the underlying error value in the `Error` method.
+// - `"stacktrace"`: the stack trace associated with a particular log line or error
+//                   (often from the `Error` message).
+// - `"caller"`: the calling information (file/line) of a particular log line.
+// - `"msg"`: the log message.
+// - `"level"`: the log level.
+// - `"ts"`: the timestamp for a log line.
+//
+// Implementations are encouraged to make use of these keys to represent the above
+// concepts, when neccessary (for example, in a pure-JSON output form, it would be
+// necessary to represent at least message and timestamp as ordinary named values).
+package logr
+
+// TODO: consider adding back in format strings if they're really needed
+// TODO: consider other bits of zap/zapcore functionality like ObjectMarshaller (for arbitrary objects)
+// TODO: consider other bits of glog functionality like Flush, InfoDepth, OutputStats
+
+// InfoLogger represents the ability to log non-error messages, at a particular verbosity.
+type InfoLogger interface {
+	// Info logs a non-error message with the given key/value pairs as context.
+	//
+	// The msg argument should be used to add some constant description to
+	// the log line.  The key/value pairs can then be used to add additional
+	// variable information.  The key/value pairs should alternate string
+	// keys and arbitrary values.
+	Info(msg string, keysAndValues ...interface{})
+
+	// Enabled tests whether this InfoLogger is enabled.  For example,
+	// commandline flags might be used to set the logging verbosity and disable
+	// some info logs.
+	Enabled() bool
+}
+
+// Logger represents the ability to log messages, both errors and not.
+type Logger interface {
+	// All Loggers implement InfoLogger.  Calling InfoLogger methods directly on
+	// a Logger value is equivalent to calling them on a V(0) InfoLogger.  For
+	// example, logger.Info() produces the same result as logger.V(0).Info.
+	InfoLogger
+
+	// Error logs an error, with the given message and key/value pairs as context.
+	// It functions similarly to calling Info with the "error" named value, but may
+	// have unique behavior, and should be preferred for logging errors (see the
+	// package documentations for more information).
+	//
+	// The msg field should be used to add context to any underlying error,
+	// while the err field should be used to attach the actual error that
+	// triggered this log line, if present.
+	Error(err error, msg string, keysAndValues ...interface{})
+
+	// V returns an InfoLogger value for a specific verbosity level.  A higher
+	// verbosity level means a log message is less important.  It's illegal to
+	// pass a log level less than zero.
+	V(level int) InfoLogger
+
+	// WithValues adds some key-value pairs of context to a logger.
+	// See Info for documentation on how key/value pairs work.
+	WithValues(keysAndValues ...interface{}) Logger
+
+	// WithName adds a new element to the logger's name.
+	// Successive calls with WithName continue to append
+	// suffixes to the logger's name.  It's strongly reccomended
+	// that name segments contain only letters, digits, and hyphens
+	// (see the package documentation for more information).
+	WithName(name string) Logger
+}

--- a/vendor/github.com/kr/pretty/License
+++ b/vendor/github.com/kr/pretty/License
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright 2012 Keith Rarick
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/kr/pretty/diff.go
+++ b/vendor/github.com/kr/pretty/diff.go
@@ -1,0 +1,265 @@
+package pretty
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+)
+
+type sbuf []string
+
+func (p *sbuf) Printf(format string, a ...interface{}) {
+	s := fmt.Sprintf(format, a...)
+	*p = append(*p, s)
+}
+
+// Diff returns a slice where each element describes
+// a difference between a and b.
+func Diff(a, b interface{}) (desc []string) {
+	Pdiff((*sbuf)(&desc), a, b)
+	return desc
+}
+
+// wprintfer calls Fprintf on w for each Printf call
+// with a trailing newline.
+type wprintfer struct{ w io.Writer }
+
+func (p *wprintfer) Printf(format string, a ...interface{}) {
+	fmt.Fprintf(p.w, format+"\n", a...)
+}
+
+// Fdiff writes to w a description of the differences between a and b.
+func Fdiff(w io.Writer, a, b interface{}) {
+	Pdiff(&wprintfer{w}, a, b)
+}
+
+type Printfer interface {
+	Printf(format string, a ...interface{})
+}
+
+// Pdiff prints to p a description of the differences between a and b.
+// It calls Printf once for each difference, with no trailing newline.
+// The standard library log.Logger is a Printfer.
+func Pdiff(p Printfer, a, b interface{}) {
+	diffPrinter{w: p}.diff(reflect.ValueOf(a), reflect.ValueOf(b))
+}
+
+type Logfer interface {
+	Logf(format string, a ...interface{})
+}
+
+// logprintfer calls Fprintf on w for each Printf call
+// with a trailing newline.
+type logprintfer struct{ l Logfer }
+
+func (p *logprintfer) Printf(format string, a ...interface{}) {
+	p.l.Logf(format, a...)
+}
+
+// Ldiff prints to l a description of the differences between a and b.
+// It calls Logf once for each difference, with no trailing newline.
+// The standard library testing.T and testing.B are Logfers.
+func Ldiff(l Logfer, a, b interface{}) {
+	Pdiff(&logprintfer{l}, a, b)
+}
+
+type diffPrinter struct {
+	w Printfer
+	l string // label
+}
+
+func (w diffPrinter) printf(f string, a ...interface{}) {
+	var l string
+	if w.l != "" {
+		l = w.l + ": "
+	}
+	w.w.Printf(l+f, a...)
+}
+
+func (w diffPrinter) diff(av, bv reflect.Value) {
+	if !av.IsValid() && bv.IsValid() {
+		w.printf("nil != %# v", formatter{v: bv, quote: true})
+		return
+	}
+	if av.IsValid() && !bv.IsValid() {
+		w.printf("%# v != nil", formatter{v: av, quote: true})
+		return
+	}
+	if !av.IsValid() && !bv.IsValid() {
+		return
+	}
+
+	at := av.Type()
+	bt := bv.Type()
+	if at != bt {
+		w.printf("%v != %v", at, bt)
+		return
+	}
+
+	switch kind := at.Kind(); kind {
+	case reflect.Bool:
+		if a, b := av.Bool(), bv.Bool(); a != b {
+			w.printf("%v != %v", a, b)
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if a, b := av.Int(), bv.Int(); a != b {
+			w.printf("%d != %d", a, b)
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		if a, b := av.Uint(), bv.Uint(); a != b {
+			w.printf("%d != %d", a, b)
+		}
+	case reflect.Float32, reflect.Float64:
+		if a, b := av.Float(), bv.Float(); a != b {
+			w.printf("%v != %v", a, b)
+		}
+	case reflect.Complex64, reflect.Complex128:
+		if a, b := av.Complex(), bv.Complex(); a != b {
+			w.printf("%v != %v", a, b)
+		}
+	case reflect.Array:
+		n := av.Len()
+		for i := 0; i < n; i++ {
+			w.relabel(fmt.Sprintf("[%d]", i)).diff(av.Index(i), bv.Index(i))
+		}
+	case reflect.Chan, reflect.Func, reflect.UnsafePointer:
+		if a, b := av.Pointer(), bv.Pointer(); a != b {
+			w.printf("%#x != %#x", a, b)
+		}
+	case reflect.Interface:
+		w.diff(av.Elem(), bv.Elem())
+	case reflect.Map:
+		ak, both, bk := keyDiff(av.MapKeys(), bv.MapKeys())
+		for _, k := range ak {
+			w := w.relabel(fmt.Sprintf("[%#v]", k))
+			w.printf("%q != (missing)", av.MapIndex(k))
+		}
+		for _, k := range both {
+			w := w.relabel(fmt.Sprintf("[%#v]", k))
+			w.diff(av.MapIndex(k), bv.MapIndex(k))
+		}
+		for _, k := range bk {
+			w := w.relabel(fmt.Sprintf("[%#v]", k))
+			w.printf("(missing) != %q", bv.MapIndex(k))
+		}
+	case reflect.Ptr:
+		switch {
+		case av.IsNil() && !bv.IsNil():
+			w.printf("nil != %# v", formatter{v: bv, quote: true})
+		case !av.IsNil() && bv.IsNil():
+			w.printf("%# v != nil", formatter{v: av, quote: true})
+		case !av.IsNil() && !bv.IsNil():
+			w.diff(av.Elem(), bv.Elem())
+		}
+	case reflect.Slice:
+		lenA := av.Len()
+		lenB := bv.Len()
+		if lenA != lenB {
+			w.printf("%s[%d] != %s[%d]", av.Type(), lenA, bv.Type(), lenB)
+			break
+		}
+		for i := 0; i < lenA; i++ {
+			w.relabel(fmt.Sprintf("[%d]", i)).diff(av.Index(i), bv.Index(i))
+		}
+	case reflect.String:
+		if a, b := av.String(), bv.String(); a != b {
+			w.printf("%q != %q", a, b)
+		}
+	case reflect.Struct:
+		for i := 0; i < av.NumField(); i++ {
+			w.relabel(at.Field(i).Name).diff(av.Field(i), bv.Field(i))
+		}
+	default:
+		panic("unknown reflect Kind: " + kind.String())
+	}
+}
+
+func (d diffPrinter) relabel(name string) (d1 diffPrinter) {
+	d1 = d
+	if d.l != "" && name[0] != '[' {
+		d1.l += "."
+	}
+	d1.l += name
+	return d1
+}
+
+// keyEqual compares a and b for equality.
+// Both a and b must be valid map keys.
+func keyEqual(av, bv reflect.Value) bool {
+	if !av.IsValid() && !bv.IsValid() {
+		return true
+	}
+	if !av.IsValid() || !bv.IsValid() || av.Type() != bv.Type() {
+		return false
+	}
+	switch kind := av.Kind(); kind {
+	case reflect.Bool:
+		a, b := av.Bool(), bv.Bool()
+		return a == b
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		a, b := av.Int(), bv.Int()
+		return a == b
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		a, b := av.Uint(), bv.Uint()
+		return a == b
+	case reflect.Float32, reflect.Float64:
+		a, b := av.Float(), bv.Float()
+		return a == b
+	case reflect.Complex64, reflect.Complex128:
+		a, b := av.Complex(), bv.Complex()
+		return a == b
+	case reflect.Array:
+		for i := 0; i < av.Len(); i++ {
+			if !keyEqual(av.Index(i), bv.Index(i)) {
+				return false
+			}
+		}
+		return true
+	case reflect.Chan, reflect.UnsafePointer, reflect.Ptr:
+		a, b := av.Pointer(), bv.Pointer()
+		return a == b
+	case reflect.Interface:
+		return keyEqual(av.Elem(), bv.Elem())
+	case reflect.String:
+		a, b := av.String(), bv.String()
+		return a == b
+	case reflect.Struct:
+		for i := 0; i < av.NumField(); i++ {
+			if !keyEqual(av.Field(i), bv.Field(i)) {
+				return false
+			}
+		}
+		return true
+	default:
+		panic("invalid map key type " + av.Type().String())
+	}
+}
+
+func keyDiff(a, b []reflect.Value) (ak, both, bk []reflect.Value) {
+	for _, av := range a {
+		inBoth := false
+		for _, bv := range b {
+			if keyEqual(av, bv) {
+				inBoth = true
+				both = append(both, av)
+				break
+			}
+		}
+		if !inBoth {
+			ak = append(ak, av)
+		}
+	}
+	for _, bv := range b {
+		inBoth := false
+		for _, av := range a {
+			if keyEqual(av, bv) {
+				inBoth = true
+				break
+			}
+		}
+		if !inBoth {
+			bk = append(bk, bv)
+		}
+	}
+	return
+}

--- a/vendor/github.com/kr/pretty/formatter.go
+++ b/vendor/github.com/kr/pretty/formatter.go
@@ -1,0 +1,358 @@
+package pretty
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"strconv"
+	"text/tabwriter"
+	"time"
+
+	"github.com/kr/text"
+)
+
+var (
+	timeType = reflect.TypeOf(time.Time{})
+)
+
+type formatter struct {
+	v     reflect.Value
+	force bool
+	quote bool
+}
+
+// Formatter makes a wrapper, f, that will format x as go source with line
+// breaks and tabs. Object f responds to the "%v" formatting verb when both the
+// "#" and " " (space) flags are set, for example:
+//
+//     fmt.Sprintf("%# v", Formatter(x))
+//
+// If one of these two flags is not set, or any other verb is used, f will
+// format x according to the usual rules of package fmt.
+// In particular, if x satisfies fmt.Formatter, then x.Format will be called.
+func Formatter(x interface{}) (f fmt.Formatter) {
+	return formatter{v: reflect.ValueOf(x), quote: true}
+}
+
+func (fo formatter) String() string {
+	return fmt.Sprint(fo.v.Interface()) // unwrap it
+}
+
+func (fo formatter) passThrough(f fmt.State, c rune) {
+	s := "%"
+	for i := 0; i < 128; i++ {
+		if f.Flag(i) {
+			s += string(i)
+		}
+	}
+	if w, ok := f.Width(); ok {
+		s += fmt.Sprintf("%d", w)
+	}
+	if p, ok := f.Precision(); ok {
+		s += fmt.Sprintf(".%d", p)
+	}
+	s += string(c)
+	fmt.Fprintf(f, s, fo.v.Interface())
+}
+
+func (fo formatter) Format(f fmt.State, c rune) {
+	if fo.force || c == 'v' && f.Flag('#') && f.Flag(' ') {
+		w := tabwriter.NewWriter(f, 4, 4, 1, ' ', 0)
+		p := &printer{tw: w, Writer: w, visited: make(map[visit]int)}
+		p.printValue(fo.v, true, fo.quote)
+		w.Flush()
+		return
+	}
+	fo.passThrough(f, c)
+}
+
+type printer struct {
+	io.Writer
+	tw      *tabwriter.Writer
+	visited map[visit]int
+	depth   int
+}
+
+func (p *printer) indent() *printer {
+	q := *p
+	q.tw = tabwriter.NewWriter(p.Writer, 4, 4, 1, ' ', 0)
+	q.Writer = text.NewIndentWriter(q.tw, []byte{'\t'})
+	return &q
+}
+
+func (p *printer) printInline(v reflect.Value, x interface{}, showType bool) {
+	if showType {
+		io.WriteString(p, v.Type().String())
+		fmt.Fprintf(p, "(%#v)", x)
+	} else {
+		fmt.Fprintf(p, "%#v", x)
+	}
+}
+
+// printValue must keep track of already-printed pointer values to avoid
+// infinite recursion.
+type visit struct {
+	v   uintptr
+	typ reflect.Type
+}
+
+func (p *printer) printValue(v reflect.Value, showType, quote bool) {
+	if p.depth > 10 {
+		io.WriteString(p, "!%v(DEPTH EXCEEDED)")
+		return
+	}
+
+	switch v.Kind() {
+	case reflect.Bool:
+		p.printInline(v, v.Bool(), showType)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		p.printInline(v, v.Int(), showType)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		p.printInline(v, v.Uint(), showType)
+	case reflect.Float32, reflect.Float64:
+		p.printInline(v, v.Float(), showType)
+	case reflect.Complex64, reflect.Complex128:
+		fmt.Fprintf(p, "%#v", v.Complex())
+	case reflect.String:
+		p.fmtString(v.String(), quote)
+	case reflect.Map:
+		t := v.Type()
+		if showType {
+			io.WriteString(p, t.String())
+		}
+		writeByte(p, '{')
+		if nonzero(v) {
+			expand := !canInline(v.Type())
+			pp := p
+			if expand {
+				writeByte(p, '\n')
+				pp = p.indent()
+			}
+			keys := v.MapKeys()
+			for i := 0; i < v.Len(); i++ {
+				showTypeInStruct := true
+				k := keys[i]
+				mv := v.MapIndex(k)
+				pp.printValue(k, false, true)
+				writeByte(pp, ':')
+				if expand {
+					writeByte(pp, '\t')
+				}
+				showTypeInStruct = t.Elem().Kind() == reflect.Interface
+				pp.printValue(mv, showTypeInStruct, true)
+				if expand {
+					io.WriteString(pp, ",\n")
+				} else if i < v.Len()-1 {
+					io.WriteString(pp, ", ")
+				}
+			}
+			if expand {
+				pp.tw.Flush()
+			}
+		}
+		writeByte(p, '}')
+	case reflect.Struct:
+		t := v.Type()
+		if t == timeType {
+			io.WriteString(p, "time.Now()")
+			break
+		}
+
+		if v.CanAddr() {
+			addr := v.UnsafeAddr()
+			vis := visit{addr, t}
+			if vd, ok := p.visited[vis]; ok && vd < p.depth {
+				p.fmtString(t.String()+"{(CYCLIC REFERENCE)}", false)
+				break // don't print v again
+			}
+			p.visited[vis] = p.depth
+		}
+
+		if showType {
+			io.WriteString(p, t.String())
+		}
+		writeByte(p, '{')
+		if nonzero(v) {
+			expand := !canInline(v.Type())
+			pp := p
+			if expand {
+				writeByte(p, '\n')
+				pp = p.indent()
+			}
+			for i := 0; i < v.NumField(); i++ {
+				showTypeInStruct := true
+				if f := t.Field(i); f.Name != "" {
+					if f.Name == "DynamicData" {
+						continue
+					}
+					io.WriteString(pp, f.Name)
+					writeByte(pp, ':')
+					if expand {
+						writeByte(pp, '\t')
+					}
+					showTypeInStruct = labelType(f.Type)
+				}
+				pp.printValue(getField(v, i), showTypeInStruct, true)
+				if expand {
+					io.WriteString(pp, ",\n")
+				} else if i < v.NumField()-1 {
+					io.WriteString(pp, ", ")
+				}
+			}
+			if expand {
+				pp.tw.Flush()
+			}
+		}
+		writeByte(p, '}')
+	case reflect.Interface:
+		switch e := v.Elem(); {
+		case e.Kind() == reflect.Invalid:
+			io.WriteString(p, "nil")
+		case e.IsValid():
+			pp := *p
+			pp.depth++
+			pp.printValue(e, showType, true)
+		default:
+			io.WriteString(p, v.Type().String())
+			io.WriteString(p, "(nil)")
+		}
+	case reflect.Array, reflect.Slice:
+		t := v.Type()
+		if showType {
+			io.WriteString(p, t.String())
+		}
+		if v.Kind() == reflect.Slice && v.IsNil() && showType {
+			io.WriteString(p, "(nil)")
+			break
+		}
+		if v.Kind() == reflect.Slice && v.IsNil() {
+			io.WriteString(p, "nil")
+			break
+		}
+		if !showType {
+			// we always want the type for slices
+			io.WriteString(p, t.String())
+		}
+		writeByte(p, '{')
+		expand := !canInline(v.Type())
+		pp := p
+		if expand {
+			writeByte(p, '\n')
+			pp = p.indent()
+		}
+		for i := 0; i < v.Len(); i++ {
+			showTypeInSlice := t.Elem().Kind() == reflect.Interface
+			pp.printValue(v.Index(i), showTypeInSlice, true)
+			if expand {
+				io.WriteString(pp, ",\n")
+			} else if i < v.Len()-1 {
+				io.WriteString(pp, ", ")
+			}
+		}
+		if expand {
+			pp.tw.Flush()
+		}
+		writeByte(p, '}')
+	case reflect.Ptr:
+		e := v.Elem()
+		if !e.IsValid() {
+			writeByte(p, '(')
+			io.WriteString(p, v.Type().String())
+			io.WriteString(p, ")(nil)")
+		} else {
+			switch e.Kind() {
+			case reflect.Bool:
+				io.WriteString(p, fmt.Sprintf("types.NewBool(%v)", e.Bool()))
+			case reflect.Int32:
+				io.WriteString(p, fmt.Sprintf("types.NewInt32(%v)", e.Int()))
+			case reflect.Int64:
+				io.WriteString(p, fmt.Sprintf("types.NewInt64(%v)", e.Int()))
+			default:
+				if e.Kind() == reflect.Struct && e.Type() == timeType {
+					io.WriteString(p, "types.NewTime(time.Now())")
+				} else {
+					pp := *p
+					pp.depth++
+					writeByte(pp, '&')
+					pp.printValue(e, true, true)
+				}
+			}
+		}
+	case reflect.Chan:
+		x := v.Pointer()
+		if showType {
+			writeByte(p, '(')
+			io.WriteString(p, v.Type().String())
+			fmt.Fprintf(p, ")(%#v)", x)
+		} else {
+			fmt.Fprintf(p, "%#v", x)
+		}
+	case reflect.Func:
+		io.WriteString(p, v.Type().String())
+		io.WriteString(p, " {...}")
+	case reflect.UnsafePointer:
+		p.printInline(v, v.Pointer(), showType)
+	case reflect.Invalid:
+		io.WriteString(p, "nil")
+	}
+}
+
+func canInline(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Map:
+		return !canExpand(t.Elem())
+	case reflect.Struct:
+		for i := 0; i < t.NumField(); i++ {
+			if canExpand(t.Field(i).Type) {
+				return false
+			}
+		}
+		return true
+	case reflect.Interface:
+		return false
+	case reflect.Array, reflect.Slice:
+		return !canExpand(t.Elem())
+	case reflect.Ptr:
+		return false
+	case reflect.Chan, reflect.Func, reflect.UnsafePointer:
+		return false
+	}
+	return true
+}
+
+func canExpand(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Map, reflect.Struct,
+		reflect.Interface, reflect.Array, reflect.Slice,
+		reflect.Ptr:
+		return true
+	}
+	return false
+}
+
+func labelType(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Interface, reflect.Struct:
+		return true
+	}
+	return false
+}
+
+func (p *printer) fmtString(s string, quote bool) {
+	if quote {
+		s = strconv.Quote(s)
+	}
+	io.WriteString(p, s)
+}
+
+func writeByte(w io.Writer, b byte) {
+	w.Write([]byte{b})
+}
+
+func getField(v reflect.Value, i int) reflect.Value {
+	val := v.Field(i)
+	if val.Kind() == reflect.Interface && !val.IsNil() {
+		val = val.Elem()
+	}
+	return val
+}

--- a/vendor/github.com/kr/pretty/pretty.go
+++ b/vendor/github.com/kr/pretty/pretty.go
@@ -1,0 +1,108 @@
+// Package pretty provides pretty-printing for Go values. This is
+// useful during debugging, to avoid wrapping long output lines in
+// the terminal.
+//
+// It provides a function, Formatter, that can be used with any
+// function that accepts a format string. It also provides
+// convenience wrappers for functions in packages fmt and log.
+package pretty
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"reflect"
+)
+
+// Errorf is a convenience wrapper for fmt.Errorf.
+//
+// Calling Errorf(f, x, y) is equivalent to
+// fmt.Errorf(f, Formatter(x), Formatter(y)).
+func Errorf(format string, a ...interface{}) error {
+	return fmt.Errorf(format, wrap(a, false)...)
+}
+
+// Fprintf is a convenience wrapper for fmt.Fprintf.
+//
+// Calling Fprintf(w, f, x, y) is equivalent to
+// fmt.Fprintf(w, f, Formatter(x), Formatter(y)).
+func Fprintf(w io.Writer, format string, a ...interface{}) (n int, error error) {
+	return fmt.Fprintf(w, format, wrap(a, false)...)
+}
+
+// Log is a convenience wrapper for log.Printf.
+//
+// Calling Log(x, y) is equivalent to
+// log.Print(Formatter(x), Formatter(y)), but each operand is
+// formatted with "%# v".
+func Log(a ...interface{}) {
+	log.Print(wrap(a, true)...)
+}
+
+// Logf is a convenience wrapper for log.Printf.
+//
+// Calling Logf(f, x, y) is equivalent to
+// log.Printf(f, Formatter(x), Formatter(y)).
+func Logf(format string, a ...interface{}) {
+	log.Printf(format, wrap(a, false)...)
+}
+
+// Logln is a convenience wrapper for log.Printf.
+//
+// Calling Logln(x, y) is equivalent to
+// log.Println(Formatter(x), Formatter(y)), but each operand is
+// formatted with "%# v".
+func Logln(a ...interface{}) {
+	log.Println(wrap(a, true)...)
+}
+
+// Print pretty-prints its operands and writes to standard output.
+//
+// Calling Print(x, y) is equivalent to
+// fmt.Print(Formatter(x), Formatter(y)), but each operand is
+// formatted with "%# v".
+func Print(a ...interface{}) (n int, errno error) {
+	return fmt.Print(wrap(a, true)...)
+}
+
+// Printf is a convenience wrapper for fmt.Printf.
+//
+// Calling Printf(f, x, y) is equivalent to
+// fmt.Printf(f, Formatter(x), Formatter(y)).
+func Printf(format string, a ...interface{}) (n int, errno error) {
+	return fmt.Printf(format, wrap(a, false)...)
+}
+
+// Println pretty-prints its operands and writes to standard output.
+//
+// Calling Print(x, y) is equivalent to
+// fmt.Println(Formatter(x), Formatter(y)), but each operand is
+// formatted with "%# v".
+func Println(a ...interface{}) (n int, errno error) {
+	return fmt.Println(wrap(a, true)...)
+}
+
+// Sprint is a convenience wrapper for fmt.Sprintf.
+//
+// Calling Sprint(x, y) is equivalent to
+// fmt.Sprint(Formatter(x), Formatter(y)), but each operand is
+// formatted with "%# v".
+func Sprint(a ...interface{}) string {
+	return fmt.Sprint(wrap(a, true)...)
+}
+
+// Sprintf is a convenience wrapper for fmt.Sprintf.
+//
+// Calling Sprintf(f, x, y) is equivalent to
+// fmt.Sprintf(f, Formatter(x), Formatter(y)).
+func Sprintf(format string, a ...interface{}) string {
+	return fmt.Sprintf(format, wrap(a, false)...)
+}
+
+func wrap(a []interface{}, force bool) []interface{} {
+	w := make([]interface{}, len(a))
+	for i, x := range a {
+		w[i] = formatter{v: reflect.ValueOf(x), force: force}
+	}
+	return w
+}

--- a/vendor/github.com/kr/pretty/zero.go
+++ b/vendor/github.com/kr/pretty/zero.go
@@ -1,0 +1,41 @@
+package pretty
+
+import (
+	"reflect"
+)
+
+func nonzero(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Bool:
+		return v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() != 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() != 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() != 0
+	case reflect.Complex64, reflect.Complex128:
+		return v.Complex() != complex(0, 0)
+	case reflect.String:
+		return v.String() != ""
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			if nonzero(getField(v, i)) {
+				return true
+			}
+		}
+		return false
+	case reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			if nonzero(v.Index(i)) {
+				return true
+			}
+		}
+		return false
+	case reflect.Map, reflect.Interface, reflect.Slice, reflect.Ptr, reflect.Chan, reflect.Func:
+		return !v.IsNil()
+	case reflect.UnsafePointer:
+		return v.Pointer() != 0
+	}
+	return true
+}

--- a/vendor/github.com/kr/text/License
+++ b/vendor/github.com/kr/text/License
@@ -1,0 +1,19 @@
+Copyright 2012 Keith Rarick
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/kr/text/doc.go
+++ b/vendor/github.com/kr/text/doc.go
@@ -1,0 +1,3 @@
+// Package text provides rudimentary functions for manipulating text in
+// paragraphs.
+package text

--- a/vendor/github.com/kr/text/indent.go
+++ b/vendor/github.com/kr/text/indent.go
@@ -1,0 +1,74 @@
+package text
+
+import (
+	"io"
+)
+
+// Indent inserts prefix at the beginning of each non-empty line of s. The
+// end-of-line marker is NL.
+func Indent(s, prefix string) string {
+	return string(IndentBytes([]byte(s), []byte(prefix)))
+}
+
+// IndentBytes inserts prefix at the beginning of each non-empty line of b.
+// The end-of-line marker is NL.
+func IndentBytes(b, prefix []byte) []byte {
+	var res []byte
+	bol := true
+	for _, c := range b {
+		if bol && c != '\n' {
+			res = append(res, prefix...)
+		}
+		res = append(res, c)
+		bol = c == '\n'
+	}
+	return res
+}
+
+// Writer indents each line of its input.
+type indentWriter struct {
+	w   io.Writer
+	bol bool
+	pre [][]byte
+	sel int
+	off int
+}
+
+// NewIndentWriter makes a new write filter that indents the input
+// lines. Each line is prefixed in order with the corresponding
+// element of pre. If there are more lines than elements, the last
+// element of pre is repeated for each subsequent line.
+func NewIndentWriter(w io.Writer, pre ...[]byte) io.Writer {
+	return &indentWriter{
+		w:   w,
+		pre: pre,
+		bol: true,
+	}
+}
+
+// The only errors returned are from the underlying indentWriter.
+func (w *indentWriter) Write(p []byte) (n int, err error) {
+	for _, c := range p {
+		if w.bol {
+			var i int
+			i, err = w.w.Write(w.pre[w.sel][w.off:])
+			w.off += i
+			if err != nil {
+				return n, err
+			}
+		}
+		_, err = w.w.Write([]byte{c})
+		if err != nil {
+			return n, err
+		}
+		n++
+		w.bol = c == '\n'
+		if w.bol {
+			w.off = 0
+			if w.sel < len(w.pre)-1 {
+				w.sel++
+			}
+		}
+	}
+	return n, nil
+}

--- a/vendor/github.com/kr/text/wrap.go
+++ b/vendor/github.com/kr/text/wrap.go
@@ -1,0 +1,86 @@
+package text
+
+import (
+	"bytes"
+	"math"
+)
+
+var (
+	nl = []byte{'\n'}
+	sp = []byte{' '}
+)
+
+const defaultPenalty = 1e5
+
+// Wrap wraps s into a paragraph of lines of length lim, with minimal
+// raggedness.
+func Wrap(s string, lim int) string {
+	return string(WrapBytes([]byte(s), lim))
+}
+
+// WrapBytes wraps b into a paragraph of lines of length lim, with minimal
+// raggedness.
+func WrapBytes(b []byte, lim int) []byte {
+	words := bytes.Split(bytes.Replace(bytes.TrimSpace(b), nl, sp, -1), sp)
+	var lines [][]byte
+	for _, line := range WrapWords(words, 1, lim, defaultPenalty) {
+		lines = append(lines, bytes.Join(line, sp))
+	}
+	return bytes.Join(lines, nl)
+}
+
+// WrapWords is the low-level line-breaking algorithm, useful if you need more
+// control over the details of the text wrapping process. For most uses, either
+// Wrap or WrapBytes will be sufficient and more convenient.
+//
+// WrapWords splits a list of words into lines with minimal "raggedness",
+// treating each byte as one unit, accounting for spc units between adjacent
+// words on each line, and attempting to limit lines to lim units. Raggedness
+// is the total error over all lines, where error is the square of the
+// difference of the length of the line and lim. Too-long lines (which only
+// happen when a single word is longer than lim units) have pen penalty units
+// added to the error.
+func WrapWords(words [][]byte, spc, lim, pen int) [][][]byte {
+	n := len(words)
+
+	length := make([][]int, n)
+	for i := 0; i < n; i++ {
+		length[i] = make([]int, n)
+		length[i][i] = len(words[i])
+		for j := i + 1; j < n; j++ {
+			length[i][j] = length[i][j-1] + spc + len(words[j])
+		}
+	}
+
+	nbrk := make([]int, n)
+	cost := make([]int, n)
+	for i := range cost {
+		cost[i] = math.MaxInt32
+	}
+	for i := n - 1; i >= 0; i-- {
+		if length[i][n-1] <= lim || i == n-1 {
+			cost[i] = 0
+			nbrk[i] = n
+		} else {
+			for j := i + 1; j < n; j++ {
+				d := lim - length[i][j-1]
+				c := d*d + cost[j]
+				if length[i][j-1] > lim {
+					c += pen // too-long lines get a worse penalty
+				}
+				if c < cost[i] {
+					cost[i] = c
+					nbrk[i] = j
+				}
+			}
+		}
+	}
+
+	var lines [][][]byte
+	i := 0
+	for i < n {
+		lines = append(lines, words[i:nbrk[i]])
+		i = nbrk[i]
+	}
+	return lines
+}

--- a/vendor/github.com/vmware/govmomi/govc/about/cert.go
+++ b/vendor/github.com/vmware/govmomi/govc/about/cert.go
@@ -1,0 +1,120 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package about
+
+import (
+	"context"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+type cert struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+
+	show       bool
+	thumbprint bool
+}
+
+func init() {
+	cli.Register("about.cert", &cert{})
+}
+
+func (cmd *cert) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.show, "show", false, "Show PEM encoded server certificate only")
+	f.BoolVar(&cmd.thumbprint, "thumbprint", false, "Output host hash and thumbprint only")
+}
+
+func (cmd *cert) Description() string {
+	return `Display TLS certificate info for HOST.
+
+If the HOST certificate cannot be verified, about.cert will return with exit code 60 (as curl does).
+If the '-k' flag is provided, about.cert will return with exit code 0 in this case.
+The SHA1 thumbprint can also be used as '-thumbprint' for the 'host.add' and 'cluster.add' commands.
+
+Examples:
+  govc about.cert -k -json | jq -r .ThumbprintSHA1
+  govc about.cert -k -show | sudo tee /usr/local/share/ca-certificates/host.crt
+  govc about.cert -k -thumbprint | tee -a ~/.govmomi/known_hosts`
+}
+
+func (cmd *cert) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+type certResult struct {
+	cmd  *cert
+	info object.HostCertificateInfo
+}
+
+func (r *certResult) Write(w io.Writer) error {
+	if r.cmd.show {
+		return pem.Encode(w, &pem.Block{Type: "CERTIFICATE", Bytes: r.info.Certificate.Raw})
+	}
+
+	if r.cmd.thumbprint {
+		u := r.cmd.URLWithoutPassword()
+		_, err := fmt.Fprintf(w, "%s %s\n", u.Host, r.info.ThumbprintSHA1)
+		return err
+	}
+
+	return r.cmd.WriteResult(&r.info)
+}
+
+func (cmd *cert) Run(ctx context.Context, f *flag.FlagSet) error {
+	u := cmd.URLWithoutPassword()
+	c := soap.NewClient(u, false)
+	t := c.Client.Transport.(*http.Transport)
+	r := certResult{cmd: cmd}
+
+	if err := cmd.SetRootCAs(c); err != nil {
+		return err
+	}
+
+	if err := r.info.FromURL(u, t.TLSClientConfig); err != nil {
+		return err
+	}
+
+	if r.info.Err != nil && r.cmd.IsSecure() {
+		cmd.Out = os.Stderr
+		// using same exit code as curl:
+		defer os.Exit(60)
+	}
+
+	return r.Write(cmd.Out)
+}

--- a/vendor/github.com/vmware/govmomi/govc/about/command.go
+++ b/vendor/github.com/vmware/govmomi/govc/about/command.go
@@ -1,0 +1,124 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package about
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type about struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+
+	Long bool
+	c    bool
+}
+
+func init() {
+	cli.Register("about", &about{})
+}
+
+func (cmd *about) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.Long, "l", false, "Include service content")
+	f.BoolVar(&cmd.c, "c", false, "Include client info")
+}
+
+func (cmd *about) Description() string {
+	return `Display About info for HOST.
+
+System information including the name, type, version, and build number.
+
+Examples:
+  govc about
+  govc about -json | jq -r .About.ProductLineId`
+}
+
+func (cmd *about) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *about) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	res := infoResult{
+		a: &c.ServiceContent.About,
+	}
+
+	if cmd.Long {
+		res.Content = &c.ServiceContent
+	} else {
+		res.About = res.a
+	}
+
+	if cmd.c {
+		res.Client = c.Client
+	}
+
+	return cmd.WriteResult(&res)
+}
+
+type infoResult struct {
+	Content *types.ServiceContent `json:",omitempty"`
+	About   *types.AboutInfo      `json:",omitempty"`
+	Client  *soap.Client          `json:",omitempty"`
+	a       *types.AboutInfo
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, "Name:\t%s\n", r.a.Name)
+	fmt.Fprintf(tw, "Vendor:\t%s\n", r.a.Vendor)
+	fmt.Fprintf(tw, "Version:\t%s\n", r.a.Version)
+	fmt.Fprintf(tw, "Build:\t%s\n", r.a.Build)
+	fmt.Fprintf(tw, "OS type:\t%s\n", r.a.OsType)
+	fmt.Fprintf(tw, "API type:\t%s\n", r.a.ApiType)
+	fmt.Fprintf(tw, "API version:\t%s\n", r.a.ApiVersion)
+	fmt.Fprintf(tw, "Product ID:\t%s\n", r.a.ProductLineId)
+	fmt.Fprintf(tw, "UUID:\t%s\n", r.a.InstanceUuid)
+	return tw.Flush()
+}
+
+func (r *infoResult) Dump() interface{} {
+	if r.Content != nil {
+		return r.Content
+	}
+	return r.About
+}

--- a/vendor/github.com/vmware/govmomi/govc/cli/command.go
+++ b/vendor/github.com/vmware/govmomi/govc/cli/command.go
@@ -1,0 +1,193 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type HasFlags interface {
+	// Register may be called more than once and should be idempotent.
+	Register(ctx context.Context, f *flag.FlagSet)
+
+	// Process may be called more than once and should be idempotent.
+	Process(ctx context.Context) error
+}
+
+type Command interface {
+	HasFlags
+
+	Run(ctx context.Context, f *flag.FlagSet) error
+}
+
+func generalHelp(w io.Writer, filter string) {
+	var cmds, matches []string
+	for name := range commands {
+		cmds = append(cmds, name)
+
+		if filter != "" && strings.Contains(name, filter) {
+			matches = append(matches, name)
+		}
+	}
+
+	if len(matches) == 0 {
+		fmt.Fprintf(w, "Usage of %s:\n", os.Args[0])
+	} else {
+		fmt.Fprintf(w, "%s: command '%s' not found, did you mean:\n", os.Args[0], filter)
+		cmds = matches
+	}
+
+	sort.Strings(cmds)
+	for _, name := range cmds {
+		fmt.Fprintf(w, "  %s\n", name)
+	}
+}
+
+func commandHelp(w io.Writer, name string, cmd Command, f *flag.FlagSet) {
+	type HasUsage interface {
+		Usage() string
+	}
+
+	fmt.Fprintf(w, "Usage: %s %s [OPTIONS]", os.Args[0], name)
+	if u, ok := cmd.(HasUsage); ok {
+		fmt.Fprintf(w, " %s", u.Usage())
+	}
+	fmt.Fprintf(w, "\n")
+
+	type HasDescription interface {
+		Description() string
+	}
+
+	if u, ok := cmd.(HasDescription); ok {
+		fmt.Fprintf(w, "\n%s\n", u.Description())
+	}
+
+	n := 0
+	f.VisitAll(func(_ *flag.Flag) {
+		n += 1
+	})
+
+	if n > 0 {
+		fmt.Fprintf(w, "\nOptions:\n")
+		tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+		f.VisitAll(func(f *flag.Flag) {
+			fmt.Fprintf(tw, "\t-%s=%s\t%s\n", f.Name, f.DefValue, f.Usage)
+		})
+		tw.Flush()
+	}
+}
+
+func clientLogout(ctx context.Context, cmd Command) error {
+	type logout interface {
+		Logout(context.Context) error
+	}
+
+	if l, ok := cmd.(logout); ok {
+		return l.Logout(ctx)
+	}
+
+	return nil
+}
+
+func Run(args []string) int {
+	hw := os.Stderr
+	rc := 1
+	hwrc := func(arg string) {
+		if arg == "-h" {
+			hw = os.Stdout
+			rc = 0
+		}
+	}
+
+	var err error
+
+	if len(args) == 0 {
+		generalHelp(hw, "")
+		return rc
+	}
+
+	// Look up real command name in aliases table.
+	name, ok := aliases[args[0]]
+	if !ok {
+		name = args[0]
+	}
+
+	cmd, ok := commands[name]
+	if !ok {
+		hwrc(name)
+		generalHelp(hw, name)
+		return rc
+	}
+
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	fs.SetOutput(ioutil.Discard)
+
+	ctx := context.Background()
+
+	if id := os.Getenv("GOVC_OPERATION_ID"); id != "" {
+		ctx = context.WithValue(ctx, types.ID{}, id)
+	}
+
+	cmd.Register(ctx, fs)
+
+	if err = fs.Parse(args[1:]); err != nil {
+		goto error
+	}
+
+	if err = cmd.Process(ctx); err != nil {
+		goto error
+	}
+
+	if err = cmd.Run(ctx, fs); err != nil {
+		goto error
+	}
+
+	if err = clientLogout(ctx, cmd); err != nil {
+		goto error
+	}
+
+	return 0
+
+error:
+	if err == flag.ErrHelp {
+		if len(args) == 2 {
+			hwrc(args[1])
+		}
+		commandHelp(hw, args[0], cmd, fs)
+	} else {
+		if x, ok := err.(interface{ ExitCode() int }); ok {
+			// propagate exit code, e.g. from guest.run
+			rc = x.ExitCode()
+		} else {
+			fmt.Fprintf(os.Stderr, "%s: %s\n", os.Args[0], err)
+		}
+	}
+
+	_ = clientLogout(ctx, cmd)
+
+	return rc
+}

--- a/vendor/github.com/vmware/govmomi/govc/cli/register.go
+++ b/vendor/github.com/vmware/govmomi/govc/cli/register.go
@@ -1,0 +1,43 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import "os"
+
+var commands = map[string]Command{}
+
+var aliases = map[string]string{}
+
+// hideUnreleased allows commands to be compiled into the govc binary without being registered by default.
+// Unreleased commands are omitted from 'govc -h' help text and the generated govc/USAGE.md
+// Setting the env var GOVC_SHOW_UNRELEASED=true enables any commands registered as unreleased.
+var hideUnreleased = os.Getenv("GOVC_SHOW_UNRELEASED") != "true"
+
+func Register(name string, c Command, unreleased ...bool) {
+	if len(unreleased) != 0 && unreleased[0] && hideUnreleased {
+		return
+	}
+	commands[name] = c
+}
+
+func Alias(name string, alias string) {
+	aliases[alias] = name
+}
+
+func Commands() map[string]Command {
+	return commands
+}

--- a/vendor/github.com/vmware/govmomi/govc/cluster/add.go
+++ b/vendor/github.com/vmware/govmomi/govc/cluster/add.go
@@ -1,0 +1,114 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type add struct {
+	*flags.ClusterFlag
+	*flags.HostConnectFlag
+
+	connect bool
+	license string
+}
+
+func init() {
+	cli.Register("cluster.add", &add{})
+}
+
+func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClusterFlag, ctx = flags.NewClusterFlag(ctx)
+	cmd.ClusterFlag.Register(ctx, f)
+
+	cmd.HostConnectFlag, ctx = flags.NewHostConnectFlag(ctx)
+	cmd.HostConnectFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.license, "license", "", "Assign license key")
+
+	f.BoolVar(&cmd.connect, "connect", true, "Immediately connect to host")
+}
+
+func (cmd *add) Process(ctx context.Context) error {
+	if err := cmd.ClusterFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostConnectFlag.Process(ctx); err != nil {
+		return err
+	}
+	if cmd.HostName == "" {
+		return flag.ErrHelp
+	}
+	if cmd.UserName == "" {
+		return flag.ErrHelp
+	}
+	if cmd.Password == "" {
+		return flag.ErrHelp
+	}
+	return nil
+}
+
+func (cmd *add) Description() string {
+	return `Add HOST to CLUSTER.
+
+The host is added to the cluster specified by the 'cluster' flag.
+
+Examples:
+  thumbprint=$(govc about.cert -k -u host.example.com -thumbprint | awk '{print $2}')
+  govc cluster.add -cluster ClusterA -hostname host.example.com -username root -password pass -thumbprint $thumbprint
+  govc cluster.add -cluster ClusterB -hostname 10.0.6.1 -username root -password pass -noverify`
+}
+
+func (cmd *add) Add(ctx context.Context, cluster *object.ClusterComputeResource) error {
+	spec := cmd.HostConnectSpec
+
+	var license *string
+	if cmd.license != "" {
+		license = &cmd.license
+	}
+
+	task, err := cluster.AddHost(ctx, cmd.Spec(cluster.Client()), cmd.connect, license, nil)
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("adding %s to cluster %s... ", spec.HostName, cluster.InventoryPath))
+	defer logger.Wait()
+
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}
+
+func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 0 {
+		return flag.ErrHelp
+	}
+
+	cluster, err := cmd.Cluster()
+	if err != nil {
+		return err
+	}
+
+	return cmd.Fault(cmd.Add(ctx, cluster))
+}

--- a/vendor/github.com/vmware/govmomi/govc/cluster/change.go
+++ b/vendor/github.com/vmware/govmomi/govc/cluster/change.go
@@ -1,0 +1,116 @@
+/*
+Copyright (c) 2015-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"context"
+	"flag"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func DrsBehaviorUsage() string {
+	drsModes := []string{
+		string(types.DrsBehaviorManual),
+		string(types.DrsBehaviorPartiallyAutomated),
+		string(types.DrsBehaviorFullyAutomated),
+	}
+
+	return "DRS behavior for virtual machines: " + strings.Join(drsModes, ", ")
+}
+
+type change struct {
+	*flags.DatacenterFlag
+
+	types.ClusterConfigSpecEx
+}
+
+func init() {
+	cli.Register("cluster.change", &change{})
+}
+
+func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	cmd.DrsConfig = new(types.ClusterDrsConfigInfo)
+	cmd.DasConfig = new(types.ClusterDasConfigInfo)
+	cmd.VsanConfig = new(types.VsanClusterConfigInfo)
+	cmd.VsanConfig.DefaultConfig = new(types.VsanClusterConfigInfoHostDefaultInfo)
+
+	// DRS
+	f.Var(flags.NewOptionalBool(&cmd.DrsConfig.Enabled), "drs-enabled", "Enable DRS")
+
+	f.StringVar((*string)(&cmd.DrsConfig.DefaultVmBehavior), "drs-mode", "", DrsBehaviorUsage())
+
+	// HA
+	f.Var(flags.NewOptionalBool(&cmd.DasConfig.Enabled), "ha-enabled", "Enable HA")
+
+	// vSAN
+	f.Var(flags.NewOptionalBool(&cmd.VsanConfig.Enabled), "vsan-enabled", "Enable vSAN")
+	f.Var(flags.NewOptionalBool(&cmd.VsanConfig.DefaultConfig.AutoClaimStorage), "vsan-autoclaim", "Autoclaim storage on cluster hosts")
+}
+
+func (cmd *change) Process(ctx context.Context) error {
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *change) Usage() string {
+	return "CLUSTER..."
+}
+
+func (cmd *change) Description() string {
+	return `Change configuration of the given clusters.
+
+Examples:
+  govc cluster.change -drs-enabled -vsan-enabled -vsan-autoclaim ClusterA
+  govc cluster.change -drs-enabled=false ClusterB`
+}
+
+func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	for _, path := range f.Args() {
+		clusters, err := finder.ClusterComputeResourceList(ctx, path)
+		if err != nil {
+			return err
+		}
+
+		for _, cluster := range clusters {
+			task, err := cluster.Reconfigure(ctx, &cmd.ClusterConfigSpecEx, true)
+			if err != nil {
+				return err
+			}
+
+			_, err = task.WaitForResult(ctx, nil)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/cluster/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/cluster/create.go
@@ -1,0 +1,78 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type create struct {
+	*flags.FolderFlag
+
+	types.ClusterConfigSpecEx
+}
+
+func init() {
+	cli.Register("cluster.create", &create{})
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.FolderFlag, ctx = flags.NewFolderFlag(ctx)
+	cmd.FolderFlag.Register(ctx, f)
+}
+
+func (cmd *create) Usage() string {
+	return "CLUSTER"
+}
+
+func (cmd *create) Description() string {
+	return `Create CLUSTER in datacenter.
+
+The cluster is added to the folder specified by the 'folder' flag. If not given,
+this defaults to the host folder in the specified or default datacenter.
+
+Examples:
+  govc cluster.create ClusterA
+  govc cluster.create -folder /dc2/test-folder ClusterB`
+}
+
+func (cmd *create) Process(ctx context.Context) error {
+	if err := cmd.FolderFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	folder, err := cmd.FolderOrDefault("host")
+	if err != nil {
+		return err
+	}
+
+	_, err = folder.CreateCluster(ctx, f.Arg(0), cmd.ClusterConfigSpecEx)
+
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/cluster/group/change.go
+++ b/vendor/github.com/vmware/govmomi/govc/cluster/group/change.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package group
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type change struct {
+	*InfoFlag
+}
+
+func init() {
+	cli.Register("cluster.group.change", &change{})
+}
+
+func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.InfoFlag, ctx = NewInfoFlag(ctx)
+	cmd.InfoFlag.Register(ctx, f)
+}
+
+func (cmd *change) Process(ctx context.Context) error {
+	if cmd.name == "" {
+		return flag.ErrHelp
+	}
+	return cmd.InfoFlag.Process(ctx)
+}
+
+func (cmd *change) Usage() string {
+	return `NAME...`
+}
+
+func (cmd *change) Description() string {
+	return `Set cluster group members.
+
+Examples:
+  govc cluster.group.change -name my_group vm_a vm_b vm_c # set
+  govc cluster.group.change -name my_group vm_a vm_b vm_c $(govc cluster.group.ls -name my_group) vm_d # add
+  govc cluster.group.ls -name my_group | grep -v vm_b | xargs govc cluster.group.change -name my_group vm_a vm_b vm_c # remove`
+}
+
+func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
+	update := types.ArrayUpdateSpec{Operation: types.ArrayUpdateOperationEdit}
+	group, err := cmd.Group(ctx)
+	if err != nil {
+		return err
+	}
+
+	refs, err := cmd.ObjectList(ctx, group.kind, f.Args())
+	if err != nil {
+		return err
+	}
+
+	*group.refs = refs
+
+	return cmd.Apply(ctx, update, group.info)
+}

--- a/vendor/github.com/vmware/govmomi/govc/cluster/group/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/cluster/group/create.go
@@ -1,0 +1,86 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package group
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type create struct {
+	*InfoFlag
+
+	vm   bool
+	host bool
+}
+
+func init() {
+	cli.Register("cluster.group.create", &create{})
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.InfoFlag, ctx = NewInfoFlag(ctx)
+	cmd.InfoFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.vm, "vm", false, "Create cluster VM group")
+	f.BoolVar(&cmd.host, "host", false, "Create cluster Host group")
+}
+
+func (cmd *create) Process(ctx context.Context) error {
+	if cmd.name == "" {
+		return flag.ErrHelp
+	}
+	return cmd.InfoFlag.Process(ctx)
+}
+
+func (cmd *create) Description() string {
+	return `Create cluster group.
+
+One of '-vm' or '-host' must be provided to specify the group type.
+
+Examples:
+  govc cluster.group.create -name my_vm_group -vm vm_a vm_b vm_c
+  govc cluster.group.create -name my_host_group -host host_a host_b host_c`
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	update := types.ArrayUpdateSpec{Operation: types.ArrayUpdateOperationAdd}
+	var info types.BaseClusterGroupInfo
+	var err error
+
+	switch {
+	case cmd.vm:
+		info = new(types.ClusterVmGroup)
+	case cmd.host:
+		info = new(types.ClusterHostGroup)
+	default:
+		return flag.ErrHelp
+	}
+
+	info.GetClusterGroupInfo().Name = cmd.name
+
+	group := newGroupInfo(info)
+	*group.refs, err = cmd.ObjectList(ctx, group.kind, f.Args())
+	if err != nil {
+		return err
+	}
+
+	return cmd.Apply(ctx, update, info)
+}

--- a/vendor/github.com/vmware/govmomi/govc/cluster/group/info_flag.go
+++ b/vendor/github.com/vmware/govmomi/govc/cluster/group/info_flag.go
@@ -1,0 +1,121 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package group
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type InfoFlag struct {
+	*flags.ClusterFlag
+
+	groups []types.BaseClusterGroupInfo
+
+	name string
+}
+
+func NewInfoFlag(ctx context.Context) (*InfoFlag, context.Context) {
+	f := &InfoFlag{}
+	f.ClusterFlag, ctx = flags.NewClusterFlag(ctx)
+	return f, ctx
+}
+
+func (f *InfoFlag) Register(ctx context.Context, fs *flag.FlagSet) {
+	f.ClusterFlag.Register(ctx, fs)
+
+	fs.StringVar(&f.name, "name", "", "Cluster group name")
+}
+
+func (f *InfoFlag) Process(ctx context.Context) error {
+	return f.ClusterFlag.Process(ctx)
+}
+
+func (f *InfoFlag) Groups(ctx context.Context) ([]types.BaseClusterGroupInfo, error) {
+	if f.groups != nil {
+		return f.groups, nil
+	}
+
+	cluster, err := f.Cluster()
+	if err != nil {
+		return nil, err
+	}
+
+	config, err := cluster.Configuration(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	f.groups = config.Group
+
+	return f.groups, nil
+}
+
+type ClusterGroupInfo struct {
+	info types.BaseClusterGroupInfo
+
+	refs *[]types.ManagedObjectReference
+
+	kind string
+}
+
+func newGroupInfo(info types.BaseClusterGroupInfo) *ClusterGroupInfo {
+	group := &ClusterGroupInfo{info: info}
+
+	switch info := info.(type) {
+	case *types.ClusterHostGroup:
+		group.refs = &info.Host
+		group.kind = "HostSystem"
+	case *types.ClusterVmGroup:
+		group.refs = &info.Vm
+		group.kind = "VirtualMachine"
+	}
+
+	return group
+}
+
+func (f *InfoFlag) Group(ctx context.Context) (*ClusterGroupInfo, error) {
+	groups, err := f.Groups(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, group := range groups {
+		if group.GetClusterGroupInfo().Name == f.name {
+			return newGroupInfo(group), nil
+		}
+	}
+
+	return nil, fmt.Errorf("group %q not found", f.name)
+}
+
+func (f *InfoFlag) Apply(ctx context.Context, update types.ArrayUpdateSpec, info types.BaseClusterGroupInfo) error {
+	spec := &types.ClusterConfigSpecEx{
+		GroupSpec: []types.ClusterGroupSpec{
+			{
+				ArrayUpdateSpec: update,
+				Info:            info,
+			},
+		},
+	}
+
+	return f.Reconfigure(ctx, spec)
+}

--- a/vendor/github.com/vmware/govmomi/govc/cluster/group/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/cluster/group/ls.go
@@ -1,0 +1,92 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package group
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/vmware/govmomi/govc/cli"
+)
+
+type ls struct {
+	*InfoFlag
+}
+
+func init() {
+	cli.Register("cluster.group.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.InfoFlag, ctx = NewInfoFlag(ctx)
+	cmd.InfoFlag.Register(ctx, f)
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	return cmd.InfoFlag.Process(ctx)
+}
+
+func (cmd *ls) Description() string {
+	return `List cluster groups and group members.
+
+Examples:
+  govc cluster.group.ls -cluster my_cluster
+  govc cluster.group.ls -cluster my_cluster -name my_group`
+}
+
+type groupResult []string
+
+func (r groupResult) Write(w io.Writer) error {
+	for i := range r {
+		fmt.Fprintln(w, r[i])
+	}
+
+	return nil
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	var res groupResult
+
+	if cmd.name == "" {
+		groups, err := cmd.Groups(ctx)
+		if err != nil {
+			return err
+		}
+
+		for _, g := range groups {
+			res = append(res, g.GetClusterGroupInfo().Name)
+		}
+	} else {
+		group, err := cmd.Group(ctx)
+		if err != nil {
+			return err
+		}
+
+		names, err := cmd.Names(ctx, *group.refs)
+		if err != nil {
+			return err
+		}
+
+		for _, ref := range *group.refs {
+			res = append(res, names[ref])
+		}
+	}
+
+	return cmd.WriteResult(res)
+}

--- a/vendor/github.com/vmware/govmomi/govc/cluster/group/remove.go
+++ b/vendor/github.com/vmware/govmomi/govc/cluster/group/remove.go
@@ -1,0 +1,61 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package group
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type remove struct {
+	*InfoFlag
+}
+
+func init() {
+	cli.Register("cluster.group.remove", &remove{})
+}
+
+func (cmd *remove) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.InfoFlag, ctx = NewInfoFlag(ctx)
+	cmd.InfoFlag.Register(ctx, f)
+}
+
+func (cmd *remove) Process(ctx context.Context) error {
+	if cmd.name == "" {
+		return flag.ErrHelp
+	}
+	return cmd.InfoFlag.Process(ctx)
+}
+
+func (cmd *remove) Description() string {
+	return `Remove cluster group.
+
+Examples:
+  govc cluster.group.remove -cluster my_cluster -name my_group`
+}
+
+func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
+	update := types.ArrayUpdateSpec{
+		Operation: types.ArrayUpdateOperationRemove,
+		RemoveKey: cmd.name,
+	}
+
+	return cmd.Apply(ctx, update, nil)
+}

--- a/vendor/github.com/vmware/govmomi/govc/cluster/override/change.go
+++ b/vendor/github.com/vmware/govmomi/govc/cluster/override/change.go
@@ -1,0 +1,148 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package override
+
+import (
+	"context"
+	"flag"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/cluster"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type change struct {
+	*flags.ClusterFlag
+	*flags.VirtualMachineFlag
+
+	drs types.ClusterDrsVmConfigInfo
+	das types.ClusterDasVmConfigInfo
+}
+
+func init() {
+	cli.Register("cluster.override.change", &change{})
+}
+
+func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClusterFlag, ctx = flags.NewClusterFlag(ctx)
+	cmd.ClusterFlag.Register(ctx, f)
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	// DRS
+	f.Var(flags.NewOptionalBool(&cmd.drs.Enabled), "drs-enabled", "Enable DRS")
+
+	f.StringVar((*string)(&cmd.drs.Behavior), "drs-mode", "", cluster.DrsBehaviorUsage())
+
+	// HA
+	rp := []string{
+		string(types.DasVmPriorityDisabled),
+		string(types.DasVmPriorityLow),
+		string(types.DasVmPriorityMedium),
+		string(types.DasVmPriorityHigh),
+	}
+	cmd.das.DasSettings = new(types.ClusterDasVmSettings)
+
+	f.StringVar((*string)(&cmd.das.DasSettings.RestartPriority), "ha-restart-priority", "", "HA restart priority: "+strings.Join(rp, ", "))
+}
+
+func (cmd *change) Description() string {
+	return `Change cluster VM overrides.
+
+Examples:
+  govc cluster.override.change -cluster cluster_1 -vm vm_1 -ha-restart-priority high
+  govc cluster.override.change -cluster cluster_1 -vm vm_2 -drs-enabled=false
+  govc cluster.override.change -cluster cluster_1 -vm vm_3 -drs-enabled -drs-mode fullyAutomated`
+}
+
+func (cmd *change) Process(ctx context.Context) error {
+	if err := cmd.ClusterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.VirtualMachineFlag.Process(ctx)
+}
+
+func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	cluster, err := cmd.Cluster()
+	if err != nil {
+		return err
+	}
+
+	config, err := cluster.Configuration(ctx)
+	if err != nil {
+		return err
+	}
+
+	spec := &types.ClusterConfigSpecEx{}
+	cmd.drs.Key = vm.Reference()
+	cmd.das.Key = vm.Reference()
+
+	if cmd.drs.Behavior != "" || cmd.drs.Enabled != nil {
+		op := types.ArrayUpdateOperationAdd
+		for _, c := range config.DrsVmConfig {
+			if c.Key == cmd.drs.Key {
+				op = types.ArrayUpdateOperationEdit
+				break
+			}
+		}
+
+		spec.DrsVmConfigSpec = []types.ClusterDrsVmConfigSpec{
+			{
+				ArrayUpdateSpec: types.ArrayUpdateSpec{
+					Operation: op,
+				},
+				Info: &cmd.drs,
+			},
+		}
+	}
+
+	if cmd.das.DasSettings.RestartPriority != "" {
+		op := types.ArrayUpdateOperationAdd
+		for _, c := range config.DasVmConfig {
+			if c.Key == cmd.das.Key {
+				op = types.ArrayUpdateOperationEdit
+				break
+			}
+		}
+
+		spec.DasVmConfigSpec = []types.ClusterDasVmConfigSpec{
+			{
+				ArrayUpdateSpec: types.ArrayUpdateSpec{
+					Operation: op,
+				},
+				Info: &cmd.das,
+			},
+		}
+	}
+
+	if spec.DrsVmConfigSpec == nil && spec.DasVmConfigSpec == nil {
+		return flag.ErrHelp
+	}
+
+	return cmd.Reconfigure(ctx, spec)
+}

--- a/vendor/github.com/vmware/govmomi/govc/cluster/override/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/cluster/override/info.go
@@ -1,0 +1,142 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package override
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*flags.ClusterFlag
+}
+
+func init() {
+	cli.Register("cluster.override.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClusterFlag, ctx = flags.NewClusterFlag(ctx)
+	cmd.ClusterFlag.Register(ctx, f)
+}
+
+func (cmd *info) Description() string {
+	return `Cluster VM overrides info.
+
+Examples:
+  govc cluster.override.info
+  govc cluster.override.info -json`
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	return cmd.ClusterFlag.Process(ctx)
+}
+
+type Override struct {
+	id   types.ManagedObjectReference
+	Name string
+	Host string                        `json:",omitempty"`
+	DRS  *types.ClusterDrsVmConfigInfo `json:",omitempty"`
+	DAS  *types.ClusterDasVmConfigInfo `json:",omitempty"`
+}
+
+type infoResult struct {
+	Overrides map[string]*Override
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for _, entry := range r.Overrides {
+		behavior := fmt.Sprintf("Default (%s)", types.DrsBehaviorFullyAutomated)
+		if entry.DRS != nil {
+			if *entry.DRS.Enabled {
+				behavior = string(entry.DRS.Behavior)
+			}
+		}
+
+		priority := fmt.Sprintf("Default (%s)", types.DasVmPriorityMedium)
+		if entry.DAS != nil {
+			priority = entry.DAS.DasSettings.RestartPriority
+		}
+
+		fmt.Fprintf(tw, "Name:\t%s\n", entry.Name)
+		fmt.Fprintf(tw, "  DRS Automation Level:\t%s\n", strings.Title(behavior))
+		fmt.Fprintf(tw, "  HA Restart Priority:\t%s\n", strings.Title(priority))
+		fmt.Fprintf(tw, "  Host:\t%s\n", entry.Host)
+	}
+
+	return tw.Flush()
+}
+
+func (r *infoResult) entry(id types.ManagedObjectReference) *Override {
+	key := id.String()
+	vm, ok := r.Overrides[key]
+	if !ok {
+		r.Overrides[key] = &Override{id: id}
+		vm = r.Overrides[key]
+	}
+	return vm
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	cluster, err := cmd.Cluster()
+	if err != nil {
+		return err
+	}
+
+	config, err := cluster.Configuration(ctx)
+	if err != nil {
+		return err
+	}
+
+	res := &infoResult{
+		Overrides: make(map[string]*Override),
+	}
+
+	for i := range config.DasVmConfig {
+		vm := res.entry(config.DasVmConfig[i].Key)
+
+		vm.DAS = &config.DasVmConfig[i]
+	}
+
+	for i := range config.DrsVmConfig {
+		vm := res.entry(config.DrsVmConfig[i].Key)
+
+		vm.DRS = &config.DrsVmConfig[i]
+	}
+
+	for _, o := range res.Overrides {
+		// TODO: can optimize to reduce round trips
+		vm := object.NewVirtualMachine(cluster.Client(), o.id)
+		o.Name, _ = vm.ObjectName(ctx)
+		if h, herr := vm.HostSystem(ctx); herr == nil {
+			o.Host, _ = h.ObjectName(ctx)
+		}
+	}
+
+	return cmd.WriteResult(res)
+}

--- a/vendor/github.com/vmware/govmomi/govc/cluster/override/remove.go
+++ b/vendor/github.com/vmware/govmomi/govc/cluster/override/remove.go
@@ -1,0 +1,110 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package override
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type remove struct {
+	*flags.ClusterFlag
+	*flags.VirtualMachineFlag
+}
+
+func init() {
+	cli.Register("cluster.override.remove", &remove{})
+}
+
+func (cmd *remove) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClusterFlag, ctx = flags.NewClusterFlag(ctx)
+	cmd.ClusterFlag.Register(ctx, f)
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+}
+
+func (cmd *remove) Description() string {
+	return `Remove cluster VM overrides.
+
+Examples:
+  govc cluster.override.remove -cluster cluster_1 -vm vm_1`
+}
+
+func (cmd *remove) Process(ctx context.Context) error {
+	if err := cmd.ClusterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.VirtualMachineFlag.Process(ctx)
+}
+
+func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	cluster, err := cmd.Cluster()
+	if err != nil {
+		return err
+	}
+
+	config, err := cluster.Configuration(ctx)
+	if err != nil {
+		return err
+	}
+
+	spec := &types.ClusterConfigSpecEx{}
+	ref := vm.Reference()
+
+	for _, c := range config.DrsVmConfig {
+		if c.Key == ref {
+			spec.DrsVmConfigSpec = []types.ClusterDrsVmConfigSpec{
+				{
+					ArrayUpdateSpec: types.ArrayUpdateSpec{
+						Operation: types.ArrayUpdateOperationRemove,
+						RemoveKey: ref,
+					},
+				},
+			}
+			break
+		}
+	}
+
+	for _, c := range config.DasVmConfig {
+		if c.Key == ref {
+			spec.DasVmConfigSpec = []types.ClusterDasVmConfigSpec{
+				{
+					ArrayUpdateSpec: types.ArrayUpdateSpec{
+						Operation: types.ArrayUpdateOperationRemove,
+						RemoveKey: ref,
+					},
+				},
+			}
+			break
+		}
+	}
+
+	return cmd.Reconfigure(ctx, spec)
+}

--- a/vendor/github.com/vmware/govmomi/govc/cluster/rule/change.go
+++ b/vendor/github.com/vmware/govmomi/govc/cluster/rule/change.go
@@ -1,0 +1,93 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rule
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type change struct {
+	*SpecFlag
+	*InfoFlag
+}
+
+func init() {
+	cli.Register("cluster.rule.change", &change{})
+}
+
+func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.SpecFlag = new(SpecFlag)
+	cmd.SpecFlag.Register(ctx, f)
+
+	cmd.InfoFlag, ctx = NewInfoFlag(ctx)
+	cmd.InfoFlag.Register(ctx, f)
+}
+
+func (cmd *change) Process(ctx context.Context) error {
+	if cmd.name == "" {
+		return flag.ErrHelp
+	}
+	return cmd.InfoFlag.Process(ctx)
+}
+
+func (cmd *change) Usage() string {
+	return `NAME...`
+}
+
+func (cmd *change) Description() string {
+	return `Change cluster rule.
+
+Examples:
+  govc cluster.rule.change -cluster my_cluster -name my_rule -enable=false`
+}
+
+func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
+	update := types.ArrayUpdateSpec{Operation: types.ArrayUpdateOperationEdit}
+	rule, err := cmd.Rule(ctx)
+	if err != nil {
+		return err
+	}
+
+	var vms *[]types.ManagedObjectReference
+
+	switch r := rule.info.(type) {
+	case *types.ClusterAffinityRuleSpec:
+		vms = &r.Vm
+	case *types.ClusterAntiAffinityRuleSpec:
+		vms = &r.Vm
+	}
+
+	if vms != nil && f.NArg() != 0 {
+		refs, err := cmd.ObjectList(ctx, rule.kind, f.Args())
+		if err != nil {
+			return err
+		}
+
+		*vms = refs
+	}
+
+	info := rule.info.GetClusterRuleInfo()
+	info.Name = cmd.name
+	info.Enabled = cmd.Enabled
+	info.Mandatory = cmd.Mandatory
+
+	return cmd.Apply(ctx, update, rule.info)
+}

--- a/vendor/github.com/vmware/govmomi/govc/cluster/rule/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/cluster/rule/create.go
@@ -1,0 +1,136 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rule
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type create struct {
+	*SpecFlag
+	*InfoFlag
+
+	vmhost       bool
+	affinity     bool
+	antiaffinity bool
+	depends      bool
+}
+
+func init() {
+	cli.Register("cluster.rule.create", &create{})
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.SpecFlag = new(SpecFlag)
+	cmd.SpecFlag.Register(ctx, f)
+
+	cmd.InfoFlag, ctx = NewInfoFlag(ctx)
+	cmd.InfoFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.vmhost, "vm-host", false, "Virtual Machines to Hosts")
+	f.BoolVar(&cmd.affinity, "affinity", false, "Keep Virtual Machines Together")
+	f.BoolVar(&cmd.antiaffinity, "anti-affinity", false, "Separate Virtual Machines")
+	f.BoolVar(&cmd.depends, "depends", false, "Virtual Machines to Virtual Machines")
+}
+
+func (cmd *create) Process(ctx context.Context) error {
+	if cmd.name == "" {
+		return flag.ErrHelp
+	}
+	return cmd.InfoFlag.Process(ctx)
+}
+
+func (cmd *create) Usage() string {
+	return "NAME..."
+}
+
+func (cmd *create) Description() string {
+	return `Create cluster rule.
+
+Rules are not enabled by default, use the 'enable' flag to enable upon creation or cluster.rule.change after creation.
+
+One of '-affinity', '-anti-affinity', '-depends' or '-vm-host' must be provided to specify the rule type.
+
+With '-affinity' or '-anti-affinity', at least 2 vm NAME arguments must be specified.
+
+With '-depends', vm group NAME and vm group dependency NAME arguments must be specified.
+
+With '-vm-host', use the '-vm-group' flag combined with the '-host-affine-group' and/or '-host-anti-affine-group' flags.
+
+Examples:
+  govc cluster.rule.create -name pod1 -enable -affinity vm_a vm_b vm_c
+  govc cluster.rule.create -name pod2 -enable -anti-affinity vm_d vm_e vm_f
+  govc cluster.rule.create -name pod3 -enable -mandatory -vm-host -vm-group my_vms -host-affine-group my_hosts
+  govc cluster.rule.create -name pod4 -depends vm_group_app vm_group_db`
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	args := f.Args()
+	update := types.ArrayUpdateSpec{Operation: types.ArrayUpdateOperationAdd}
+	var rule types.BaseClusterRuleInfo
+	var err error
+
+	switch {
+	case cmd.vmhost:
+		rule = &cmd.ClusterVmHostRuleInfo
+	case cmd.affinity:
+		rule = &cmd.ClusterAffinityRuleSpec
+		if len(args) < 2 {
+			return flag.ErrHelp // can't create this rule without 2 or more hosts
+		}
+		cmd.ClusterAffinityRuleSpec.Vm, err = cmd.ObjectList(ctx, "VirtualMachine", args)
+		if err != nil {
+			return err
+		}
+	case cmd.antiaffinity:
+		rule = &cmd.ClusterAntiAffinityRuleSpec
+		if len(args) < 2 {
+			return flag.ErrHelp // can't create this rule without 2 or more hosts
+		}
+		cmd.ClusterAntiAffinityRuleSpec.Vm, err = cmd.ObjectList(ctx, "VirtualMachine", args)
+		if err != nil {
+			return err
+		}
+	case cmd.depends:
+		if len(args) != 2 {
+			return flag.ErrHelp
+		}
+		rule = &types.ClusterDependencyRuleInfo{
+			VmGroup:          args[0],
+			DependsOnVmGroup: args[1],
+		}
+	default:
+		return flag.ErrHelp
+	}
+
+	if cmd.Enabled == nil {
+		// ClusterDependencyRuleInfo throws InvalidArgument if Enabled == nil
+		cmd.Enabled = types.NewBool(false)
+	}
+
+	info := rule.GetClusterRuleInfo()
+	info.Name = cmd.name
+	info.Enabled = cmd.Enabled
+	info.Mandatory = cmd.Mandatory
+	info.UserCreated = types.NewBool(true)
+
+	return cmd.Apply(ctx, update, rule)
+}

--- a/vendor/github.com/vmware/govmomi/govc/cluster/rule/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/cluster/rule/info.go
@@ -1,0 +1,92 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rule
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+)
+
+type info struct {
+	*InfoFlag
+}
+
+func init() {
+	cli.Register("cluster.rule.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.InfoFlag, ctx = NewInfoFlag(ctx)
+	cmd.InfoFlag.Register(ctx, f)
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	return cmd.InfoFlag.Process(ctx)
+}
+
+func (cmd *info) Description() string {
+	return `Provides detailed infos about cluster rules, their types and rule members.
+
+Examples:
+  govc cluster.rule.info -cluster my_cluster
+  govc cluster.rule.info -cluster my_cluster -name my_rule`
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	var res ruleResult
+
+	rules, err := cmd.Rules(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, rule := range rules {
+		ruleName := rule.GetClusterRuleInfo().Name
+		ruleInfo := GetExtendedClusterRuleInfo(rule)
+		if cmd.name == "" || cmd.name == ruleName {
+			res = append(res, fmt.Sprintf("Rule: %s", ruleName))
+			res = append(res, fmt.Sprintf("  Type: %s", ruleInfo.ruleType))
+			switch ruleInfo.ruleType {
+			case "ClusterAffinityRuleSpec", "ClusterAntiAffinityRuleSpec":
+				names, err := cmd.Names(ctx, *ruleInfo.refs)
+				if err != nil {
+					cmd.WriteResult(res)
+					return err
+				}
+
+				for _, ref := range *ruleInfo.refs {
+					res = append(res, fmt.Sprintf("  VM: %s", names[ref]))
+				}
+			case "ClusterVmHostRuleInfo":
+				res = append(res, fmt.Sprintf("  vmGroupName: %s", ruleInfo.vmGroupName))
+				res = append(res, fmt.Sprintf("  affineHostGroupName %s", ruleInfo.affineHostGroupName))
+				res = append(res, fmt.Sprintf("  antiAffineHostGroupName %s", ruleInfo.antiAffineHostGroupName))
+			case "ClusterDependencyRuleInfo":
+				res = append(res, fmt.Sprintf("  VmGroup %s", ruleInfo.VmGroup))
+				res = append(res, fmt.Sprintf("  DependsOnVmGroup %s", ruleInfo.DependsOnVmGroup))
+			default:
+				res = append(res, "unknown rule type, no further rule details known")
+			}
+		}
+
+	}
+
+	return cmd.WriteResult(res)
+}

--- a/vendor/github.com/vmware/govmomi/govc/cluster/rule/info_flag.go
+++ b/vendor/github.com/vmware/govmomi/govc/cluster/rule/info_flag.go
@@ -1,0 +1,164 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rule
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type InfoFlag struct {
+	*flags.ClusterFlag
+
+	rules []types.BaseClusterRuleInfo
+
+	name string
+	Long bool
+}
+
+func NewInfoFlag(ctx context.Context) (*InfoFlag, context.Context) {
+	f := &InfoFlag{}
+	f.ClusterFlag, ctx = flags.NewClusterFlag(ctx)
+	return f, ctx
+}
+
+func (f *InfoFlag) Register(ctx context.Context, fs *flag.FlagSet) {
+	f.ClusterFlag.Register(ctx, fs)
+
+	fs.StringVar(&f.name, "name", "", "Cluster rule name")
+	fs.BoolVar(&f.Long, "l", false, "Long listing format")
+}
+
+func (f *InfoFlag) Process(ctx context.Context) error {
+	return f.ClusterFlag.Process(ctx)
+}
+
+func (f *InfoFlag) Rules(ctx context.Context) ([]types.BaseClusterRuleInfo, error) {
+	if f.rules != nil {
+		return f.rules, nil
+	}
+
+	cluster, err := f.Cluster()
+	if err != nil {
+		return nil, err
+	}
+
+	config, err := cluster.Configuration(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	f.rules = config.Rule
+
+	return f.rules, nil
+}
+
+type ClusterRuleInfo struct {
+	info types.BaseClusterRuleInfo
+
+	ruleType string
+
+	// only ClusterAffinityRuleSpec and ClusterAntiAffinityRuleSpec
+	refs *[]types.ManagedObjectReference
+
+	kind string
+
+	// only ClusterVmHostRuleInfo
+	vmGroupName             string
+	affineHostGroupName     string
+	antiAffineHostGroupName string
+
+	// only ClusterDependencyRuleInfo
+	VmGroup          string
+	DependsOnVmGroup string
+}
+
+func (f *InfoFlag) Rule(ctx context.Context) (*ClusterRuleInfo, error) {
+	rules, err := f.Rules(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, rule := range rules {
+		if rule.GetClusterRuleInfo().Name != f.name {
+			continue
+		}
+
+		r := GetExtendedClusterRuleInfo(rule)
+		return &r, nil
+	}
+
+	return nil, fmt.Errorf("rule %q not found", f.name)
+}
+
+func GetExtendedClusterRuleInfo(rule types.BaseClusterRuleInfo) ClusterRuleInfo {
+	r := ClusterRuleInfo{info: rule}
+
+	switch info := rule.(type) {
+	case *types.ClusterAffinityRuleSpec:
+		r.ruleType = "ClusterAffinityRuleSpec"
+		r.refs = &info.Vm
+		r.kind = "VirtualMachine"
+	case *types.ClusterAntiAffinityRuleSpec:
+		r.ruleType = "ClusterAntiAffinityRuleSpec"
+		r.refs = &info.Vm
+		r.kind = "VirtualMachine"
+	case *types.ClusterVmHostRuleInfo:
+		r.ruleType = "ClusterVmHostRuleInfo"
+		r.vmGroupName = info.VmGroupName
+		r.affineHostGroupName = info.AffineHostGroupName
+		r.antiAffineHostGroupName = info.AntiAffineHostGroupName
+	case *types.ClusterDependencyRuleInfo:
+		r.ruleType = "ClusterDependencyRuleInfo"
+		r.VmGroup = info.VmGroup
+		r.DependsOnVmGroup = info.DependsOnVmGroup
+	}
+	return r
+}
+
+func (f *InfoFlag) Apply(ctx context.Context, update types.ArrayUpdateSpec, info types.BaseClusterRuleInfo) error {
+	spec := &types.ClusterConfigSpecEx{
+		RulesSpec: []types.ClusterRuleSpec{
+			{
+				ArrayUpdateSpec: update,
+				Info:            info,
+			},
+		},
+	}
+
+	return f.Reconfigure(ctx, spec)
+}
+
+type SpecFlag struct {
+	types.ClusterRuleInfo
+	types.ClusterVmHostRuleInfo
+	types.ClusterAffinityRuleSpec
+	types.ClusterAntiAffinityRuleSpec
+}
+
+func (s *SpecFlag) Register(ctx context.Context, f *flag.FlagSet) {
+	f.Var(flags.NewOptionalBool(&s.Enabled), "enable", "Enable rule")
+	f.Var(flags.NewOptionalBool(&s.Mandatory), "mandatory", "Enforce rule compliance")
+
+	f.StringVar(&s.VmGroupName, "vm-group", "", "VM group name")
+	f.StringVar(&s.AffineHostGroupName, "host-affine-group", "", "Host affine group name")
+	f.StringVar(&s.AntiAffineHostGroupName, "host-anti-affine-group", "", "Host anti-affine group name")
+}

--- a/vendor/github.com/vmware/govmomi/govc/cluster/rule/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/cluster/rule/ls.go
@@ -1,0 +1,124 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rule
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/vmware/govmomi/govc/cli"
+)
+
+type ls struct {
+	*InfoFlag
+}
+
+func init() {
+	cli.Register("cluster.rule.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.InfoFlag, ctx = NewInfoFlag(ctx)
+	cmd.InfoFlag.Register(ctx, f)
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	return cmd.InfoFlag.Process(ctx)
+}
+
+func (cmd *ls) Description() string {
+	return `List cluster rules and rule members.
+
+Examples:
+  govc cluster.rule.ls -cluster my_cluster
+  govc cluster.rule.ls -cluster my_cluster -name my_rule
+  govc cluster.rule.ls -cluster my_cluster -l
+  govc cluster.rule.ls -cluster my_cluster -name my_rule -l`
+}
+
+type ruleResult []string
+
+func (r ruleResult) Write(w io.Writer) error {
+	for i := range r {
+		fmt.Fprintln(w, r[i])
+	}
+
+	return nil
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	var res ruleResult
+
+	if cmd.name == "" {
+		rules, err := cmd.Rules(ctx)
+		if err != nil {
+			return err
+		}
+
+		for _, g := range rules {
+			ruleName := g.GetClusterRuleInfo().Name
+			if cmd.Long {
+				ruleTypeInfo := GetExtendedClusterRuleInfo(g).ruleType
+				res = append(res, fmt.Sprintf("%s (%s)", ruleName, ruleTypeInfo))
+			} else {
+				res = append(res, ruleName)
+			}
+		}
+	} else {
+		rule, err := cmd.Rule(ctx)
+		if err != nil {
+			return err
+		}
+
+		switch rule.ruleType {
+		case "ClusterAffinityRuleSpec", "ClusterAntiAffinityRuleSpec":
+			names, err := cmd.Names(ctx, *rule.refs)
+			if err != nil {
+				cmd.WriteResult(res)
+				return err
+			}
+
+			for _, ref := range *rule.refs {
+				res = extendedAppend(res, cmd.Long, names[ref], "VM")
+			}
+		case "ClusterVmHostRuleInfo":
+			res = extendedAppend(res, cmd.Long, rule.vmGroupName, "vmGroupName")
+			res = extendedAppend(res, cmd.Long, rule.affineHostGroupName, "affineHostGroupName")
+			res = extendedAppend(res, cmd.Long, rule.antiAffineHostGroupName, "antiAffineHostGroupName")
+		case "ClusterDependencyRuleInfo":
+			res = extendedAppend(res, cmd.Long, rule.VmGroup, "VmGroup")
+			res = extendedAppend(res, cmd.Long, rule.DependsOnVmGroup, "DependsOnVmGroup")
+		default:
+			res = append(res, "unknown rule type, no further rule details known")
+		}
+
+	}
+
+	return cmd.WriteResult(res)
+}
+
+func extendedAppend(res ruleResult, long bool, entryValue string, entryType string) ruleResult {
+	var newres ruleResult
+	if long {
+		newres = append(res, fmt.Sprintf("%s (%s)", entryValue, entryType))
+	} else {
+		newres = append(res, entryValue)
+	}
+	return newres
+}

--- a/vendor/github.com/vmware/govmomi/govc/cluster/rule/remove.go
+++ b/vendor/github.com/vmware/govmomi/govc/cluster/rule/remove.go
@@ -1,0 +1,66 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rule
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type remove struct {
+	*InfoFlag
+}
+
+func init() {
+	cli.Register("cluster.rule.remove", &remove{})
+}
+
+func (cmd *remove) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.InfoFlag, ctx = NewInfoFlag(ctx)
+	cmd.InfoFlag.Register(ctx, f)
+}
+
+func (cmd *remove) Process(ctx context.Context) error {
+	if cmd.name == "" {
+		return flag.ErrHelp
+	}
+	return cmd.InfoFlag.Process(ctx)
+}
+
+func (cmd *remove) Description() string {
+	return `Remove cluster rule.
+
+Examples:
+  govc cluster.group.remove -cluster my_cluster -name my_rule`
+}
+
+func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
+	rule, err := cmd.Rule(ctx)
+	if err != nil {
+		return err
+	}
+
+	update := types.ArrayUpdateSpec{
+		Operation: types.ArrayUpdateOperationRemove,
+		RemoveKey: rule.info.GetClusterRuleInfo().Key,
+	}
+
+	return cmd.Apply(ctx, update, nil)
+}

--- a/vendor/github.com/vmware/govmomi/govc/datacenter/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/datacenter/create.go
@@ -1,0 +1,77 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datacenter
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type create struct {
+	*flags.FolderFlag
+}
+
+func init() {
+	cli.Register("datacenter.create", &create{})
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.FolderFlag, ctx = flags.NewFolderFlag(ctx)
+	cmd.FolderFlag.Register(ctx, f)
+}
+
+func (cmd *create) Usage() string {
+	return "NAME..."
+}
+
+func (cmd *create) Description() string {
+	return `Create datacenter NAME.
+
+Examples:
+  govc datacenter.create MyDC # create
+  govc object.destroy /MyDC   # delete`
+}
+
+func (cmd *create) Process(ctx context.Context) error {
+	if err := cmd.FolderFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	folder, err := cmd.FolderOrDefault("/")
+	if err != nil {
+		return err
+	}
+
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
+	for _, name := range f.Args() {
+		_, err := folder.CreateDatacenter(ctx, name)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/datacenter/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/datacenter/info.go
@@ -1,0 +1,196 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datacenter
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/view"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+	*flags.DatacenterFlag
+}
+
+func init() {
+	cli.Register("datacenter.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *info) Usage() string {
+	return "[PATH]..."
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	args := f.Args()
+	if len(args) == 0 {
+		args = []string{"*"}
+	}
+
+	var props []string
+	res := infoResult{
+		finder: finder,
+		ctx:    ctx,
+		client: c,
+	}
+
+	if !cmd.OutputFlag.All() {
+		props = []string{
+			"name",
+			"vmFolder",
+			"hostFolder",
+			"datastoreFolder",
+			"networkFolder",
+			"datastore",
+			"network",
+		}
+	}
+
+	for _, arg := range args {
+		objects, err := finder.DatacenterList(ctx, arg)
+		if err != nil {
+			return err
+		}
+		res.objects = append(res.objects, objects...)
+	}
+
+	if len(res.objects) != 0 {
+		refs := make([]types.ManagedObjectReference, 0, len(res.objects))
+		for _, o := range res.objects {
+			refs = append(refs, o.Reference())
+		}
+
+		pc := property.DefaultCollector(c)
+		err = pc.Retrieve(ctx, refs, props, &res.Datacenters)
+		if err != nil {
+			return err
+		}
+	}
+
+	return cmd.WriteResult(&res)
+}
+
+type infoResult struct {
+	Datacenters []mo.Datacenter
+	objects     []*object.Datacenter
+	finder      *find.Finder
+	ctx         context.Context
+	client      *vim25.Client
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	// Maintain order via r.objects as Property collector does not always return results in order.
+	objects := make(map[types.ManagedObjectReference]mo.Datacenter, len(r.Datacenters))
+	for _, o := range r.Datacenters {
+		objects[o.Reference()] = o
+	}
+
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for _, o := range r.objects {
+		dc := objects[o.Reference()]
+		fmt.Fprintf(tw, "Name:\t%s\n", dc.Name)
+		fmt.Fprintf(tw, "  Path:\t%s\n", o.InventoryPath)
+
+		r.finder.SetDatacenter(o)
+
+		hosts, _ := r.finder.HostSystemList(r.ctx, "*")
+		fmt.Fprintf(tw, "  Hosts:\t%d\n", len(hosts))
+
+		clusters, _ := r.finder.ClusterComputeResourceList(r.ctx, "*")
+		fmt.Fprintf(tw, "  Clusters:\t%d\n", len(clusters))
+
+		manager := view.NewManager(r.client)
+
+		v, err := manager.CreateContainerView(r.ctx, r.client.ServiceContent.RootFolder, []string{"VirtualMachine"}, true)
+		if err != nil {
+			return err
+		}
+
+		var vms []mo.VirtualMachine
+		err = v.Retrieve(r.ctx, []string{"VirtualMachine"}, []string{"summary.config.template"}, &vms)
+		if err != nil {
+			return err
+		}
+
+		defer func() {
+			_ = v.Destroy(r.ctx)
+		}()
+
+		totalVms := 0
+		for _, vm := range vms {
+			if vm.Summary.Config.Template {
+				continue
+			}
+			totalVms++
+		}
+
+		fmt.Fprintf(tw, "  Virtual Machines:\t%d\n", totalVms)
+
+		fmt.Fprintf(tw, "  Networks:\t%d\n", len(dc.Network))
+		fmt.Fprintf(tw, "  Datastores:\t%d\n", len(dc.Datastore))
+	}
+
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/datastore/cluster/change.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/cluster/change.go
@@ -1,0 +1,104 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"context"
+	"flag"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func DrsBehaviorUsage() string {
+	drsModes := []string{
+		string(types.StorageDrsPodConfigInfoBehaviorManual),
+		string(types.StorageDrsPodConfigInfoBehaviorAutomated),
+	}
+
+	return "Storage DRS behavior: " + strings.Join(drsModes, ", ")
+}
+
+type change struct {
+	*flags.DatacenterFlag
+
+	types.StorageDrsConfigSpec
+}
+
+func init() {
+	cli.Register("datastore.cluster.change", &change{})
+}
+
+func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	cmd.PodConfigSpec = new(types.StorageDrsPodConfigSpec)
+
+	f.Var(flags.NewOptionalBool(&cmd.PodConfigSpec.Enabled), "drs-enabled", "Enable Storage DRS")
+
+	f.StringVar((*string)(&cmd.PodConfigSpec.DefaultVmBehavior), "drs-mode", "", DrsBehaviorUsage())
+}
+
+func (cmd *change) Usage() string {
+	return "CLUSTER..."
+}
+
+func (cmd *change) Description() string {
+	return `Change configuration of the given datastore clusters.
+
+Examples:
+  govc datastore.cluster.change -drs-enabled ClusterA
+  govc datastore.cluster.change -drs-enabled=false ClusterB`
+}
+
+func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
+	client, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	m := object.NewStorageResourceManager(client)
+
+	for _, path := range f.Args() {
+		clusters, err := finder.DatastoreClusterList(ctx, path)
+		if err != nil {
+			return err
+		}
+
+		for _, cluster := range clusters {
+			task, err := m.ConfigureStorageDrsForPod(ctx, cluster, cmd.StorageDrsConfigSpec, true)
+			if err != nil {
+				return err
+			}
+
+			_, err = task.WaitForResult(ctx, nil)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/datastore/cluster/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/cluster/info.go
@@ -1,0 +1,136 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*flags.DatacenterFlag
+}
+
+func init() {
+	cli.Register("datastore.cluster.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+}
+
+func (cmd *info) Usage() string {
+	return "[PATH]..."
+}
+
+func (cmd *info) Description() string {
+	return `Display datastore cluster info.
+
+Examples:
+  govc datastore.cluster.info
+  govc datastore.cluster.info MyDatastoreCluster`
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	args := f.Args()
+	if len(args) == 0 {
+		args = []string{"*"}
+	}
+
+	var res infoResult
+	var props []string
+
+	if cmd.OutputFlag.All() {
+		props = nil // Load everything
+	} else {
+		props = []string{"podStorageDrsEntry", "summary"} // Load summary
+	}
+
+	for _, arg := range args {
+		objects, err := finder.DatastoreClusterList(ctx, arg)
+		if err != nil {
+			return err
+		}
+		res.objects = append(res.objects, objects...)
+	}
+
+	if len(res.objects) != 0 {
+		refs := make([]types.ManagedObjectReference, 0, len(res.objects))
+		for _, o := range res.objects {
+			refs = append(refs, o.Reference())
+		}
+
+		pc := property.DefaultCollector(c)
+		err = pc.Retrieve(ctx, refs, props, &res.Clusters)
+		if err != nil {
+			return err
+		}
+	}
+
+	return cmd.WriteResult(&res)
+}
+
+type infoResult struct {
+	Clusters []mo.StoragePod
+	objects  []*object.StoragePod
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	// Maintain order via r.objects as Property collector does not always return results in order.
+	objects := make(map[types.ManagedObjectReference]mo.StoragePod, len(r.Clusters))
+	for _, o := range r.Clusters {
+		objects[o.Reference()] = o
+	}
+
+	tw := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
+
+	for _, o := range r.objects {
+		ds := objects[o.Reference()]
+		s := ds.Summary
+		c := ds.PodStorageDrsEntry.StorageDrsConfig
+		fmt.Fprintf(tw, "Name:\t%s\n", s.Name)
+		fmt.Fprintf(tw, "  Path:\t%s\n", o.InventoryPath)
+		fmt.Fprintf(tw, "  Capacity:\t%.1f GB\n", float64(s.Capacity)/(1<<30))
+		fmt.Fprintf(tw, "  Free:\t%.1f GB\n", float64(s.FreeSpace)/(1<<30))
+		fmt.Fprintf(tw, "  SDRS Enabled:\t%t\n", c.PodConfig.Enabled)
+		fmt.Fprintf(tw, "  SDRS Mode:\t%s\n", c.PodConfig.DefaultVmBehavior)
+	}
+
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/datastore/cp.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/cp.go
@@ -1,0 +1,152 @@
+/*
+Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastore
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type cp struct {
+	target
+}
+
+func init() {
+	cli.Register("datastore.cp", &cp{})
+}
+
+type target struct {
+	*flags.DatastoreFlag // The source Datastore and the default target Datastore
+
+	dc *flags.DatacenterFlag // Optionally target a different Datacenter
+	ds *flags.DatastoreFlag  // Optionally target a different Datastore
+
+	kind  bool
+	force bool
+}
+
+func (cmd *target) FileManager() (*object.DatastoreFileManager, error) {
+	dc, err := cmd.Datacenter()
+	if err != nil {
+		return nil, err
+	}
+
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return nil, err
+	}
+
+	m := ds.NewFileManager(dc, cmd.force)
+
+	dc, err = cmd.dc.Datacenter()
+	if err != nil {
+		return nil, err
+	}
+	m.DatacenterTarget = dc
+
+	return m, nil
+}
+
+func (cmd *target) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	cmd.dc = &flags.DatacenterFlag{
+		OutputFlag: cmd.OutputFlag,
+		ClientFlag: cmd.ClientFlag,
+	}
+	f.StringVar(&cmd.dc.Name, "dc-target", "", "Datacenter destination (defaults to -dc)")
+
+	cmd.ds = &flags.DatastoreFlag{
+		DatacenterFlag: cmd.dc,
+	}
+	f.StringVar(&cmd.ds.Name, "ds-target", "", "Datastore destination (defaults to -ds)")
+
+	f.BoolVar(&cmd.kind, "t", true, "Use file type to choose disk or file manager")
+	f.BoolVar(&cmd.force, "f", false, "If true, overwrite any identically named file at the destination")
+}
+
+func (cmd *target) Process(ctx context.Context) error {
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+
+	if cmd.dc.Name == "" {
+		// Use source DC as target DC
+		cmd.dc = cmd.DatacenterFlag
+		cmd.ds.DatacenterFlag = cmd.dc
+	}
+
+	if cmd.ds.Name == "" {
+		// Use source DS as target DS
+		cmd.ds.Name = cmd.DatastoreFlag.Name
+	}
+
+	return nil
+}
+
+func (cmd *cp) Usage() string {
+	return "SRC DST"
+}
+
+func (cmd *cp) Description() string {
+	return `Copy SRC to DST on DATASTORE.
+
+Examples:
+  govc datastore.cp foo/foo.vmx foo/foo.vmx.old
+  govc datastore.cp -f my.vmx foo/foo.vmx
+  govc datastore.cp disks/disk1.vmdk disks/disk2.vmdk
+  govc datastore.cp disks/disk1.vmdk -dc-target DC2 disks/disk2.vmdk
+  govc datastore.cp disks/disk1.vmdk -ds-target NFS-2 disks/disk2.vmdk`
+}
+
+func (cmd *cp) Run(ctx context.Context, f *flag.FlagSet) error {
+	args := f.Args()
+	if len(args) != 2 {
+		return flag.ErrHelp
+	}
+
+	m, err := cmd.FileManager()
+	if err != nil {
+		return err
+	}
+
+	src, err := cmd.DatastorePath(args[0])
+	if err != nil {
+		return err
+	}
+
+	dst, err := cmd.target.ds.DatastorePath(args[1])
+	if err != nil {
+		return err
+	}
+
+	cp := m.CopyFile
+	if cmd.kind {
+		cp = m.Copy
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("Copying %s to %s...", src, dst))
+	defer logger.Wait()
+
+	return cp(m.WithProgress(ctx, logger), src, dst)
+}

--- a/vendor/github.com/vmware/govmomi/govc/datastore/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/create.go
@@ -1,0 +1,321 @@
+/*
+Copyright (c) 2015-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastore
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type create struct {
+	*flags.HostSystemFlag
+
+	// Generic options
+	Type  typeFlag
+	Name  string
+	Force bool
+
+	// Options for NAS
+	RemoteHost string
+	RemotePath string
+	AccessMode string
+	UserName   string
+	Password   string
+
+	// Options for VMFS
+	DiskCanonicalName string
+
+	// Options for local
+	Path string
+}
+
+func init() {
+	cli.Register("datastore.create", &create{})
+}
+
+var nasTypes = []string{
+	string(types.HostFileSystemVolumeFileSystemTypeNFS),
+	string(types.HostFileSystemVolumeFileSystemTypeNFS41),
+	string(types.HostFileSystemVolumeFileSystemTypeCIFS),
+}
+
+var vmfsTypes = []string{
+	string(types.HostFileSystemVolumeFileSystemTypeVMFS),
+}
+
+var localTypes = []string{
+	"local",
+}
+
+var allTypes = []string{}
+
+func init() {
+	allTypes = append(allTypes, nasTypes...)
+	allTypes = append(allTypes, vmfsTypes...)
+	allTypes = append(allTypes, localTypes...)
+}
+
+type typeFlag string
+
+func (t *typeFlag) Set(s string) error {
+	s = strings.ToLower(s)
+	for _, e := range allTypes {
+		if s == strings.ToLower(e) {
+			*t = typeFlag(e)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("unknown type")
+}
+
+func (t *typeFlag) String() string {
+	return string(*t)
+}
+
+func (t *typeFlag) partOf(m []string) bool {
+	for _, e := range m {
+		if t.String() == e {
+			return true
+		}
+	}
+	return false
+}
+
+func (t *typeFlag) IsNasType() bool {
+	return t.partOf(nasTypes)
+}
+
+func (t *typeFlag) IsVmfsType() bool {
+	return t.partOf(vmfsTypes)
+}
+
+func (t *typeFlag) IsLocalType() bool {
+	return t.partOf(localTypes)
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	modes := []string{
+		string(types.HostMountModeReadOnly),
+		string(types.HostMountModeReadWrite),
+	}
+
+	f.StringVar(&cmd.Name, "name", "", "Datastore name")
+	f.Var(&cmd.Type, "type", fmt.Sprintf("Datastore type (%s)", strings.Join(allTypes, "|")))
+	f.BoolVar(&cmd.Force, "force", false, "Ignore DuplicateName error if datastore is already mounted on a host")
+
+	// Options for NAS
+	f.StringVar(&cmd.RemoteHost, "remote-host", "", "Remote hostname of the NAS datastore")
+	f.StringVar(&cmd.RemotePath, "remote-path", "", "Remote path of the NFS mount point")
+	f.StringVar(&cmd.AccessMode, "mode", modes[0],
+		fmt.Sprintf("Access mode for the mount point (%s)", strings.Join(modes, "|")))
+	f.StringVar(&cmd.UserName, "username", "", "Username to use when connecting (CIFS only)")
+	f.StringVar(&cmd.Password, "password", "", "Password to use when connecting (CIFS only)")
+
+	// Options for VMFS
+	f.StringVar(&cmd.DiskCanonicalName, "disk", "", "Canonical name of disk (VMFS only)")
+
+	// Options for Local
+	f.StringVar(&cmd.Path, "path", "", "Local directory path for the datastore (local only)")
+}
+
+func (cmd *create) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *create) Usage() string {
+	return "HOST..."
+}
+
+func (cmd *create) Description() string {
+	return `Create datastore on HOST.
+
+Examples:
+  govc datastore.create -type nfs -name nfsDatastore -remote-host 10.143.2.232 -remote-path /share cluster1
+  govc datastore.create -type vmfs -name vmfsDatastore -disk=mpx.vmhba0:C0:T0:L0 cluster1
+  govc datastore.create -type local -name localDatastore -path /var/datastore host1`
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	hosts, err := cmd.HostSystems(f.Args())
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case cmd.Type.IsNasType():
+		return cmd.CreateNasDatastore(ctx, hosts)
+	case cmd.Type.IsVmfsType():
+		return cmd.CreateVmfsDatastore(ctx, hosts)
+	case cmd.Type.IsLocalType():
+		return cmd.CreateLocalDatastore(ctx, hosts)
+	default:
+		return fmt.Errorf("unhandled type %#v", cmd.Type)
+	}
+}
+
+func (cmd *create) GetHostNasVolumeSpec() types.HostNasVolumeSpec {
+	localPath := cmd.Path
+	if localPath == "" {
+		localPath = cmd.Name
+	}
+
+	s := types.HostNasVolumeSpec{
+		LocalPath:  localPath,
+		Type:       cmd.Type.String(),
+		RemoteHost: cmd.RemoteHost,
+		RemotePath: cmd.RemotePath,
+		AccessMode: cmd.AccessMode,
+		UserName:   cmd.UserName,
+		Password:   cmd.Password,
+	}
+
+	return s
+}
+
+func (cmd *create) CreateNasDatastore(ctx context.Context, hosts []*object.HostSystem) error {
+	object := types.ManagedObjectReference{
+		Type:  "Datastore",
+		Value: fmt.Sprintf("%s:%s", cmd.RemoteHost, cmd.RemotePath),
+	}
+
+	spec := cmd.GetHostNasVolumeSpec()
+
+	for _, host := range hosts {
+		ds, err := host.ConfigManager().DatastoreSystem(ctx)
+		if err != nil {
+			return err
+		}
+
+		_, err = ds.CreateNasDatastore(ctx, spec)
+		if err != nil {
+			if soap.IsSoapFault(err) {
+				switch fault := soap.ToSoapFault(err).VimFault().(type) {
+				case types.PlatformConfigFault:
+					if len(fault.FaultMessage) != 0 {
+						return errors.New(fault.FaultMessage[0].Message)
+					}
+				case types.DuplicateName:
+					if cmd.Force && fault.Object == object {
+						fmt.Fprintf(os.Stderr, "%s: '%s' already mounted\n",
+							host.InventoryPath, cmd.Name)
+						continue
+					}
+				}
+			}
+
+			return fmt.Errorf("%s: %s", host.InventoryPath, err)
+		}
+	}
+
+	return nil
+}
+
+func (cmd *create) CreateVmfsDatastore(ctx context.Context, hosts []*object.HostSystem) error {
+	for _, host := range hosts {
+		ds, err := host.ConfigManager().DatastoreSystem(ctx)
+		if err != nil {
+			return err
+		}
+
+		// Find the specified disk
+		disks, err := ds.QueryAvailableDisksForVmfs(ctx)
+		if err != nil {
+			return err
+		}
+
+		var disk *types.HostScsiDisk
+		for _, e := range disks {
+			if e.CanonicalName == cmd.DiskCanonicalName {
+				disk = &e
+				break
+			}
+		}
+
+		if disk == nil {
+			return fmt.Errorf("no eligible disk found for name %#v", cmd.DiskCanonicalName)
+		}
+
+		// Query for creation options and pick the right one
+		options, err := ds.QueryVmfsDatastoreCreateOptions(ctx, disk.DevicePath)
+		if err != nil {
+			return err
+		}
+
+		var option *types.VmfsDatastoreOption
+		for _, e := range options {
+			if _, ok := e.Info.(*types.VmfsDatastoreAllExtentOption); ok {
+				option = &e
+				break
+			}
+		}
+
+		if option == nil {
+			return fmt.Errorf("cannot use entire disk for datastore for name %#v", cmd.DiskCanonicalName)
+		}
+
+		spec := *option.Spec.(*types.VmfsDatastoreCreateSpec)
+		spec.Vmfs.VolumeName = cmd.Name
+		_, err = ds.CreateVmfsDatastore(ctx, spec)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (cmd *create) CreateLocalDatastore(ctx context.Context, hosts []*object.HostSystem) error {
+	for _, host := range hosts {
+		ds, err := host.ConfigManager().DatastoreSystem(ctx)
+		if err != nil {
+			return err
+		}
+
+		if cmd.Path == "" {
+			cmd.Path = cmd.Name
+		}
+
+		if cmd.Name == "" {
+			cmd.Name = filepath.Base(cmd.Path)
+		}
+
+		_, err = ds.CreateLocalDatastore(ctx, cmd.Name, cmd.Path)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/datastore/disk/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/disk/create.go
@@ -1,0 +1,123 @@
+/*
+Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/units"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type spec struct {
+	types.FileBackedVirtualDiskSpec
+	force bool
+	uuid  string
+}
+
+func (s *spec) Register(ctx context.Context, f *flag.FlagSet) {
+	f.StringVar(&s.AdapterType, "a", string(types.VirtualDiskAdapterTypeLsiLogic), "Disk adapter")
+	f.StringVar(&s.DiskType, "d", string(types.VirtualDiskTypeThin), "Disk format")
+	f.BoolVar(&s.force, "f", false, "Force")
+	f.StringVar(&s.uuid, "uuid", "", "Disk UUID")
+}
+
+type create struct {
+	*flags.DatastoreFlag
+
+	Bytes units.ByteSize
+	spec
+}
+
+func init() {
+	cli.Register("datastore.disk.create", &create{})
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	_ = cmd.Bytes.Set("10G")
+	f.Var(&cmd.Bytes, "size", "Size of new disk")
+
+	cmd.spec.Register(ctx, f)
+}
+
+func (cmd *create) Usage() string {
+	return "VMDK"
+}
+
+func (cmd *create) Description() string {
+	return `Create VMDK on DS.
+
+Examples:
+  govc datastore.mkdir disks
+  govc datastore.disk.create -size 24G disks/disk1.vmdk
+  govc datastore.disk.create disks/parent.vmdk disk/child.vmdk`
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
+	dc, err := cmd.Datacenter()
+	if err != nil {
+		return err
+	}
+
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	m := object.NewVirtualDiskManager(ds.Client())
+
+	var task *object.Task
+	var dst string
+
+	if f.NArg() == 1 {
+		cmd.spec.CapacityKb = int64(cmd.Bytes) / 1024
+		dst = ds.Path(f.Arg(0))
+		task, err = m.CreateVirtualDisk(ctx, dst, dc, &cmd.spec.FileBackedVirtualDiskSpec)
+	} else {
+		dst = ds.Path(f.Arg(0))
+		task, err = m.CreateChildDisk(ctx, ds.Path(f.Arg(0)), dc, dst, dc, cmd.force)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("Creating %s...", dst))
+	defer logger.Wait()
+
+	if _, err = task.WaitForResult(ctx, logger); err != nil {
+		return err
+	}
+
+	if cmd.uuid != "" {
+		return m.SetVirtualDiskUuid(ctx, dst, dc, cmd.uuid)
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/datastore/disk/inflate.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/disk/inflate.go
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type inflate struct {
+	*flags.DatastoreFlag
+}
+
+func init() {
+	cli.Register("datastore.disk.inflate", &inflate{})
+}
+
+func (cmd *inflate) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+}
+
+func (cmd *inflate) Process(ctx context.Context) error {
+	return cmd.DatastoreFlag.Process(ctx)
+}
+
+func (cmd *inflate) Usage() string {
+	return "VMDK"
+}
+
+func (cmd *inflate) Description() string {
+	return `Inflate VMDK on DS.
+
+Examples:
+  govc datastore.disk.inflate disks/disk1.vmdk`
+}
+
+func (cmd *inflate) Run(ctx context.Context, f *flag.FlagSet) error {
+	dc, err := cmd.Datacenter()
+	if err != nil {
+		return err
+	}
+
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	m := object.NewVirtualDiskManager(ds.Client())
+	path := ds.Path(f.Arg(0))
+	task, err := m.InflateVirtualDisk(ctx, path, dc)
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("Inflating %s...", path))
+	defer logger.Wait()
+
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/datastore/disk/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/disk/info.go
@@ -1,0 +1,160 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type info struct {
+	*flags.DatastoreFlag
+
+	c bool
+	d bool
+	p bool
+
+	uuid bool
+}
+
+func init() {
+	cli.Register("datastore.disk.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.c, "c", false, "Chain format")
+	f.BoolVar(&cmd.d, "d", false, "Include datastore in output")
+	f.BoolVar(&cmd.p, "p", true, "Include parents")
+	f.BoolVar(&cmd.uuid, "uuid", false, "Include disk UUID")
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *info) Usage() string {
+	return "VMDK"
+}
+
+func (cmd *info) Description() string {
+	return `Query VMDK info on DS.
+
+Examples:
+  govc datastore.disk.info disks/disk1.vmdk`
+}
+
+func fullPath(s string) string {
+	return s
+}
+
+func dsPath(s string) string {
+	var p object.DatastorePath
+
+	if p.FromString(s) {
+		return p.Path
+	}
+
+	return s
+}
+
+var infoPath = dsPath
+
+var queryUUID func(string) string
+
+type infoResult []object.VirtualDiskInfo
+
+func (r infoResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for _, info := range r {
+		fmt.Fprintf(tw, "Name:\t%s\n", infoPath(info.Name))
+		if queryUUID != nil {
+			fmt.Fprintf(tw, "  UUID:\t%s\n", queryUUID(info.Name))
+		}
+		fmt.Fprintf(tw, "  Type:\t%s\n", info.DiskType)
+		fmt.Fprintf(tw, "  Parent:\t%s\n", infoPath(info.Parent))
+	}
+
+	return tw.Flush()
+}
+
+type chainResult []object.VirtualDiskInfo
+
+func (r chainResult) Write(w io.Writer) error {
+	for i, info := range r {
+		fmt.Fprint(w, strings.Repeat(" ", i*2))
+		fmt.Fprintln(w, infoPath(info.Name))
+	}
+
+	return nil
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	dc, err := cmd.Datacenter()
+	if err != nil {
+		return err
+	}
+
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	m := object.NewVirtualDiskManager(ds.Client())
+
+	if cmd.uuid {
+		queryUUID = func(name string) string {
+			id, _ := m.QueryVirtualDiskUuid(ctx, name, dc)
+			return id
+		}
+	}
+
+	info, err := m.QueryVirtualDiskInfo(ctx, ds.Path(f.Arg(0)), dc, cmd.p)
+	if err != nil {
+		return err
+	}
+
+	if cmd.d {
+		infoPath = fullPath
+	}
+
+	var r flags.OutputWriter = infoResult(info)
+
+	if cmd.c {
+		r = chainResult(info)
+	}
+
+	return cmd.WriteResult(r)
+}

--- a/vendor/github.com/vmware/govmomi/govc/datastore/disk/shrink.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/disk/shrink.go
@@ -1,0 +1,84 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type shrink struct {
+	*flags.DatastoreFlag
+
+	copy *bool
+}
+
+func init() {
+	cli.Register("datastore.disk.shrink", &shrink{})
+}
+
+func (cmd *shrink) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	f.Var(flags.NewOptionalBool(&cmd.copy), "copy", "Perform shrink in-place mode if false, copy-shrink mode otherwise")
+}
+
+func (cmd *shrink) Process(ctx context.Context) error {
+	return cmd.DatastoreFlag.Process(ctx)
+}
+
+func (cmd *shrink) Usage() string {
+	return "VMDK"
+}
+
+func (cmd *shrink) Description() string {
+	return `Shrink VMDK on DS.
+
+Examples:
+  govc datastore.disk.shrink disks/disk1.vmdk`
+}
+
+func (cmd *shrink) Run(ctx context.Context, f *flag.FlagSet) error {
+	dc, err := cmd.Datacenter()
+	if err != nil {
+		return err
+	}
+
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	m := object.NewVirtualDiskManager(ds.Client())
+	path := ds.Path(f.Arg(0))
+	task, err := m.ShrinkVirtualDisk(ctx, path, dc, cmd.copy)
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("Shrinking %s...", path))
+	defer logger.Wait()
+
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/datastore/download.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/download.go
@@ -1,0 +1,117 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastore
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+type download struct {
+	*flags.DatastoreFlag
+	*flags.HostSystemFlag
+}
+
+func init() {
+	cli.Register("datastore.download", &download{})
+}
+
+func (cmd *download) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+}
+
+func (cmd *download) Process(ctx context.Context) error {
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *download) Usage() string {
+	return "SOURCE DEST"
+}
+
+func (cmd *download) Description() string {
+	return `Copy SOURCE from DS to DEST on the local system.
+
+If DEST name is "-", source is written to stdout.
+
+Examples:
+  govc datastore.download vm-name/vmware.log ./local.log
+  govc datastore.download vm-name/vmware.log - | grep -i error`
+}
+
+func (cmd *download) Run(ctx context.Context, f *flag.FlagSet) error {
+	args := f.Args()
+	if len(args) != 2 {
+		return errors.New("invalid arguments")
+	}
+
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	h, err := cmd.HostSystemIfSpecified()
+	if err != nil {
+		return err
+	}
+
+	var via string
+
+	if h != nil {
+		via = fmt.Sprintf(" via %s", h.InventoryPath)
+		ctx = ds.HostContext(ctx, h)
+	}
+
+	p := soap.DefaultDownload
+
+	src := args[0]
+	dst := args[1]
+
+	if dst == "-" {
+		f, _, err := ds.Download(ctx, src, &p)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(os.Stdout, f)
+		return err
+	}
+
+	if cmd.DatastoreFlag.OutputFlag.TTY {
+		logger := cmd.DatastoreFlag.ProgressLogger(fmt.Sprintf("Downloading%s... ", via))
+		p.Progress = logger
+		defer logger.Wait()
+	}
+
+	return ds.DownloadFile(ctx, src, dst, &p)
+}

--- a/vendor/github.com/vmware/govmomi/govc/datastore/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/info.go
@@ -1,0 +1,213 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastore
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+	*flags.DatacenterFlag
+
+	host bool
+}
+
+func init() {
+	cli.Register("datastore.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.host, "H", false, "Display info for Datastores shared between hosts")
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *info) Usage() string {
+	return "[PATH]..."
+}
+
+func (cmd *info) Description() string {
+	return `Display info for Datastores.
+
+Examples:
+  govc datastore.info
+  govc datastore.info vsanDatastore
+  # info on Datastores shared between cluster hosts:
+  govc object.collect -s -d " " /dc1/host/k8s-cluster host | xargs govc datastore.info -H
+  # info on Datastores shared between VM hosts:
+  govc ls /dc1/vm/*k8s* | xargs -n1 -I% govc object.collect -s % summary.runtime.host | xargs govc datastore.info -H`
+}
+
+func intersect(common []types.ManagedObjectReference, refs []types.ManagedObjectReference) []types.ManagedObjectReference {
+	var shared []types.ManagedObjectReference
+	for i := range common {
+		for j := range refs {
+			if common[i] == refs[j] {
+				shared = append(shared, common[i])
+				break
+			}
+		}
+	}
+	return shared
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+	pc := property.DefaultCollector(c)
+
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	args := f.Args()
+	if len(args) == 0 {
+		args = []string{"*"}
+	}
+
+	var res infoResult
+	var props []string
+
+	if cmd.OutputFlag.All() {
+		props = nil // Load everything
+	} else {
+		props = []string{"info", "summary"} // Load summary
+	}
+
+	if cmd.host {
+		if f.NArg() == 0 {
+			return flag.ErrHelp
+		}
+		refs, err := cmd.ManagedObjects(ctx, args)
+		if err != nil {
+			return err
+		}
+
+		var hosts []mo.HostSystem
+		err = pc.Retrieve(ctx, refs, []string{"name", "datastore"}, &hosts)
+		if err != nil {
+			return err
+		}
+
+		refs = hosts[0].Datastore
+		for _, host := range hosts[1:] {
+			refs = intersect(refs, host.Datastore)
+			if len(refs) == 0 {
+				return fmt.Errorf("host %s (%s) has no shared datastores", host.Name, host.Reference())
+			}
+		}
+		for i := range refs {
+			ds, err := finder.ObjectReference(ctx, refs[i])
+			if err != nil {
+				return err
+			}
+			res.objects = append(res.objects, ds.(*object.Datastore))
+		}
+	} else {
+		for _, arg := range args {
+			objects, err := finder.DatastoreList(ctx, arg)
+			if err != nil {
+				return err
+			}
+			res.objects = append(res.objects, objects...)
+		}
+	}
+
+	if len(res.objects) != 0 {
+		refs := make([]types.ManagedObjectReference, 0, len(res.objects))
+		for _, o := range res.objects {
+			refs = append(refs, o.Reference())
+		}
+
+		err = pc.Retrieve(ctx, refs, props, &res.Datastores)
+		if err != nil {
+			return err
+		}
+	}
+
+	return cmd.WriteResult(&res)
+}
+
+type infoResult struct {
+	Datastores []mo.Datastore
+	objects    []*object.Datastore
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	// Maintain order via r.objects as Property collector does not always return results in order.
+	objects := make(map[types.ManagedObjectReference]mo.Datastore, len(r.Datastores))
+	for _, o := range r.Datastores {
+		objects[o.Reference()] = o
+	}
+
+	tw := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
+
+	for _, o := range r.objects {
+		ds := objects[o.Reference()]
+		s := ds.Summary
+		fmt.Fprintf(tw, "Name:\t%s\n", s.Name)
+		fmt.Fprintf(tw, "  Path:\t%s\n", o.InventoryPath)
+		fmt.Fprintf(tw, "  Type:\t%s\n", s.Type)
+		fmt.Fprintf(tw, "  URL:\t%s\n", s.Url)
+		fmt.Fprintf(tw, "  Capacity:\t%.1f GB\n", float64(s.Capacity)/(1<<30))
+		fmt.Fprintf(tw, "  Free:\t%.1f GB\n", float64(s.FreeSpace)/(1<<30))
+
+		switch info := ds.Info.(type) {
+		case *types.NasDatastoreInfo:
+			fmt.Fprintf(tw, "  Remote:\t%s:%s\n", info.Nas.RemoteHost, info.Nas.RemotePath)
+		}
+	}
+
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/datastore/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/ls.go
@@ -1,0 +1,280 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastore
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/units"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ls struct {
+	*flags.DatastoreFlag
+	*flags.OutputFlag
+
+	long    bool
+	slash   bool
+	all     bool
+	recurse bool
+}
+
+func init() {
+	cli.Register("datastore.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.long, "l", false, "Long listing format")
+	f.BoolVar(&cmd.slash, "p", false, "Append / indicator to directories")
+	f.BoolVar(&cmd.all, "a", false, "Do not ignore entries starting with .")
+	f.BoolVar(&cmd.recurse, "R", false, "List subdirectories recursively")
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ls) Usage() string {
+	return "[FILE]..."
+}
+
+func isInvalid(err error) bool {
+	if f, ok := err.(types.HasFault); ok {
+		switch f.Fault().(type) {
+		case *types.InvalidArgument:
+			return true
+		}
+	}
+
+	return false
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	args := cmd.Args(f.Args())
+
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	b, err := ds.Browser(ctx)
+	if err != nil {
+		return err
+	}
+
+	if len(args) == 0 {
+		args = append(args, object.DatastorePath{})
+	}
+
+	result := &listOutput{
+		rs:  make([]types.HostDatastoreBrowserSearchResults, 0),
+		cmd: cmd,
+	}
+
+	for _, p := range args {
+		arg := p.Path
+
+		spec := types.HostDatastoreBrowserSearchSpec{
+			MatchPattern: []string{"*"},
+		}
+
+		if cmd.long {
+			spec.Details = &types.FileQueryFlags{
+				FileType:     true,
+				FileSize:     true,
+				FileOwner:    types.NewBool(true), // TODO: omitempty is generated, but seems to be required
+				Modification: true,
+			}
+		}
+
+		for i := 0; ; i++ {
+			r, err := cmd.ListPath(b, arg, spec)
+			if err != nil {
+				// Treat the argument as a match pattern if not found as directory
+				if i == 0 && types.IsFileNotFound(err) || isInvalid(err) {
+					spec.MatchPattern[0] = path.Base(arg)
+					arg = path.Dir(arg)
+					continue
+				}
+
+				return err
+			}
+
+			// Treat an empty result against match pattern as file not found
+			if i == 1 && len(r) == 1 && len(r[0].File) == 0 {
+				return fmt.Errorf("file %s/%s was not found", r[0].FolderPath, spec.MatchPattern[0])
+			}
+
+			for n := range r {
+				result.add(r[n])
+			}
+
+			break
+		}
+	}
+
+	return cmd.WriteResult(result)
+}
+
+func (cmd *ls) ListPath(b *object.HostDatastoreBrowser, path string, spec types.HostDatastoreBrowserSearchSpec) ([]types.HostDatastoreBrowserSearchResults, error) {
+	ctx := context.TODO()
+
+	path, err := cmd.DatastorePath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	search := b.SearchDatastore
+	if cmd.recurse {
+		search = b.SearchDatastoreSubFolders
+	}
+
+	task, err := search(ctx, path, &spec)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := task.WaitForResult(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	switch r := info.Result.(type) {
+	case types.HostDatastoreBrowserSearchResults:
+		return []types.HostDatastoreBrowserSearchResults{r}, nil
+	case types.ArrayOfHostDatastoreBrowserSearchResults:
+		return r.HostDatastoreBrowserSearchResults, nil
+	default:
+		panic(fmt.Sprintf("unknown result type: %T", r))
+	}
+}
+
+type listOutput struct {
+	rs  []types.HostDatastoreBrowserSearchResults
+	cmd *ls
+}
+
+func (o *listOutput) add(r types.HostDatastoreBrowserSearchResults) {
+	if o.cmd.recurse && !o.cmd.all {
+		// filter out ".hidden" directories
+		path := strings.SplitN(r.FolderPath, " ", 2)
+		if len(path) == 2 {
+			path = strings.Split(path[1], "/")
+			if path[0] == "." {
+				path = path[1:]
+			}
+
+			for _, p := range path {
+				if p != "" && p[0] == '.' {
+					return
+				}
+			}
+		}
+	}
+
+	res := r
+	res.File = nil
+
+	for _, f := range r.File {
+		if f.GetFileInfo().Path[0] == '.' && !o.cmd.all {
+			continue
+		}
+
+		if o.cmd.slash {
+			if d, ok := f.(*types.FolderFileInfo); ok {
+				d.Path += "/"
+			}
+		}
+
+		res.File = append(res.File, f)
+	}
+
+	o.rs = append(o.rs, res)
+}
+
+// hasMultiplePaths returns whether or not the slice of search results contains
+// results from more than one folder path.
+func (o *listOutput) hasMultiplePaths() bool {
+	if len(o.rs) == 0 {
+		return false
+	}
+
+	p := o.rs[0].FolderPath
+
+	// Multiple paths if any entry is not equal to the first one.
+	for _, e := range o.rs {
+		if e.FolderPath != p {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (o *listOutput) MarshalJSON() ([]byte, error) {
+	return json.Marshal(o.rs)
+}
+
+func (o *listOutput) Write(w io.Writer) error {
+	// Only include path header if we're dealing with more than one path.
+	includeHeader := false
+	if o.hasMultiplePaths() {
+		includeHeader = true
+	}
+
+	tw := tabwriter.NewWriter(w, 3, 0, 2, ' ', 0)
+	for i, r := range o.rs {
+		if includeHeader {
+			if i > 0 {
+				fmt.Fprintf(tw, "\n")
+			}
+			fmt.Fprintf(tw, "%s:\n", r.FolderPath)
+		}
+		for _, file := range r.File {
+			info := file.GetFileInfo()
+			if o.cmd.long {
+				fmt.Fprintf(tw, "%s\t%s\t%s\n", units.ByteSize(info.FileSize), info.Modification.Format("Mon Jan 2 15:04:05 2006"), info.Path)
+			} else {
+				fmt.Fprintf(tw, "%s\n", info.Path)
+			}
+		}
+	}
+	tw.Flush()
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/datastore/maintenance/enter.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/maintenance/enter.go
@@ -1,0 +1,82 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maintenance
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type enter struct {
+	*flags.DatastoreFlag
+}
+
+func init() {
+	cli.Register("datastore.maintenance.enter", &enter{})
+}
+
+func (cmd *enter) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+}
+
+func (cmd *enter) Usage() string {
+	return "DATASTORE"
+}
+
+func (cmd *enter) Description() string {
+	return `Put DATASTORE in maintenance mode.
+
+Examples:
+  govc datastore.cluster.change -drs-mode automated my-datastore-cluster # automatically schedule Storage DRS migration
+  govc datastore.maintenance.enter -ds my-datastore-cluster/datastore1
+  # no virtual machines can be powered on and no provisioning operations can be performed on the datastore during this time
+  govc datastore.maintenance.exit -ds my-datastore-cluster/datastore1`
+}
+
+func (cmd *enter) EnterMaintenanceMode(ctx context.Context, ds *object.Datastore) error {
+	req := &types.DatastoreEnterMaintenanceMode{
+		This: ds.Reference(),
+	}
+	res, err := methods.DatastoreEnterMaintenanceMode(ctx, ds.Client(), req)
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("%s entering maintenance mode... ", ds.InventoryPath))
+	defer logger.Wait()
+
+	task := object.NewTask(ds.Client(), *res.Returnval.Task)
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}
+
+func (cmd *enter) Run(ctx context.Context, f *flag.FlagSet) error {
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	return cmd.EnterMaintenanceMode(ctx, ds)
+}

--- a/vendor/github.com/vmware/govmomi/govc/datastore/maintenance/exit.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/maintenance/exit.go
@@ -1,0 +1,77 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maintenance
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type exit struct {
+	*flags.DatastoreFlag
+}
+
+func init() {
+	cli.Register("datastore.maintenance.exit", &exit{})
+}
+
+func (cmd *exit) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+}
+
+func (cmd *exit) Usage() string {
+	return "DATASTORE"
+}
+
+func (cmd *exit) Description() string {
+	return `Take DATASTORE out of maintenance mode.`
+}
+
+func (cmd *exit) ExitMaintenanceMode(ctx context.Context, ds *object.Datastore) error {
+	req := &types.DatastoreExitMaintenanceMode_Task{
+		This: ds.Reference(),
+	}
+	res, err := methods.DatastoreExitMaintenanceMode_Task(ctx, ds.Client(), req)
+	if err != nil {
+		return err
+	}
+
+	task := object.NewTask(ds.Client(), res.Returnval)
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("%s exiting maintenance mode... ", ds.InventoryPath))
+	defer logger.Wait()
+
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}
+
+func (cmd *exit) Run(ctx context.Context, f *flag.FlagSet) error {
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	return cmd.ExitMaintenanceMode(ctx, ds)
+}

--- a/vendor/github.com/vmware/govmomi/govc/datastore/mkdir.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/mkdir.go
@@ -1,0 +1,118 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastore
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type mkdir struct {
+	*flags.DatastoreFlag
+
+	createParents bool
+	isNamespace   bool
+}
+
+func init() {
+	cli.Register("datastore.mkdir", &mkdir{})
+}
+
+func (cmd *mkdir) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.createParents, "p", false, "Create intermediate directories as needed")
+	f.BoolVar(&cmd.isNamespace, "namespace", false, "Return uuid of namespace created on vsan datastore")
+}
+
+func (cmd *mkdir) Process(ctx context.Context) error {
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *mkdir) Usage() string {
+	return "DIRECTORY"
+}
+
+func (cmd *mkdir) Run(ctx context.Context, f *flag.FlagSet) error {
+	args := f.Args()
+	if len(args) == 0 {
+		return errors.New("missing operand")
+	}
+
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	if cmd.isNamespace {
+		var uuid string
+		var ds *object.Datastore
+
+		if ds, err = cmd.Datastore(); err != nil {
+			return err
+		}
+
+		path := args[0]
+
+		nm := object.NewDatastoreNamespaceManager(c)
+		if uuid, err = nm.CreateDirectory(ctx, ds, path, ""); err != nil {
+			return err
+		}
+
+		fmt.Println(uuid)
+	} else {
+		var dc *object.Datacenter
+		var path string
+
+		dc, err = cmd.Datacenter()
+		if err != nil {
+			return err
+		}
+
+		path, err = cmd.DatastorePath(args[0])
+		if err != nil {
+			return err
+		}
+
+		m := object.NewFileManager(c)
+		err = m.MakeDirectory(ctx, path, dc, cmd.createParents)
+
+		// ignore EEXIST if -p flag is given
+		if err != nil && cmd.createParents {
+			if soap.IsSoapFault(err) {
+				soapFault := soap.ToSoapFault(err)
+				if _, ok := soapFault.VimFault().(types.FileAlreadyExists); ok {
+					return nil
+				}
+			}
+		}
+	}
+
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/datastore/mv.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/mv.go
@@ -1,0 +1,77 @@
+/*
+Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastore
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+)
+
+type mv struct {
+	target
+}
+
+func init() {
+	cli.Register("datastore.mv", &mv{})
+}
+
+func (cmd *mv) Usage() string {
+	return "SRC DST"
+}
+
+func (cmd *mv) Description() string {
+	return `Move SRC to DST on DATASTORE.
+
+Examples:
+  govc datastore.mv foo/foo.vmx foo/foo.vmx.old
+  govc datastore.mv -f my.vmx foo/foo.vmx`
+}
+
+func (cmd *mv) Run(ctx context.Context, f *flag.FlagSet) error {
+	args := f.Args()
+	if len(args) != 2 {
+		return flag.ErrHelp
+	}
+
+	m, err := cmd.FileManager()
+	if err != nil {
+		return err
+	}
+
+	src, err := cmd.DatastorePath(args[0])
+	if err != nil {
+		return err
+	}
+
+	dst, err := cmd.target.ds.DatastorePath(args[1])
+	if err != nil {
+		return err
+	}
+
+	mv := m.MoveFile
+	if cmd.kind {
+		mv = m.Move
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("Moving %s to %s...", src, dst))
+	defer logger.Wait()
+
+	return mv(m.WithProgress(ctx, logger), src, dst)
+}

--- a/vendor/github.com/vmware/govmomi/govc/datastore/remove.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/remove.go
@@ -1,0 +1,90 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastore
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type remove struct {
+	*flags.HostSystemFlag
+	*flags.DatastoreFlag
+}
+
+func init() {
+	cli.Register("datastore.remove", &remove{})
+}
+
+func (cmd *remove) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+}
+
+func (cmd *remove) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *remove) Usage() string {
+	return "HOST..."
+}
+
+func (cmd *remove) Description() string {
+	return `Remove datastore from HOST.
+
+Examples:
+  govc datastore.remove -ds nfsDatastore cluster1
+  govc datastore.remove -ds nasDatastore host1 host2 host3`
+}
+
+func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	hosts, err := cmd.HostSystems(f.Args())
+	if err != nil {
+		return err
+	}
+
+	for _, host := range hosts {
+		hds, err := host.ConfigManager().DatastoreSystem(ctx)
+		if err != nil {
+			return err
+		}
+
+		err = hds.Remove(ctx, ds)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/datastore/rm.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/rm.go
@@ -1,0 +1,117 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastore
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type rm struct {
+	*flags.DatastoreFlag
+
+	kind        bool
+	force       bool
+	isNamespace bool
+}
+
+func init() {
+	cli.Register("datastore.rm", &rm{})
+	cli.Alias("datastore.rm", "datastore.delete")
+}
+
+func (cmd *rm) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.kind, "t", true, "Use file type to choose disk or file manager")
+	f.BoolVar(&cmd.force, "f", false, "Force; ignore nonexistent files and arguments")
+	f.BoolVar(&cmd.isNamespace, "namespace", false, "Path is uuid of namespace on vsan datastore")
+}
+
+func (cmd *rm) Process(ctx context.Context) error {
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *rm) Usage() string {
+	return "FILE"
+}
+
+func (cmd *rm) Description() string {
+	return `Remove FILE from DATASTORE.
+
+Examples:
+  govc datastore.rm vm/vmware.log
+  govc datastore.rm vm
+  govc datastore.rm -f images/base.vmdk`
+}
+
+func (cmd *rm) Run(ctx context.Context, f *flag.FlagSet) error {
+	args := f.Args()
+	if len(args) == 0 {
+		return flag.ErrHelp
+	}
+
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	var dc *object.Datacenter
+	dc, err = cmd.Datacenter()
+	if err != nil {
+		return err
+	}
+
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	if cmd.isNamespace {
+		path := args[0]
+
+		nm := object.NewDatastoreNamespaceManager(c)
+		err = nm.DeleteDirectory(ctx, dc, path)
+	} else {
+		fm := ds.NewFileManager(dc, cmd.force)
+
+		remove := fm.DeleteFile // File delete
+		if cmd.kind {
+			remove = fm.Delete // VirtualDisk or File delete
+		}
+
+		err = remove(ctx, args[0])
+	}
+
+	if err != nil {
+		if types.IsFileNotFound(err) && cmd.force {
+			// Ignore error
+			return nil
+		}
+	}
+
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/datastore/tail.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/tail.go
@@ -1,0 +1,137 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastore
+
+import (
+	"context"
+	"flag"
+	"io"
+	"os"
+	"time"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type tail struct {
+	*flags.DatastoreFlag
+	*flags.HostSystemFlag
+
+	count  int64
+	lines  int
+	follow bool
+}
+
+func init() {
+	cli.Register("datastore.tail", &tail{})
+}
+
+func (cmd *tail) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	f.Int64Var(&cmd.count, "c", -1, "Output the last NUM bytes")
+	f.IntVar(&cmd.lines, "n", 10, "Output the last NUM lines")
+	f.BoolVar(&cmd.follow, "f", false, "Output appended data as the file grows")
+}
+
+func (cmd *tail) Description() string {
+	return `Output the last part of datastore files.
+
+Examples:
+  govc datastore.tail -n 100 vm-name/vmware.log
+  govc datastore.tail -n 0 -f vm-name/vmware.log`
+}
+
+func (cmd *tail) Process(ctx context.Context) error {
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *tail) Usage() string {
+	return "PATH"
+}
+
+func (cmd *tail) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	p := cmd.Args(f.Args())[0]
+
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	h, err := cmd.HostSystemIfSpecified()
+	if err != nil {
+		return err
+	}
+
+	if h != nil {
+		ctx = ds.HostContext(ctx, h)
+	}
+
+	file, err := ds.Open(ctx, p.Path)
+	if err != nil {
+		return err
+	}
+
+	var reader io.ReadCloser = file
+
+	var offset int64
+
+	if cmd.count >= 0 {
+		info, serr := file.Stat()
+		if serr != nil {
+			return serr
+		}
+
+		if info.Size() > cmd.count {
+			offset = info.Size() - cmd.count
+
+			_, err = file.Seek(offset, io.SeekStart)
+			if err != nil {
+				return err
+			}
+		}
+	} else if cmd.lines >= 0 {
+		err = file.Tail(cmd.lines)
+		if err != nil {
+			return err
+		}
+	}
+
+	if cmd.follow {
+		reader = file.Follow(time.Second)
+	}
+
+	_, err = io.Copy(os.Stdout, reader)
+
+	_ = reader.Close()
+
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/datastore/upload.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/upload.go
@@ -1,0 +1,98 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastore
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"os"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+type upload struct {
+	*flags.OutputFlag
+	*flags.DatastoreFlag
+}
+
+func init() {
+	cli.Register("datastore.upload", &upload{})
+}
+
+func (cmd *upload) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+}
+
+func (cmd *upload) Process(ctx context.Context) error {
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *upload) Usage() string {
+	return "SOURCE DEST"
+}
+
+func (cmd *upload) Description() string {
+	return `Copy SOURCE from the local system to DEST on DS.
+
+If SOURCE name is "-", read source from stdin.
+
+Examples:
+  govc datastore.upload -ds datastore1 ./config.iso vm-name/config.iso
+  genisoimage ... | govc datastore.upload -ds datastore1 - vm-name/config.iso`
+}
+
+func (cmd *upload) Run(ctx context.Context, f *flag.FlagSet) error {
+	args := f.Args()
+	if len(args) != 2 {
+		return errors.New("invalid arguments")
+	}
+
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	p := soap.DefaultUpload
+
+	src := args[0]
+	dst := args[1]
+
+	if src == "-" {
+		return ds.Upload(ctx, os.Stdin, dst, &p)
+	}
+
+	if cmd.OutputFlag.TTY {
+		logger := cmd.ProgressLogger("Uploading... ")
+		p.Progress = logger
+		defer logger.Wait()
+	}
+
+	return ds.UploadFile(ctx, src, dst, &p)
+}

--- a/vendor/github.com/vmware/govmomi/govc/datastore/vsan/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/vsan/ls.go
@@ -1,0 +1,156 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsan
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/url"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+type ls struct {
+	*flags.DatastoreFlag
+
+	long   bool
+	orphan bool
+}
+
+func init() {
+	cli.Register("datastore.vsan.dom.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.long, "l", false, "Long listing")
+	f.BoolVar(&cmd.orphan, "o", false, "List orphan objects")
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ls) Usage() string {
+	return "[UUID]..."
+}
+
+func (cmd *ls) Description() string {
+	return `List vSAN DOM objects in DS.
+
+Examples:
+  govc datastore.vsan.dom.ls
+  govc datastore.vsan.dom.ls -ds vsanDatastore -l
+  govc datastore.vsan.dom.ls -l d85aa758-63f5-500a-3150-0200308e589c`
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	var mds mo.Datastore
+	err = ds.Properties(ctx, ds.Reference(), []string{"summary"}, &mds)
+	if err != nil {
+		return err
+	}
+
+	if mds.Summary.Type != "vsan" {
+		return flag.ErrHelp
+	}
+
+	hosts, err := ds.AttachedHosts(ctx)
+	if err != nil {
+		return err
+	}
+
+	if len(hosts) == 0 {
+		return flag.ErrHelp
+	}
+
+	m, err := hosts[0].ConfigManager().VsanInternalSystem(ctx)
+	if err != nil {
+		return err
+	}
+
+	ids, err := m.QueryVsanObjectUuidsByFilter(ctx, f.Args(), 0, 0)
+	if err != nil {
+		return err
+	}
+
+	if len(ids) == 0 {
+		return nil
+	}
+
+	if !cmd.long && !cmd.orphan {
+		for _, id := range ids {
+			fmt.Fprintln(cmd.Out, id)
+		}
+
+		return nil
+	}
+
+	objs, err := m.GetVsanObjExtAttrs(ctx, ids)
+	if err != nil {
+		return err
+	}
+
+	u, err := url.Parse(mds.Summary.Url)
+	if err != nil {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(cmd.Out, 2, 0, 2, ' ', 0)
+	cmd.Out = tw
+
+	for id, obj := range objs {
+		path := obj.DatastorePath(u.Path)
+
+		if cmd.orphan {
+			_, err = ds.Stat(ctx, path)
+			if err == nil {
+				continue
+			}
+
+			switch err.(type) {
+			case object.DatastoreNoSuchDirectoryError, object.DatastoreNoSuchFileError:
+			default:
+				return err
+			}
+
+			if !cmd.long {
+				fmt.Fprintln(cmd.Out, id)
+				continue
+			}
+		}
+
+		fmt.Fprintf(cmd.Out, "%s\t%s\t%s\n", id, obj.Class, path)
+	}
+
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/datastore/vsan/rm.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/vsan/rm.go
@@ -1,0 +1,108 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsan
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type rm struct {
+	*flags.DatastoreFlag
+
+	force   bool
+	verbose bool
+}
+
+func init() {
+	cli.Register("datastore.vsan.dom.rm", &rm{})
+}
+
+func (cmd *rm) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.force, "f", false, "Force delete")
+	f.BoolVar(&cmd.verbose, "v", false, "Print deleted UUIDs to stdout, failed to stderr")
+}
+
+func (cmd *rm) Process(ctx context.Context) error {
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *rm) Usage() string {
+	return "UUID..."
+}
+
+func (cmd *rm) Description() string {
+	return `Remove vSAN DOM objects in DS.
+
+Examples:
+  govc datastore.vsan.dom.rm d85aa758-63f5-500a-3150-0200308e589c
+  govc datastore.vsan.dom.rm -f d85aa758-63f5-500a-3150-0200308e589c
+  govc datastore.vsan.dom.ls -o | xargs govc datastore.vsan.dom.rm`
+}
+
+func (cmd *rm) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	hosts, err := ds.AttachedHosts(ctx)
+	if err != nil {
+		return err
+	}
+
+	if len(hosts) == 0 {
+		return flag.ErrHelp
+	}
+
+	m, err := hosts[0].ConfigManager().VsanInternalSystem(ctx)
+	if err != nil {
+		return err
+	}
+
+	res, err := m.DeleteVsanObjects(ctx, f.Args(), &cmd.force)
+	if err != nil {
+		return err
+	}
+
+	if cmd.verbose {
+		for _, r := range res {
+			if r.Success {
+				fmt.Fprintln(cmd.Out, r.Uuid)
+			} else {
+				fmt.Fprintf(os.Stderr, "%s %s\n", r.Uuid, r.FailureReason[0].Message)
+			}
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/device/boot.go
+++ b/vendor/github.com/vmware/govmomi/govc/device/boot.go
@@ -1,0 +1,94 @@
+/*
+Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package device
+
+import (
+	"context"
+	"flag"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type boot struct {
+	*flags.VirtualMachineFlag
+
+	order string
+	types.VirtualMachineBootOptions
+}
+
+func init() {
+	cli.Register("device.boot", &boot{})
+}
+
+func (cmd *boot) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.Int64Var(&cmd.BootDelay, "delay", 0, "Delay in ms before starting the boot sequence")
+	f.StringVar(&cmd.order, "order", "", "Boot device order [-,floppy,cdrom,ethernet,disk]")
+	f.Int64Var(&cmd.BootRetryDelay, "retry-delay", 0, "Delay in ms before a boot retry")
+
+	cmd.BootRetryEnabled = types.NewBool(false)
+	f.BoolVar(cmd.BootRetryEnabled, "retry", false, "If true, retry boot after retry-delay")
+
+	cmd.EnterBIOSSetup = types.NewBool(false)
+	f.BoolVar(cmd.EnterBIOSSetup, "setup", false, "If true, enter BIOS setup on next boot")
+
+	f.Var(flags.NewOptionalBool(&cmd.EfiSecureBootEnabled), "secure", "Enable EFI secure boot")
+}
+
+func (cmd *boot) Description() string {
+	return `Configure VM boot settings.
+
+Examples:
+  govc device.boot -vm $vm -delay 1000 -order floppy,cdrom,ethernet,disk
+  govc device.boot -vm $vm -order - # reset boot order
+  govc device.boot -vm $vm -secure`
+}
+
+func (cmd *boot) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *boot) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	if cmd.order != "" {
+		o := strings.Split(cmd.order, ",")
+		cmd.BootOrder = devices.BootOrder(o)
+	}
+
+	return vm.SetBootOptions(ctx, &cmd.VirtualMachineBootOptions)
+}

--- a/vendor/github.com/vmware/govmomi/govc/device/cdrom/add.go
+++ b/vendor/github.com/vmware/govmomi/govc/device/cdrom/add.go
@@ -1,0 +1,105 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cdrom
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type add struct {
+	*flags.VirtualMachineFlag
+
+	controller string
+}
+
+func init() {
+	cli.Register("device.cdrom.add", &add{})
+}
+
+func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.controller, "controller", "", "IDE controller name")
+}
+
+func (cmd *add) Description() string {
+	return `Add CD-ROM device to VM.
+
+Examples:
+  govc device.cdrom.add -vm $vm
+  govc device.ls -vm $vm | grep ide-
+  govc device.cdrom.add -vm $vm -controller ide-200
+  govc device.info cdrom-*`
+}
+
+func (cmd *add) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	c, err := devices.FindIDEController(cmd.controller)
+	if err != nil {
+		return err
+	}
+
+	d, err := devices.CreateCdrom(c)
+	if err != nil {
+		return err
+	}
+
+	err = vm.AddDevice(ctx, d)
+	if err != nil {
+		return err
+	}
+
+	// output name of device we just created
+	devices, err = vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	devices = devices.SelectByType(d)
+
+	name := devices.Name(devices[len(devices)-1])
+
+	fmt.Println(name)
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/device/cdrom/eject.go
+++ b/vendor/github.com/vmware/govmomi/govc/device/cdrom/eject.go
@@ -1,0 +1,82 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cdrom
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type eject struct {
+	*flags.VirtualMachineFlag
+
+	device string
+}
+
+func init() {
+	cli.Register("device.cdrom.eject", &eject{})
+}
+
+func (cmd *eject) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.device, "device", "", "CD-ROM device name")
+}
+
+func (cmd *eject) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *eject) Description() string {
+	return `Eject media from CD-ROM device.
+
+If device is not specified, the first CD-ROM device is used.
+
+Examples:
+  govc device.cdrom.eject -vm vm-1
+  govc device.cdrom.eject -vm vm-1 -device floppy-1`
+}
+
+func (cmd *eject) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	c, err := devices.FindCdrom(cmd.device)
+	if err != nil {
+		return err
+	}
+
+	return vm.EditDevice(ctx, devices.EjectIso(c))
+}

--- a/vendor/github.com/vmware/govmomi/govc/device/cdrom/insert.go
+++ b/vendor/github.com/vmware/govmomi/govc/device/cdrom/insert.go
@@ -1,0 +1,96 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cdrom
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type insert struct {
+	*flags.DatastoreFlag
+	*flags.VirtualMachineFlag
+
+	device string
+}
+
+func init() {
+	cli.Register("device.cdrom.insert", &insert{})
+}
+
+func (cmd *insert) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.device, "device", "", "CD-ROM device name")
+}
+
+func (cmd *insert) Process(ctx context.Context) error {
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *insert) Usage() string {
+	return "ISO"
+}
+
+func (cmd *insert) Description() string {
+	return `Insert media on datastore into CD-ROM device.
+
+If device is not specified, the first CD-ROM device is used.
+
+Examples:
+  govc device.cdrom.insert -vm vm-1 -device cdrom-3000 images/boot.iso`
+}
+
+func (cmd *insert) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil || f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	c, err := devices.FindCdrom(cmd.device)
+	if err != nil {
+		return err
+	}
+
+	iso, err := cmd.DatastorePath(f.Arg(0))
+	if err != nil {
+		return err
+	}
+
+	return vm.EditDevice(ctx, devices.InsertIso(c, iso))
+}

--- a/vendor/github.com/vmware/govmomi/govc/device/connect.go
+++ b/vendor/github.com/vmware/govmomi/govc/device/connect.go
@@ -1,0 +1,90 @@
+/*
+Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package device
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type connect struct {
+	*flags.VirtualMachineFlag
+}
+
+func init() {
+	cli.Register("device.connect", &connect{})
+}
+
+func (cmd *connect) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+}
+
+func (cmd *connect) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *connect) Usage() string {
+	return "DEVICE..."
+}
+
+func (cmd *connect) Description() string {
+	return `Connect DEVICE on VM.
+
+Examples:
+  govc device.connect -vm $name cdrom-3000`
+}
+
+func (cmd *connect) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, name := range f.Args() {
+		device := devices.Find(name)
+		if device == nil {
+			return fmt.Errorf("device '%s' not found", name)
+		}
+
+		if err = devices.Connect(device); err != nil {
+			return err
+		}
+
+		if err = vm.EditDevice(ctx, device); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/device/disconnect.go
+++ b/vendor/github.com/vmware/govmomi/govc/device/disconnect.go
@@ -1,0 +1,90 @@
+/*
+Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package device
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type disconnect struct {
+	*flags.VirtualMachineFlag
+}
+
+func init() {
+	cli.Register("device.disconnect", &disconnect{})
+}
+
+func (cmd *disconnect) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+}
+
+func (cmd *disconnect) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *disconnect) Usage() string {
+	return "DEVICE..."
+}
+
+func (cmd *disconnect) Description() string {
+	return `Disconnect DEVICE on VM.
+
+Examples:
+  govc device.disconnect -vm $name cdrom-3000`
+}
+
+func (cmd *disconnect) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, name := range f.Args() {
+		device := devices.Find(name)
+		if device == nil {
+			return fmt.Errorf("device '%s' not found", name)
+		}
+
+		if err = devices.Disconnect(device); err != nil {
+			return err
+		}
+
+		if err = vm.EditDevice(ctx, device); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/device/floppy/add.go
+++ b/vendor/github.com/vmware/govmomi/govc/device/floppy/add.go
@@ -1,0 +1,94 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package floppy
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type add struct {
+	*flags.VirtualMachineFlag
+}
+
+func init() {
+	cli.Register("device.floppy.add", &add{})
+}
+
+func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+}
+
+func (cmd *add) Description() string {
+	return `Add floppy device to VM.
+
+Examples:
+  govc device.floppy.add -vm $vm
+  govc device.info floppy-*`
+}
+
+func (cmd *add) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	d, err := devices.CreateFloppy()
+	if err != nil {
+		return err
+	}
+
+	err = vm.AddDevice(ctx, d)
+	if err != nil {
+		return err
+	}
+
+	// output name of device we just created
+	devices, err = vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	devices = devices.SelectByType(d)
+
+	name := devices.Name(devices[len(devices)-1])
+
+	fmt.Println(name)
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/device/floppy/eject.go
+++ b/vendor/github.com/vmware/govmomi/govc/device/floppy/eject.go
@@ -1,0 +1,81 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package floppy
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type eject struct {
+	*flags.VirtualMachineFlag
+
+	device string
+}
+
+func init() {
+	cli.Register("device.floppy.eject", &eject{})
+}
+
+func (cmd *eject) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.device, "device", "", "Floppy device name")
+}
+
+func (cmd *eject) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *eject) Description() string {
+	return `Eject image from floppy device.
+
+If device is not specified, the first floppy device is used.
+
+Examples:
+  govc device.floppy.eject -vm vm-1`
+}
+
+func (cmd *eject) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	c, err := devices.FindFloppy(cmd.device)
+	if err != nil {
+		return err
+	}
+
+	return vm.EditDevice(ctx, devices.EjectImg(c))
+}

--- a/vendor/github.com/vmware/govmomi/govc/device/floppy/insert.go
+++ b/vendor/github.com/vmware/govmomi/govc/device/floppy/insert.go
@@ -1,0 +1,96 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package floppy
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type insert struct {
+	*flags.DatastoreFlag
+	*flags.VirtualMachineFlag
+
+	device string
+}
+
+func init() {
+	cli.Register("device.floppy.insert", &insert{})
+}
+
+func (cmd *insert) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.device, "device", "", "Floppy device name")
+}
+
+func (cmd *insert) Process(ctx context.Context) error {
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *insert) Usage() string {
+	return "IMG"
+}
+
+func (cmd *insert) Description() string {
+	return `Insert IMG on datastore into floppy device.
+
+If device is not specified, the first floppy device is used.
+
+Examples:
+  govc device.floppy.insert -vm vm-1 vm-1/config.img`
+}
+
+func (cmd *insert) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil || f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	c, err := devices.FindFloppy(cmd.device)
+	if err != nil {
+		return err
+	}
+
+	img, err := cmd.DatastorePath(f.Arg(0))
+	if err != nil {
+		return nil
+	}
+
+	return vm.EditDevice(ctx, devices.InsertImg(c, img))
+}

--- a/vendor/github.com/vmware/govmomi/govc/device/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/device/info.go
@@ -1,0 +1,248 @@
+/*
+Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package device
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*flags.VirtualMachineFlag
+	*flags.OutputFlag
+	*flags.NetworkFlag
+}
+
+func init() {
+	cli.Register("device.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	cmd.NetworkFlag, ctx = flags.NewNetworkFlag(ctx)
+	cmd.NetworkFlag.Register(ctx, f)
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.NetworkFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *info) Usage() string {
+	return "[DEVICE]..."
+}
+
+func (cmd *info) Description() string {
+	return `Device info for VM.
+
+Examples:
+  govc device.info -vm $name
+  govc device.info -vm $name disk-*
+  govc device.info -vm $name -json ethernet-0 | jq -r .Devices[].MacAddress`
+}
+
+func match(p string, devices object.VirtualDeviceList) object.VirtualDeviceList {
+	var matches object.VirtualDeviceList
+	match := func(name string) bool {
+		matched, _ := path.Match(p, name)
+		return matched
+	}
+
+	for _, device := range devices {
+		name := devices.Name(device)
+		eq := name == p
+		if eq || match(name) {
+			matches = append(matches, device)
+		}
+		if eq {
+			break
+		}
+	}
+
+	return matches
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	res := infoResult{
+		list: devices,
+	}
+
+	if cmd.NetworkFlag.IsSet() {
+		net, err := cmd.Network()
+		if err != nil {
+			return err
+		}
+
+		backing, err := net.EthernetCardBackingInfo(ctx)
+		if err != nil {
+			return err
+		}
+
+		devices = devices.SelectByBackingInfo(backing)
+	}
+
+	if f.NArg() == 0 {
+		res.Devices = toInfoList(devices)
+	} else {
+		for _, name := range f.Args() {
+			matches := match(name, devices)
+			if len(matches) == 0 {
+				return fmt.Errorf("device '%s' not found", name)
+			}
+
+			res.Devices = append(res.Devices, toInfoList(matches)...)
+		}
+	}
+
+	return cmd.WriteResult(&res)
+}
+
+func toInfoList(devices object.VirtualDeviceList) []infoDevice {
+	var res []infoDevice
+
+	for _, device := range devices {
+		res = append(res, infoDevice{
+			Name:              devices.Name(device),
+			Type:              devices.TypeName(device),
+			BaseVirtualDevice: device,
+		})
+	}
+
+	return res
+}
+
+type infoDevice struct {
+	Name string
+	Type string
+	types.BaseVirtualDevice
+}
+
+func (d *infoDevice) MarshalJSON() ([]byte, error) {
+	b, err := json.Marshal(d.BaseVirtualDevice)
+	if err != nil {
+		return b, err
+	}
+
+	// TODO: make use of "inline" tag if it comes to be: https://github.com/golang/go/issues/6213
+
+	return append([]byte(fmt.Sprintf(`{"Name":"%s","Type":"%s",`, d.Name, d.Type)), b[1:]...), err
+}
+
+type infoResult struct {
+	Devices []infoDevice
+	// need the full list of devices to lookup attached devices and controllers
+	list object.VirtualDeviceList
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for i := range r.Devices {
+		device := r.Devices[i].BaseVirtualDevice
+		d := device.GetVirtualDevice()
+		info := d.DeviceInfo.GetDescription()
+
+		fmt.Fprintf(tw, "Name:\t%s\n", r.Devices[i].Name)
+		fmt.Fprintf(tw, "  Type:\t%s\n", r.list.TypeName(device))
+		fmt.Fprintf(tw, "  Label:\t%s\n", info.Label)
+		fmt.Fprintf(tw, "  Summary:\t%s\n", info.Summary)
+		fmt.Fprintf(tw, "  Key:\t%d\n", d.Key)
+
+		if c, ok := device.(types.BaseVirtualController); ok {
+			var attached []string
+			for _, key := range c.GetVirtualController().Device {
+				attached = append(attached, r.list.Name(r.list.FindByKey(key)))
+			}
+			fmt.Fprintf(tw, "  Devices:\t%s\n", strings.Join(attached, ", "))
+		} else {
+			if c := r.list.FindByKey(d.ControllerKey); c != nil {
+				fmt.Fprintf(tw, "  Controller:\t%s\n", r.list.Name(c))
+				if d.UnitNumber != nil {
+					fmt.Fprintf(tw, "  Unit number:\t%d\n", *d.UnitNumber)
+				} else {
+					fmt.Fprintf(tw, "  Unit number:\t<nil>\n")
+				}
+			}
+		}
+
+		if ca := d.Connectable; ca != nil {
+			fmt.Fprintf(tw, "  Connected:\t%t\n", ca.Connected)
+			fmt.Fprintf(tw, "  Start connected:\t%t\n", ca.StartConnected)
+			fmt.Fprintf(tw, "  Guest control:\t%t\n", ca.AllowGuestControl)
+			fmt.Fprintf(tw, "  Status:\t%s\n", ca.Status)
+		}
+
+		switch md := device.(type) {
+		case types.BaseVirtualEthernetCard:
+			fmt.Fprintf(tw, "  MAC Address:\t%s\n", md.GetVirtualEthernetCard().MacAddress)
+			fmt.Fprintf(tw, "  Address type:\t%s\n", md.GetVirtualEthernetCard().AddressType)
+		case *types.VirtualDisk:
+			if b, ok := md.Backing.(types.BaseVirtualDeviceFileBackingInfo); ok {
+				fmt.Fprintf(tw, "  File:\t%s\n", b.GetVirtualDeviceFileBackingInfo().FileName)
+			}
+			if b, ok := md.Backing.(*types.VirtualDiskFlatVer2BackingInfo); ok && b.Parent != nil {
+				fmt.Fprintf(tw, "  Parent:\t%s\n", b.Parent.GetVirtualDeviceFileBackingInfo().FileName)
+			}
+		case *types.VirtualSerialPort:
+			if b, ok := md.Backing.(*types.VirtualSerialPortURIBackingInfo); ok {
+				fmt.Fprintf(tw, "  Direction:\t%s\n", b.Direction)
+				fmt.Fprintf(tw, "  Service URI:\t%s\n", b.ServiceURI)
+				fmt.Fprintf(tw, "  Proxy URI:\t%s\n", b.ProxyURI)
+			}
+		}
+	}
+
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/device/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/device/ls.go
@@ -1,0 +1,138 @@
+/*
+Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package device
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type ls struct {
+	*flags.VirtualMachineFlag
+
+	boot bool
+}
+
+func init() {
+	cli.Register("device.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.boot, "boot", false, "List devices configured in the VM's boot options")
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ls) Description() string {
+	return `List devices for VM.
+
+Examples:
+  govc device.ls -vm $name
+  govc device.ls -vm $name disk-*
+  govc device.ls -vm $name -json | jq '.Devices[].Name'`
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	if f.NArg() != 0 {
+		var matches object.VirtualDeviceList
+		for _, name := range f.Args() {
+			device := match(name, devices)
+			if len(device) == 0 {
+				return fmt.Errorf("device '%s' not found", name)
+			}
+			matches = append(matches, device...)
+		}
+		devices = matches
+	}
+
+	if cmd.boot {
+		options, err := vm.BootOptions(ctx)
+		if err != nil {
+			return err
+		}
+
+		devices = devices.SelectBootOrder(options.BootOrder)
+	}
+
+	res := lsResult{toLsList(devices), devices}
+	return cmd.WriteResult(&res)
+}
+
+type lsDevice struct {
+	Name    string
+	Type    string
+	Summary string
+}
+
+func toLsList(devices object.VirtualDeviceList) []lsDevice {
+	var res []lsDevice
+
+	for _, device := range devices {
+		res = append(res, lsDevice{
+			Name:    devices.Name(device),
+			Type:    devices.TypeName(device),
+			Summary: device.GetVirtualDevice().DeviceInfo.GetDescription().Summary,
+		})
+	}
+
+	return res
+}
+
+type lsResult struct {
+	Devices []lsDevice
+	list    object.VirtualDeviceList
+}
+
+func (r *lsResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 3, 0, 2, ' ', 0)
+
+	for _, device := range r.list {
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", r.list.Name(device), r.list.TypeName(device),
+			device.GetVirtualDevice().DeviceInfo.GetDescription().Summary)
+	}
+
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/device/remove.go
+++ b/vendor/github.com/vmware/govmomi/govc/device/remove.go
@@ -1,0 +1,90 @@
+/*
+Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package device
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type remove struct {
+	*flags.VirtualMachineFlag
+	keepFiles bool
+}
+
+func init() {
+	cli.Register("device.remove", &remove{})
+}
+
+func (cmd *remove) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+	f.BoolVar(&cmd.keepFiles, "keep", false, "Keep files in datastore")
+}
+
+func (cmd *remove) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *remove) Usage() string {
+	return "DEVICE..."
+}
+
+func (cmd *remove) Description() string {
+	return `Remove DEVICE from VM.
+
+Examples:
+  govc device.remove -vm $name cdrom-3000
+  govc device.remove -vm $name disk-1000
+  govc device.remove -vm $name -keep disk-*`
+}
+
+func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, name := range f.Args() {
+		device := match(name, devices)
+		if len(device) == 0 {
+			return fmt.Errorf("device '%s' not found", name)
+		}
+
+		if err = vm.RemoveDevice(ctx, cmd.keepFiles, device...); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/device/scsi/add.go
+++ b/vendor/github.com/vmware/govmomi/govc/device/scsi/add.go
@@ -1,0 +1,116 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scsi
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type add struct {
+	*flags.VirtualMachineFlag
+
+	controller   string
+	sharedBus    string
+	hotAddRemove bool
+}
+
+func init() {
+	cli.Register("device.scsi.add", &add{})
+}
+
+func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	var ctypes []string
+	ct := object.SCSIControllerTypes()
+	for _, t := range ct {
+		ctypes = append(ctypes, ct.Type(t))
+	}
+	f.StringVar(&cmd.controller, "type", ct.Type(ct[0]),
+		fmt.Sprintf("SCSI controller type (%s)", strings.Join(ctypes, "|")))
+	f.StringVar(&cmd.sharedBus, "sharing", string(types.VirtualSCSISharingNoSharing), "SCSI sharing")
+	f.BoolVar(&cmd.hotAddRemove, "hot", false, "Enable hot-add/remove")
+}
+
+func (cmd *add) Description() string {
+	return `Add SCSI controller to VM.
+
+Examples:
+  govc device.scsi.add -vm $vm
+  govc device.scsi.add -vm $vm -type pvscsi
+  govc device.info -vm $vm {lsi,pv}*`
+}
+
+func (cmd *add) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	d, err := devices.CreateSCSIController(cmd.controller)
+	if err != nil {
+		return err
+	}
+
+	c := d.(types.BaseVirtualSCSIController).GetVirtualSCSIController()
+	c.HotAddRemove = &cmd.hotAddRemove
+	c.SharedBus = types.VirtualSCSISharing(cmd.sharedBus)
+
+	err = vm.AddDevice(ctx, d)
+	if err != nil {
+		return err
+	}
+
+	// output name of device we just created
+	devices, err = vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	devices = devices.SelectByType(d)
+
+	name := devices.Name(devices[len(devices)-1])
+
+	fmt.Println(name)
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/device/serial/add.go
+++ b/vendor/github.com/vmware/govmomi/govc/device/serial/add.go
@@ -1,0 +1,94 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serial
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type add struct {
+	*flags.VirtualMachineFlag
+}
+
+func init() {
+	cli.Register("device.serial.add", &add{})
+}
+
+func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+}
+
+func (cmd *add) Description() string {
+	return `Add serial port to VM.
+
+Examples:
+  govc device.serial.add -vm $vm
+  govc device.info -vm $vm serialport-*`
+}
+
+func (cmd *add) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	d, err := devices.CreateSerialPort()
+	if err != nil {
+		return err
+	}
+
+	err = vm.AddDevice(ctx, d)
+	if err != nil {
+		return err
+	}
+
+	// output name of device we just created
+	devices, err = vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	devices = devices.SelectByType(d)
+
+	name := devices.Name(devices[len(devices)-1])
+
+	fmt.Println(name)
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/device/serial/connect.go
+++ b/vendor/github.com/vmware/govmomi/govc/device/serial/connect.go
@@ -1,0 +1,116 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serial
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"path"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+type connect struct {
+	*flags.VirtualMachineFlag
+
+	proxy  string
+	device string
+	client bool
+}
+
+func init() {
+	cli.Register("device.serial.connect", &connect{})
+}
+
+func (cmd *connect) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.proxy, "vspc-proxy", "", "vSPC proxy URI")
+	f.StringVar(&cmd.device, "device", "", "serial port device name")
+	f.BoolVar(&cmd.client, "client", false, "Use client direction")
+}
+
+func (cmd *connect) Usage() string {
+	return "URI"
+}
+
+func (cmd *connect) Description() string {
+	return `Connect service URI to serial port.
+
+If "-" is given as URI, connects file backed device with file name of
+device name + .log suffix in the VM Config.Files.LogDirectory.
+
+Defaults to the first serial port if no DEVICE is given.
+
+Examples:
+  govc device.ls | grep serialport-
+  govc device.serial.connect -vm $vm -device serialport-8000 telnet://:33233
+  govc device.info -vm $vm serialport-*
+  govc device.serial.connect -vm $vm "[datastore1] $vm/console.log"
+  govc device.serial.connect -vm $vm -
+  govc datastore.tail -f $vm/serialport-8000.log`
+}
+
+func (cmd *connect) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *connect) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	d, err := devices.FindSerialPort(cmd.device)
+	if err != nil {
+		return err
+	}
+
+	uri := f.Arg(0)
+
+	if uri == "-" {
+		var mvm mo.VirtualMachine
+		err = vm.Properties(ctx, vm.Reference(), []string{"config.files.logDirectory"}, &mvm)
+		if err != nil {
+			return err
+		}
+
+		uri = path.Join(mvm.Config.Files.LogDirectory, fmt.Sprintf("%s.log", devices.Name(d)))
+	}
+
+	return vm.EditDevice(ctx, devices.ConnectSerialPort(d, uri, cmd.client, cmd.proxy))
+}

--- a/vendor/github.com/vmware/govmomi/govc/device/serial/disconnect.go
+++ b/vendor/github.com/vmware/govmomi/govc/device/serial/disconnect.go
@@ -1,0 +1,81 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serial
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type disconnect struct {
+	*flags.VirtualMachineFlag
+
+	device string
+}
+
+func init() {
+	cli.Register("device.serial.disconnect", &disconnect{})
+}
+
+func (cmd *disconnect) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.device, "device", "", "serial port device name")
+}
+
+func (cmd *disconnect) Description() string {
+	return `Disconnect service URI from serial port.
+
+Examples:
+  govc device.ls | grep serialport-
+  govc device.serial.disconnect -vm $vm -device serialport-8000
+  govc device.info -vm $vm serialport-*`
+}
+
+func (cmd *disconnect) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *disconnect) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	d, err := devices.FindSerialPort(cmd.device)
+	if err != nil {
+		return err
+	}
+
+	return vm.EditDevice(ctx, devices.DisconnectSerialPort(d))
+}

--- a/vendor/github.com/vmware/govmomi/govc/device/usb/add.go
+++ b/vendor/github.com/vmware/govmomi/govc/device/usb/add.go
@@ -1,0 +1,114 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package usb
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type add struct {
+	*flags.VirtualMachineFlag
+
+	controller  string
+	autoConnect bool
+	ehciEnabled bool
+}
+
+func init() {
+	cli.Register("device.usb.add", &add{})
+}
+
+func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	ctypes := []string{"usb", "xhci"}
+	f.StringVar(&cmd.controller, "type", ctypes[0],
+		fmt.Sprintf("USB controller type (%s)", strings.Join(ctypes, "|")))
+
+	f.BoolVar(&cmd.autoConnect, "auto", true, "Enable ability to hot plug devices")
+	f.BoolVar(&cmd.ehciEnabled, "ehci", true, "Enable enhanced host controller interface (USB 2.0)")
+}
+
+func (cmd *add) Description() string {
+	return `Add USB device to VM.
+
+Examples:
+  govc device.usb.add -vm $vm
+  govc device.usb.add -type xhci -vm $vm
+  govc device.info usb*`
+}
+
+func (cmd *add) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	var d types.BaseVirtualDevice
+
+	switch cmd.controller {
+	case "usb":
+		c := new(types.VirtualUSBController)
+		c.AutoConnectDevices = &cmd.autoConnect
+		c.EhciEnabled = &cmd.ehciEnabled
+		d = c
+	case "xhci":
+		c := new(types.VirtualUSBXHCIController)
+		c.AutoConnectDevices = &cmd.autoConnect
+		d = c
+	default:
+		return flag.ErrHelp
+	}
+
+	err = vm.AddDevice(ctx, d)
+	if err != nil {
+		return err
+	}
+
+	// output name of device we just created
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	devices = devices.SelectByType(d)
+
+	name := devices.Name(devices[len(devices)-1])
+
+	fmt.Println(name)
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/disk/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/disk/create.go
@@ -1,0 +1,147 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/units"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vslm"
+)
+
+type disk struct {
+	*flags.DatastoreFlag
+	*flags.ResourcePoolFlag
+	*flags.StoragePodFlag
+
+	size units.ByteSize
+	keep *bool
+}
+
+func init() {
+	cli.Register("disk.create", &disk{})
+}
+
+func (cmd *disk) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	cmd.StoragePodFlag, ctx = flags.NewStoragePodFlag(ctx)
+	cmd.StoragePodFlag.Register(ctx, f)
+
+	cmd.ResourcePoolFlag, ctx = flags.NewResourcePoolFlag(ctx)
+	cmd.ResourcePoolFlag.Register(ctx, f)
+
+	_ = cmd.size.Set("10G")
+	f.Var(&cmd.size, "size", "Size of new disk")
+	f.Var(flags.NewOptionalBool(&cmd.keep), "keep", "Keep disk after VM is deleted")
+}
+
+func (cmd *disk) Process(ctx context.Context) error {
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.StoragePodFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.ResourcePoolFlag.Process(ctx)
+}
+
+func (cmd *disk) Usage() string {
+	return "NAME"
+}
+
+func (cmd *disk) Description() string {
+	return `Create disk NAME on DS.
+
+Examples:
+  govc disk.create -size 24G my-disk`
+}
+
+func (cmd *disk) Run(ctx context.Context, f *flag.FlagSet) error {
+	name := f.Arg(0)
+	if name == "" {
+		return flag.ErrHelp
+	}
+
+	c, err := cmd.DatastoreFlag.Client()
+	if err != nil {
+		return err
+	}
+
+	var pool *object.ResourcePool
+	var ds mo.Reference
+	if cmd.StoragePodFlag.Isset() {
+		ds, err = cmd.StoragePod()
+		if err != nil {
+			return err
+		}
+		pool, err = cmd.ResourcePool()
+		if err != nil {
+			return err
+		}
+	} else {
+		ds, err = cmd.Datastore()
+		if err != nil {
+			return err
+		}
+	}
+
+	m := vslm.NewObjectManager(c)
+
+	spec := types.VslmCreateSpec{
+		Name:              name,
+		CapacityInMB:      int64(cmd.size) / units.MB,
+		KeepAfterDeleteVm: cmd.keep,
+		BackingSpec: &types.VslmCreateSpecDiskFileBackingSpec{
+			VslmCreateSpecBackingSpec: types.VslmCreateSpecBackingSpec{
+				Datastore: ds.Reference(),
+			},
+			ProvisioningType: string(types.BaseConfigInfoDiskFileBackingInfoProvisioningTypeThin),
+		},
+	}
+
+	if cmd.StoragePodFlag.Isset() {
+		if err = m.PlaceDisk(ctx, &spec, pool.Reference()); err != nil {
+			return err
+		}
+	}
+
+	task, err := m.CreateDisk(ctx, spec)
+	if err != nil {
+		return nil
+	}
+
+	logger := cmd.DatastoreFlag.ProgressLogger(fmt.Sprintf("Creating %s...", spec.Name))
+
+	res, err := task.WaitForResult(ctx, logger)
+	logger.Wait()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(res.Result.(types.VStorageObject).Config.Id.Id)
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/disk/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/disk/ls.go
@@ -1,0 +1,189 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/units"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vslm"
+)
+
+type ls struct {
+	*flags.DatastoreFlag
+	long     bool
+	path     bool
+	r        bool
+	category string
+	tag      string
+	tags     bool
+}
+
+func init() {
+	cli.Register("disk.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.long, "l", false, "Long listing format")
+	f.BoolVar(&cmd.path, "L", false, "Print disk backing path instead of disk name")
+	f.BoolVar(&cmd.r, "R", false, "Reconcile the datastore inventory info")
+	f.StringVar(&cmd.category, "c", "", "Query tag category")
+	f.StringVar(&cmd.tag, "t", "", "Query tag name")
+	f.BoolVar(&cmd.tags, "T", false, "List attached tags")
+}
+
+func (cmd *ls) Usage() string {
+	return "[ID]..."
+}
+
+func (cmd *ls) Description() string {
+	return `List disk IDs on DS.
+
+Examples:
+  govc disk.ls
+  govc disk.ls -l -T
+  govc disk.ls -l e9b06a8b-d047-4d3c-b15b-43ea9608b1a6
+  govc disk.ls -c k8s-region -t us-west-2`
+}
+
+type VStorageObject struct {
+	types.VStorageObject
+	Tags []types.VslmTagEntry
+}
+
+func (o *VStorageObject) tags() string {
+	var tags []string
+	for _, tag := range o.Tags {
+		tags = append(tags, tag.ParentCategoryName+":"+tag.TagName)
+	}
+	return strings.Join(tags, ",")
+}
+
+type lsResult struct {
+	cmd     *ls
+	Objects []VStorageObject
+}
+
+func (r *lsResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(r.cmd.Out, 2, 0, 2, ' ', 0)
+
+	for _, o := range r.Objects {
+		name := o.Config.Name
+		if r.cmd.path {
+			if file, ok := o.Config.Backing.(*types.BaseConfigInfoDiskFileBackingInfo); ok {
+				name = file.FilePath
+			}
+		}
+		_, _ = fmt.Fprintf(tw, "%s\t%s", o.Config.Id.Id, name)
+		if r.cmd.long {
+			created := o.Config.CreateTime.Format(time.Stamp)
+			size := units.FileSize(o.Config.CapacityInMB * 1024 * 1024)
+			_, _ = fmt.Fprintf(tw, "\t%s\t%s", size, created)
+		}
+		if r.cmd.tags {
+			_, _ = fmt.Fprintf(tw, "\t%s", o.tags())
+		}
+		_, _ = fmt.Fprintln(tw)
+	}
+
+	return tw.Flush()
+}
+
+func (r *lsResult) Dump() interface{} {
+	return r.Objects
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	m := vslm.NewObjectManager(c)
+	if cmd.r {
+		task, err := m.ReconcileDatastoreInventory(ctx, ds)
+		if err != nil {
+			return err
+		}
+		if err = task.Wait(ctx); err != nil {
+			return err
+		}
+	}
+	res := lsResult{cmd: cmd}
+
+	filterNotFound := false
+	ids := f.Args()
+	if len(ids) == 0 {
+		filterNotFound = true
+		var oids []types.ID
+		if cmd.category == "" {
+			oids, err = m.List(ctx, ds)
+		} else {
+			oids, err = m.ListAttachedObjects(ctx, cmd.category, cmd.tag)
+		}
+
+		if err != nil {
+			return err
+		}
+		for _, id := range oids {
+			ids = append(ids, id.Id)
+		}
+	}
+
+	for _, id := range ids {
+		o, err := m.Retrieve(ctx, ds, id)
+		if err != nil {
+			if filterNotFound && soap.IsSoapFault(err) {
+				fault := soap.ToSoapFault(err).Detail.Fault
+				if _, ok := fault.(types.NotFound); ok {
+					// The case when an FCD is deleted by something other than DeleteVStorageObject_Task, such as VM destroy
+					return fmt.Errorf("%s not found: use 'disk.ls -R' to reconcile datastore inventory", id)
+				}
+			}
+			return fmt.Errorf("retrieve %q: %s", id, err)
+		}
+
+		obj := VStorageObject{VStorageObject: *o}
+		if cmd.tags {
+			obj.Tags, err = m.ListAttachedTags(ctx, id)
+			if err != nil {
+				return err
+			}
+		}
+		res.Objects = append(res.Objects, obj)
+	}
+
+	return cmd.WriteResult(&res)
+}

--- a/vendor/github.com/vmware/govmomi/govc/disk/register.go
+++ b/vendor/github.com/vmware/govmomi/govc/disk/register.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vslm"
+)
+
+type register struct {
+	*flags.DatastoreFlag
+}
+
+func init() {
+	cli.Register("disk.register", &register{})
+}
+
+func (cmd *register) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+}
+
+func (cmd *register) Usage() string {
+	return "PATH [NAME]"
+}
+
+func (cmd *register) Description() string {
+	return `Register existing disk on DS.
+
+Examples:
+  govc disk.register disks/disk1.vmdk my-disk`
+}
+
+func (cmd *register) Run(ctx context.Context, f *flag.FlagSet) error {
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	m := vslm.NewObjectManager(ds.Client())
+
+	path := ds.NewURL(f.Arg(0)).String()
+
+	obj, err := m.RegisterDisk(ctx, path, f.Arg(1))
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(obj.Config.Id.Id)
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/disk/rm.go
+++ b/vendor/github.com/vmware/govmomi/govc/disk/rm.go
@@ -1,0 +1,73 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vslm"
+)
+
+type rm struct {
+	*flags.DatastoreFlag
+}
+
+func init() {
+	cli.Register("disk.rm", &rm{})
+}
+
+func (cmd *rm) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+}
+
+func (cmd *rm) Usage() string {
+	return "ID"
+}
+
+func (cmd *rm) Description() string {
+	return `Remove disk ID on DS.
+
+Examples:
+  govc disk.rm ID`
+}
+
+func (cmd *rm) Run(ctx context.Context, f *flag.FlagSet) error {
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	id := f.Arg(0)
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("Deleting %s...", id))
+	defer logger.Wait()
+
+	m := vslm.NewObjectManager(ds.Client())
+
+	task, err := m.Delete(ctx, ds, id)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/disk/snapshot/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/disk/snapshot/create.go
@@ -1,0 +1,79 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshot
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vslm"
+)
+
+type create struct {
+	*flags.DatastoreFlag
+}
+
+func init() {
+	cli.Register("disk.snapshot.create", &create{})
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+}
+
+func (cmd *create) Usage() string {
+	return "ID DESC"
+}
+
+func (cmd *create) Description() string {
+	return `Create snapshot of ID on DS.
+
+Examples:
+  govc disk.snapshot.create b9fe5f17-3b87-4a03-9739-09a82ddcc6b0 my-disk-snapshot`
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	m := vslm.NewObjectManager(ds.Client())
+	id := f.Arg(0)
+
+	task, err := m.CreateSnapshot(ctx, ds, id, f.Arg(1))
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("Snapshot %s...", id))
+
+	res, err := task.WaitForResult(ctx, logger)
+	logger.Wait()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(res.Result.(types.ID).Id)
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/disk/snapshot/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/disk/snapshot/ls.go
@@ -1,0 +1,100 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshot
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vslm"
+)
+
+type ls struct {
+	*flags.DatastoreFlag
+	long bool
+}
+
+func init() {
+	cli.Register("disk.snapshot.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.long, "l", false, "Long listing format")
+}
+
+func (cmd *ls) Usage() string {
+	return "ID"
+}
+
+func (cmd *ls) Description() string {
+	return `List snapshots for disk ID on DS.
+
+Examples:
+  govc snapshot.disk.ls -l 9b06a8b-d047-4d3c-b15b-43ea9608b1a6`
+}
+
+type lsResult struct {
+	Info *types.VStorageObjectSnapshotInfo
+	cmd  *ls
+}
+
+func (r *lsResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
+
+	for _, o := range r.Info.Snapshots {
+		_, _ = fmt.Fprintf(tw, "%s\t%s", o.Id.Id, o.Description)
+		if r.cmd.long {
+			created := o.CreateTime.Format(time.Stamp)
+			_, _ = fmt.Fprintf(tw, "\t%s", created)
+		}
+		_, _ = fmt.Fprintln(tw)
+	}
+
+	return tw.Flush()
+}
+
+func (r *lsResult) Dump() interface{} {
+	return r.Info
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	m := vslm.NewObjectManager(ds.Client())
+	info, err := m.RetrieveSnapshotInfo(ctx, ds, f.Arg(0))
+	if err != nil {
+		return err
+	}
+
+	res := lsResult{Info: info, cmd: cmd}
+
+	return cmd.WriteResult(&res)
+}

--- a/vendor/github.com/vmware/govmomi/govc/disk/snapshot/rm.go
+++ b/vendor/github.com/vmware/govmomi/govc/disk/snapshot/rm.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshot
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vslm"
+)
+
+type rm struct {
+	*flags.DatastoreFlag
+}
+
+func init() {
+	cli.Register("disk.snapshot.rm", &rm{})
+}
+
+func (cmd *rm) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+}
+
+func (cmd *rm) Usage() string {
+	return "ID SID"
+}
+
+func (cmd *rm) Description() string {
+	return `Remove disk ID snapshot ID on DS.
+
+Examples:
+  govc disk.snapshot.rm ffe6a398-eb8e-4eaa-9118-e1f16b8b8e3c ecbca542-0a25-4127-a585-82e4047750d6`
+}
+
+func (cmd *rm) Run(ctx context.Context, f *flag.FlagSet) error {
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	sid := f.Arg(1)
+	m := vslm.NewObjectManager(ds.Client())
+
+	task, err := m.DeleteSnapshot(ctx, ds, f.Arg(0), sid)
+	if err != nil {
+		return err
+	}
+	logger := cmd.ProgressLogger(fmt.Sprintf("Deleting %s...", sid))
+	defer logger.Wait()
+
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/disk/tags.go
+++ b/vendor/github.com/vmware/govmomi/govc/disk/tags.go
@@ -1,0 +1,85 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vslm"
+)
+
+type tags struct {
+	*flags.ClientFlag
+	types.VslmTagEntry
+	attach bool
+}
+
+func init() {
+	cli.Register("disk.tags.attach", &tags{attach: true})
+	cli.Register("disk.tags.detach", &tags{attach: false})
+}
+
+func (cmd *tags) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.ParentCategoryName, "c", "", "Tag category")
+}
+
+func (cmd *tags) Usage() string {
+	return "NAME ID"
+}
+
+func (cmd *tags) name() string {
+	if cmd.attach {
+		return "attach"
+	}
+	return "detach"
+}
+
+func (cmd *tags) Description() string {
+	if cmd.attach {
+		return `Attach tag NAME to disk ID.
+
+Examples:
+  govc disk.tags.attach -c k8s-region k8s-region-us $id`
+	}
+
+	return `Detach tag NAME from disk ID.
+
+Examples:
+  govc disk.tags.detach -c k8s-region k8s-region-us $id`
+}
+
+func (cmd *tags) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m := vslm.NewObjectManager(c)
+	cmd.TagName = f.Arg(0)
+	method := m.DetachTag
+	if cmd.attach {
+		method = m.AttachTag
+	}
+	return method(ctx, f.Arg(1), cmd.VslmTagEntry)
+}

--- a/vendor/github.com/vmware/govmomi/govc/dvs/add.go
+++ b/vendor/github.com/vmware/govmomi/govc/dvs/add.go
@@ -1,0 +1,147 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dvs
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type add struct {
+	*flags.HostSystemFlag
+
+	path string
+	pnic string
+}
+
+func init() {
+	cli.Register("dvs.add", &add{})
+}
+
+func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.path, "dvs", "", "DVS path")
+	f.StringVar(&cmd.pnic, "pnic", "vmnic0", "Name of the host physical NIC")
+}
+
+func (cmd *add) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *add) Usage() string {
+	return "HOST..."
+}
+
+func (cmd *add) Description() string {
+	return `Add hosts to DVS.
+
+Examples:
+  govc dvs.add -dvs dvsName -pnic vmnic1 hostA hostB hostC`
+}
+
+func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	net, err := finder.Network(ctx, cmd.path)
+	if err != nil {
+		return err
+	}
+
+	dvs, ok := net.(*object.DistributedVirtualSwitch)
+	if !ok {
+		return fmt.Errorf("%s (%T) is not of type %T", cmd.path, net, dvs)
+	}
+
+	var s mo.DistributedVirtualSwitch
+	err = dvs.Properties(ctx, dvs.Reference(), []string{"config"}, &s)
+	if err != nil {
+		return err
+	}
+
+	backing := new(types.DistributedVirtualSwitchHostMemberPnicBacking)
+
+	for _, vmnic := range strings.Split(cmd.pnic, ",") {
+		backing.PnicSpec = append(backing.PnicSpec, types.DistributedVirtualSwitchHostMemberPnicSpec{
+			PnicDevice: strings.TrimSpace(vmnic),
+		})
+	}
+
+	config := &types.DVSConfigSpec{
+		ConfigVersion: s.Config.GetDVSConfigInfo().ConfigVersion,
+	}
+
+	hosts, err := cmd.HostSystems(f.Args())
+	if err != nil {
+		return err
+	}
+
+	existing := make(map[string]bool)
+	// TODO: host.pnic.info command
+	for _, member := range s.Config.GetDVSConfigInfo().Host {
+		existing[member.Config.Host.Value] = true
+	}
+
+	for _, host := range hosts {
+		ref := host.Reference()
+		if existing[ref.Value] {
+			fmt.Fprintf(os.Stderr, "%s is already a member of %s\n", host.InventoryPath, dvs.InventoryPath)
+			continue
+		}
+
+		config.Host = append(config.Host, types.DistributedVirtualSwitchHostMemberConfigSpec{
+			Operation: "add",
+			Host:      ref,
+			Backing:   backing,
+		})
+	}
+
+	if len(config.Host) == 0 {
+		return nil
+	}
+
+	task, err := dvs.Reconfigure(ctx, config)
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("adding %d hosts to dvs %s... ", len(config.Host), dvs.InventoryPath))
+	defer logger.Wait()
+
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/dvs/change.go
+++ b/vendor/github.com/vmware/govmomi/govc/dvs/change.go
@@ -1,0 +1,129 @@
+/*
+Copyright (c) 2015-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dvs
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type change struct {
+	*flags.DatacenterFlag
+
+	types.DVSCreateSpec
+
+	configSpec *types.VMwareDVSConfigSpec
+
+	dProtocol string
+}
+
+func init() {
+	cli.Register("dvs.change", &change{})
+}
+
+func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	cmd.configSpec = new(types.VMwareDVSConfigSpec)
+
+	cmd.DVSCreateSpec.ConfigSpec = cmd.configSpec
+	cmd.DVSCreateSpec.ProductInfo = new(types.DistributedVirtualSwitchProductSpec)
+
+	f.StringVar(&cmd.ProductInfo.Version, "product-version", "", "DVS product version")
+	f.Var(flags.NewInt32(&cmd.configSpec.MaxMtu), "mtu", "DVS Max MTU")
+	f.StringVar(&cmd.dProtocol, "discovery-protocol", "", "Link Discovery Protocol")
+}
+
+func (cmd *change) Usage() string {
+	return "DVS"
+}
+
+func (cmd *change) Description() string {
+	return `Change DVS (DistributedVirtualSwitch) in datacenter.
+
+Examples:
+  govc dvs.change -product-version 5.5.0 DSwitch
+  govc dvs.change -mtu 9000 DSwitch
+  govc dvs.change -discovery-protocol [lldp|cdp] DSwitch`
+}
+
+func (cmd *change) Process(ctx context.Context) error {
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	name := f.Arg(0)
+
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	net, err := finder.Network(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	dvs, ok := net.(*object.DistributedVirtualSwitch)
+	if !ok {
+		return fmt.Errorf("%s (%s) is not a DVS", f.Arg(0), net.Reference().Type)
+	}
+	var s mo.DistributedVirtualSwitch
+	err = dvs.Properties(ctx, dvs.Reference(), []string{"config"}, &s)
+	if err != nil {
+		return err
+	}
+
+	cmd.configSpec.ConfigVersion = s.Config.GetDVSConfigInfo().ConfigVersion
+
+	if cmd.dProtocol != "" {
+		cmd.configSpec.LinkDiscoveryProtocolConfig = &types.LinkDiscoveryProtocolConfig{
+			Protocol:  cmd.dProtocol,
+			Operation: "listen",
+		}
+	}
+
+	task, err := dvs.Reconfigure(ctx, cmd.ConfigSpec)
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("updating DVS %s... ", name))
+	defer logger.Wait()
+
+	_, err = task.WaitForResult(ctx, logger)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/dvs/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/dvs/create.go
@@ -1,0 +1,112 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dvs
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type create struct {
+	*flags.FolderFlag
+
+	types.DVSCreateSpec
+
+	configSpec *types.VMwareDVSConfigSpec
+
+	dProtocol string
+}
+
+func init() {
+	cli.Register("dvs.create", &create{})
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.FolderFlag, ctx = flags.NewFolderFlag(ctx)
+	cmd.FolderFlag.Register(ctx, f)
+
+	cmd.configSpec = new(types.VMwareDVSConfigSpec)
+
+	cmd.DVSCreateSpec.ConfigSpec = cmd.configSpec
+	cmd.DVSCreateSpec.ProductInfo = new(types.DistributedVirtualSwitchProductSpec)
+
+	f.StringVar(&cmd.ProductInfo.Version, "product-version", "", "DVS product version")
+	f.Var(flags.NewInt32(&cmd.configSpec.MaxMtu), "mtu", "DVS Max MTU")
+	f.StringVar(&cmd.dProtocol, "discovery-protocol", "", "Link Discovery Protocol")
+}
+
+func (cmd *create) Usage() string {
+	return "DVS"
+}
+
+func (cmd *create) Description() string {
+	return `Create DVS (DistributedVirtualSwitch) in datacenter.
+
+The dvs is added to the folder specified by the 'folder' flag. If not given,
+this defaults to the network folder in the specified or default datacenter.
+
+Examples:
+  govc dvs.create DSwitch
+  govc dvs.create -product-version 5.5.0 DSwitch
+  govc dvs.create -mtu 9000 DSwitch
+  govc dvs.create -discovery-protocol [lldp|cdp] DSwitch`
+}
+
+func (cmd *create) Process(ctx context.Context) error {
+	if err := cmd.FolderFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	name := f.Arg(0)
+
+	cmd.configSpec.Name = name
+
+	if cmd.dProtocol != "" {
+		cmd.configSpec.LinkDiscoveryProtocolConfig = &types.LinkDiscoveryProtocolConfig{
+			Protocol:  cmd.dProtocol,
+			Operation: "listen",
+		}
+	}
+
+	folder, err := cmd.FolderOrDefault("network")
+	if err != nil {
+		return err
+	}
+
+	task, err := folder.CreateDVS(ctx, cmd.DVSCreateSpec)
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("adding %s to folder %s... ", name, folder.InventoryPath))
+	defer logger.Wait()
+
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/dvs/portgroup/add.go
+++ b/vendor/github.com/vmware/govmomi/govc/dvs/portgroup/add.go
@@ -1,0 +1,107 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portgroup
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type add struct {
+	*flags.DatacenterFlag
+
+	DVPortgroupConfigSpec
+
+	path string
+}
+
+func init() {
+	cli.Register("dvs.portgroup.add", &add{})
+}
+
+func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.path, "dvs", "", "DVS path")
+
+	cmd.DVPortgroupConfigSpec.NumPorts = 128 // default
+
+	cmd.DVPortgroupConfigSpec.Register(ctx, f)
+}
+
+func (cmd *add) Description() string {
+	return `Add portgroup to DVS.
+
+Examples:
+  govc dvs.create DSwitch
+  govc dvs.portgroup.add -dvs DSwitch -type earlyBinding -nports 16 ExternalNetwork
+  govc dvs.portgroup.add -dvs DSwitch -type ephemeral InternalNetwork`
+}
+
+func (cmd *add) Process(ctx context.Context) error {
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *add) Usage() string {
+	return "NAME"
+}
+
+func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
+	name := f.Arg(0)
+
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	net, err := finder.Network(ctx, cmd.path)
+	if err != nil {
+		return err
+	}
+
+	dvs, ok := net.(*object.DistributedVirtualSwitch)
+	if !ok {
+		return fmt.Errorf("%s (%T) is not of type %T", cmd.path, net, dvs)
+	}
+
+	cmd.DVPortgroupConfigSpec.Name = name
+
+	task, err := dvs.AddPortgroup(ctx, []types.DVPortgroupConfigSpec{cmd.Spec()})
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("adding %s portgroup to dvs %s... ", name, dvs.InventoryPath))
+	defer logger.Wait()
+
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/dvs/portgroup/change.go
+++ b/vendor/github.com/vmware/govmomi/govc/dvs/portgroup/change.go
@@ -1,0 +1,107 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portgroup
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+type change struct {
+	*flags.DatacenterFlag
+
+	DVPortgroupConfigSpec
+}
+
+func init() {
+	cli.Register("dvs.portgroup.change", &change{})
+}
+
+func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	cmd.DVPortgroupConfigSpec.Register(ctx, f)
+}
+
+func (cmd *change) Description() string {
+	return `Change DVS portgroup configuration.
+
+Examples:
+  govc dvs.portgroup.change -nports 26 ExternalNetwork
+  govc dvs.portgroup.change -vlan 3214 ExternalNetwork`
+}
+
+func (cmd *change) Process(ctx context.Context) error {
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *change) Usage() string {
+	return "PATH"
+}
+
+func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	path := f.Arg(0)
+
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	net, err := finder.Network(ctx, path)
+	if err != nil {
+		return err
+	}
+
+	pg, ok := net.(*object.DistributedVirtualPortgroup)
+	if !ok {
+		return fmt.Errorf("%s (%T) is not of type %T", path, net, pg)
+	}
+
+	var s mo.DistributedVirtualPortgroup
+	err = pg.Properties(ctx, pg.Reference(), []string{"config.configVersion"}, &s)
+	if err != nil {
+		return err
+	}
+
+	spec := cmd.Spec()
+	spec.ConfigVersion = s.Config.ConfigVersion
+
+	task, err := pg.Reconfigure(ctx, spec)
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("changing %s portgroup configuration %s... ", pg.Name(), pg.InventoryPath))
+	defer logger.Wait()
+
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/dvs/portgroup/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/dvs/portgroup/info.go
@@ -1,0 +1,342 @@
+/*
+Copyright (c) 2015-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portgroup
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*flags.DatacenterFlag
+
+	pg         string
+	active     bool
+	connected  bool
+	inside     bool
+	uplinkPort bool
+	vlanID     int
+	count      int
+	dvsRules   bool
+}
+
+var protocols = map[int32]string{
+	1:  "icmp",
+	2:  "igmp",
+	6:  "tcp",
+	17: "udp",
+	58: "ipv6-icmp",
+}
+
+type trafficRule struct {
+	Description        string
+	Direction          string
+	Action             string
+	Protocol           string
+	SourceAddress      string
+	SourceIpPort       string
+	DestinationAddress string
+	DestinationIpPort  string
+}
+
+func init() {
+	cli.Register("dvs.portgroup.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.pg, "pg", "", "Distributed Virtual Portgroup")
+	f.BoolVar(&cmd.active, "active", false, "Filter by port active or inactive status")
+	f.BoolVar(&cmd.connected, "connected", false, "Filter by port connected or disconnected status")
+	f.BoolVar(&cmd.inside, "inside", true, "Filter by port inside or outside status")
+	f.BoolVar(&cmd.uplinkPort, "uplinkPort", false, "Filter for uplink ports")
+	f.IntVar(&cmd.vlanID, "vlan", 0, "Filter by VLAN ID (0 = unfiltered)")
+	f.IntVar(&cmd.count, "count", 0, "Number of matches to return (0 = unlimited)")
+	f.BoolVar(&cmd.dvsRules, "r", false, "Show DVS rules")
+}
+
+func (cmd *info) Usage() string {
+	return "DVS"
+}
+
+func (cmd *info) Description() string {
+	return `Portgroup info for DVS.
+
+Examples:
+  govc dvs.portgroup.info DSwitch
+  govc dvs.portgroup.info -pg InternalNetwork DSwitch
+  govc find / -type DistributedVirtualSwitch | xargs -n1 govc dvs.portgroup.info`
+}
+
+type infoResult struct {
+	Port []types.DistributedVirtualPort
+	cmd  *info
+}
+
+func printPort(port types.BaseDvsIpPort) string {
+	if port != nil {
+		switch portType := port.(type) {
+		case *types.DvsSingleIpPort:
+			return fmt.Sprintf("%d", portType.PortNumber)
+		case *types.DvsIpPortRange:
+			return fmt.Sprintf("%d-%d", portType.StartPortNumber,
+				portType.EndPortNumber)
+		}
+	}
+	return "Any"
+}
+
+func printAddress(address types.BaseIpAddress) string {
+	if address != nil {
+		switch (address).(type) {
+		case *types.SingleIp:
+			return address.(*types.SingleIp).Address
+		case *types.IpRange:
+			return fmt.Sprintf("%s/%d", address.(*types.IpRange).AddressPrefix, address.(*types.IpRange).PrefixLength)
+		}
+	}
+	return "Any"
+}
+
+func printAction(action types.BaseDvsNetworkRuleAction) string {
+	if action != nil {
+		switch (action).(type) {
+		case *types.DvsAcceptNetworkRuleAction:
+			return fmt.Sprintf("Accept")
+		case *types.DvsDropNetworkRuleAction:
+			return fmt.Sprintf("Drop")
+		}
+	}
+	return "n/a"
+}
+
+func printTable(trafficRuleSet map[int]map[int]trafficRule, portID int) {
+	if len(trafficRuleSet[portID]) == 0 {
+		return
+	}
+
+	keys := []int{}
+	for k := range trafficRuleSet[portID] {
+		keys = append(keys, k)
+	}
+	sort.Ints(keys)
+	tabWidthInt := 22
+	tabWidth := fmt.Sprintf("%d", tabWidthInt)
+	headLen := 9*(tabWidthInt+2) - 1
+	fmt.Printf("+" + strings.Repeat("-", headLen) + "+\n")
+	format := "| %-" + tabWidth +
+		"s| %-" + tabWidth +
+		"s| %-" + tabWidth +
+		"s| %-" + tabWidth +
+		"s| %-" + tabWidth +
+		"s| %-" + tabWidth +
+		"s| %-" + tabWidth +
+		"s| %-" + tabWidth +
+		"s| %-" + tabWidth +
+		"s|\n"
+	fmt.Printf(format,
+		"Sequence",
+		"Description",
+		"Direction",
+		"Action",
+		"Protocol",
+		"SourceAddress",
+		"SourceIpPort",
+		"DestinationAddress",
+		"DestinationIpPort")
+	fmt.Printf("+" + strings.Repeat("-", headLen) + "+\n")
+	for _, id := range keys {
+		fmt.Printf(format,
+			fmt.Sprintf("%d", id),
+			trafficRuleSet[portID][id].Description,
+			trafficRuleSet[portID][id].Direction,
+			trafficRuleSet[portID][id].Action,
+			trafficRuleSet[portID][id].Protocol,
+			trafficRuleSet[portID][id].SourceAddress,
+			trafficRuleSet[portID][id].SourceIpPort,
+			trafficRuleSet[portID][id].DestinationAddress,
+			trafficRuleSet[portID][id].DestinationIpPort)
+	}
+	fmt.Printf("+" + strings.Repeat("-", headLen) + "+\n")
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	trafficRuleSet := make(map[int]map[int]trafficRule)
+	for portID, port := range r.Port {
+		var vlanID int32
+		setting := port.Config.Setting.(*types.VMwareDVSPortSetting)
+
+		switch vlan := setting.Vlan.(type) {
+		case *types.VmwareDistributedVirtualSwitchVlanIdSpec:
+			vlanID = vlan.VlanId
+		case *types.VmwareDistributedVirtualSwitchTrunkVlanSpec:
+		case *types.VmwareDistributedVirtualSwitchPvlanSpec:
+			vlanID = vlan.PvlanId
+		}
+
+		// Show port info if: VLAN ID is not defined, or VLAN ID matches requested VLAN
+		if r.cmd.vlanID == 0 || vlanID == int32(r.cmd.vlanID) {
+			fmt.Printf("PortgroupKey: %s\n", port.PortgroupKey)
+			fmt.Printf("DvsUuid:      %s\n", port.DvsUuid)
+			fmt.Printf("VlanId:       %d\n", vlanID)
+			fmt.Printf("PortKey:      %s\n\n", port.Key)
+
+			trafficRuleSet[portID] = make(map[int]trafficRule)
+
+			if r.cmd.dvsRules && setting.FilterPolicy != nil &&
+				setting.FilterPolicy.FilterConfig != nil &&
+				len(setting.FilterPolicy.FilterConfig) > 0 {
+
+				rules := setting.FilterPolicy.FilterConfig[0].GetDvsTrafficFilterConfig()
+				if rules != nil && rules.TrafficRuleset != nil && rules.TrafficRuleset.Rules != nil {
+					for _, rule := range rules.TrafficRuleset.Rules {
+						for _, q := range rule.Qualifier {
+							var protocol string
+							if val, ok := protocols[q.GetDvsIpNetworkRuleQualifier().Protocol.Value]; ok {
+								protocol = val
+							} else {
+								protocol = fmt.Sprintf("%d", q.GetDvsIpNetworkRuleQualifier().Protocol.Value)
+							}
+
+							trafficRuleSet[portID][int(rule.Sequence)] = trafficRule{
+								Description:        rule.Description,
+								Direction:          rule.Direction,
+								Action:             printAction(rule.Action),
+								Protocol:           protocol,
+								SourceAddress:      printAddress(q.GetDvsIpNetworkRuleQualifier().SourceAddress),
+								SourceIpPort:       printPort(q.GetDvsIpNetworkRuleQualifier().SourceIpPort),
+								DestinationAddress: printAddress(q.GetDvsIpNetworkRuleQualifier().DestinationAddress),
+								DestinationIpPort:  printPort(q.GetDvsIpNetworkRuleQualifier().DestinationIpPort),
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if r.cmd.dvsRules && len(r.Port) > 0 {
+		eq := 0
+		for i := range r.Port {
+			if i > 0 {
+				reflect.DeepEqual(trafficRuleSet[i-1], trafficRuleSet[i])
+				if reflect.DeepEqual(trafficRuleSet[i-1], trafficRuleSet[i]) {
+					eq++
+				} else {
+					fmt.Printf("%s and %s port rules are unequal\n", r.Port[i-1].Key, r.Port[i].Key)
+					break
+				}
+			}
+		}
+
+		if eq == len(trafficRuleSet)-1 {
+			printTable(trafficRuleSet, 0)
+		} else {
+			for portID, port := range r.Port {
+				fmt.Printf("\nPortKey:      %s\n", port.Key)
+				printTable(trafficRuleSet, portID)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	// Retrieve DVS reference
+	net, err := finder.Network(ctx, f.Arg(0))
+	if err != nil {
+		return err
+	}
+
+	// Convert to DVS object type
+	dvs, ok := net.(*object.DistributedVirtualSwitch)
+	if !ok {
+		return fmt.Errorf("%s (%s) is not a DVS", f.Arg(0), net.Reference().Type)
+	}
+
+	// Set base search criteria
+	criteria := types.DistributedVirtualSwitchPortCriteria{
+		Connected:  types.NewBool(cmd.connected),
+		Active:     types.NewBool(cmd.active),
+		UplinkPort: types.NewBool(cmd.uplinkPort),
+		Inside:     types.NewBool(cmd.inside),
+	}
+
+	// If a distributed virtual portgroup path is set, then add its portgroup key to the base criteria
+	if len(cmd.pg) > 0 {
+		// Retrieve distributed virtual portgroup reference
+		net, err = finder.Network(ctx, cmd.pg)
+		if err != nil {
+			return err
+		}
+
+		// Convert distributed virtual portgroup object type
+		dvpg, ok := net.(*object.DistributedVirtualPortgroup)
+		if !ok {
+			return fmt.Errorf("%s (%s) is not a DVPG", cmd.pg, net.Reference().Type)
+		}
+
+		// Obtain portgroup key property
+		var dvp mo.DistributedVirtualPortgroup
+		if err := dvpg.Properties(ctx, dvpg.Reference(), []string{"key"}, &dvp); err != nil {
+			return err
+		}
+
+		// Add portgroup key to port search criteria
+		criteria.PortgroupKey = []string{dvp.Key}
+	}
+
+	res, err := dvs.FetchDVPorts(ctx, &criteria)
+	if err != nil {
+		return err
+	}
+
+	// Truncate output to -count if specified
+	if cmd.count > 0 && cmd.count < len(res) {
+		res = res[:cmd.count]
+	}
+
+	info := infoResult{
+		cmd:  cmd,
+		Port: res,
+	}
+
+	return cmd.WriteResult(&info)
+}

--- a/vendor/github.com/vmware/govmomi/govc/dvs/portgroup/spec.go
+++ b/vendor/github.com/vmware/govmomi/govc/dvs/portgroup/spec.go
@@ -1,0 +1,55 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portgroup
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type DVPortgroupConfigSpec struct {
+	types.DVPortgroupConfigSpec
+}
+
+func (spec *DVPortgroupConfigSpec) Register(ctx context.Context, f *flag.FlagSet) {
+	ptypes := []string{
+		string(types.DistributedVirtualPortgroupPortgroupTypeEarlyBinding),
+		string(types.DistributedVirtualPortgroupPortgroupTypeLateBinding),
+		string(types.DistributedVirtualPortgroupPortgroupTypeEphemeral),
+	}
+
+	f.StringVar(&spec.Type, "type", ptypes[0],
+		fmt.Sprintf("Portgroup type (%s)", strings.Join(ptypes, "|")))
+
+	f.Var(flags.NewInt32(&spec.NumPorts), "nports", "Number of ports")
+
+	config := new(types.VMwareDVSPortSetting)
+	vlan := new(types.VmwareDistributedVirtualSwitchVlanIdSpec)
+	spec.DefaultPortConfig = config
+	config.Vlan = vlan
+
+	f.Var(flags.NewInt32(&vlan.VlanId), "vlan", "VLAN ID")
+}
+
+func (spec *DVPortgroupConfigSpec) Spec() types.DVPortgroupConfigSpec {
+	return spec.DVPortgroupConfigSpec
+}

--- a/vendor/github.com/vmware/govmomi/govc/env/command.go
+++ b/vendor/github.com/vmware/govmomi/govc/env/command.go
@@ -1,0 +1,103 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package env
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type env struct {
+	*flags.OutputFlag
+	*flags.ClientFlag
+
+	extra bool
+}
+
+func init() {
+	cli.Register("env", &env{})
+}
+
+func (cmd *env) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.extra, "x", false, "Output variables for each GOVC_URL component")
+}
+
+func (cmd *env) Process(ctx context.Context) error {
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *env) Description() string {
+	return `Output the environment variables for this client.
+
+If credentials are included in the url, they are split into separate variables.
+Useful as bash scripting helper to parse GOVC_URL.`
+}
+
+func (cmd *env) Run(ctx context.Context, f *flag.FlagSet) error {
+	env := envResult(cmd.ClientFlag.Environ(cmd.extra))
+
+	if f.NArg() > 1 {
+		return flag.ErrHelp
+	}
+
+	// Option to just output the value, example use:
+	// password=$(govc env GOVC_PASSWORD)
+	if f.NArg() == 1 {
+		var output []string
+
+		prefix := fmt.Sprintf("%s=", f.Arg(0))
+
+		for _, e := range env {
+			if strings.HasPrefix(e, prefix) {
+				output = append(output, e[len(prefix):])
+				break
+			}
+		}
+
+		return cmd.WriteResult(envResult(output))
+	}
+
+	return cmd.WriteResult(env)
+}
+
+type envResult []string
+
+func (r envResult) Write(w io.Writer) error {
+	for _, e := range r {
+		fmt.Println(e)
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/events/command.go
+++ b/vendor/github.com/vmware/govmomi/govc/events/command.go
@@ -1,0 +1,180 @@
+/*
+Copyright (c) 2015-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/vmware/govmomi/event"
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type events struct {
+	*flags.DatacenterFlag
+
+	Max   int32
+	Tail  bool
+	Force bool
+	Long  bool
+	Kind  kinds
+}
+
+type kinds []string
+
+func (e *kinds) String() string {
+	return fmt.Sprint(*e)
+}
+
+func (e *kinds) Set(value string) error {
+	*e = append(*e, value)
+	return nil
+}
+
+func init() {
+	// initialize with the maximum allowed objects set
+	cli.Register("events", &events{})
+}
+
+func (cmd *events) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	cmd.Max = 25 // default
+	f.Var(flags.NewInt32(&cmd.Max), "n", "Output the last N events")
+	f.BoolVar(&cmd.Tail, "f", false, "Follow event stream")
+	f.BoolVar(&cmd.Force, "force", false, "Disable number objects to monitor limit")
+	f.BoolVar(&cmd.Long, "l", false, "Long listing format")
+	f.Var(&cmd.Kind, "type", "Include only the specified event types")
+}
+
+func (cmd *events) Description() string {
+	return `Display events.
+
+Examples:
+  govc events vm/my-vm1 vm/my-vm2
+  govc events /dc1/vm/* /dc2/vm/*
+  govc events -type VmPoweredOffEvent -type VmPoweredOnEvent
+  govc ls -t HostSystem host/* | xargs govc events | grep -i vsan`
+}
+
+func (cmd *events) Usage() string {
+	return "[PATH]..."
+}
+
+func (cmd *events) printEvents(ctx context.Context, obj *types.ManagedObjectReference, page []types.BaseEvent, m *event.Manager) error {
+	event.Sort(page)
+	source := ""
+	if obj != nil {
+		source = obj.String()
+		if !cmd.JSON {
+			// print the object reference
+			fmt.Fprintf(os.Stdout, "\n==> %s <==\n", source)
+		}
+	}
+	for _, e := range page {
+		cat, err := m.EventCategory(ctx, e)
+		if err != nil {
+			return err
+		}
+
+		event := e.GetEvent()
+		r := &record{
+			Object:      source,
+			CreatedTime: event.CreatedTime,
+			Category:    cat,
+			Message:     strings.TrimSpace(event.FullFormattedMessage),
+			event:       e,
+		}
+
+		if cmd.Long {
+			r.Type = reflect.TypeOf(e).Elem().Name()
+		}
+
+		// if this is a TaskEvent gather a little more information
+		if t, ok := e.(*types.TaskEvent); ok {
+			// some tasks won't have this information, so just use the event message
+			if t.Info.Entity != nil {
+				r.Message = fmt.Sprintf("%s (target=%s %s)", r.Message, t.Info.Entity.Type, t.Info.EntityName)
+			}
+		}
+
+		if err = cmd.WriteResult(r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type record struct {
+	Object      string `json:",omitempty"`
+	Type        string `json:",omitempty"`
+	CreatedTime time.Time
+	Category    string
+	Message     string
+
+	event types.BaseEvent
+}
+
+// Dump the raw Event rather than the record struct.
+func (r *record) Dump() interface{} {
+	return r.event
+}
+
+func (r *record) Write(w io.Writer) error {
+	when := r.CreatedTime.Local().Format(time.ANSIC)
+	var kind string
+	if r.Type != "" {
+		kind = fmt.Sprintf(" [%s]", r.Type)
+	}
+	_, err := fmt.Fprintf(w, "[%s] [%s]%s %s\n", when, r.Category, kind, r.Message)
+	return err
+}
+
+func (cmd *events) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	objs, err := cmd.ManagedObjects(ctx, f.Args())
+	if err != nil {
+		return err
+	}
+
+	m := event.NewManager(c)
+
+	return cmd.WithCancel(ctx, func(wctx context.Context) error {
+		return m.Events(wctx, objs, cmd.Max, cmd.Tail, cmd.Force,
+			func(obj types.ManagedObjectReference, ee []types.BaseEvent) error {
+				var o *types.ManagedObjectReference
+				if len(objs) > 1 {
+					o = &obj
+				}
+
+				return cmd.printEvents(ctx, o, ee, m)
+			}, cmd.Kind...)
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/export/ovf.go
+++ b/vendor/github.com/vmware/govmomi/govc/export/ovf.go
@@ -1,0 +1,251 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package export
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"flag"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/nfc"
+	"github.com/vmware/govmomi/ovf"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ovfx struct {
+	*flags.VirtualMachineFlag
+
+	dest   string
+	name   string
+	force  bool
+	images bool
+	sha    int
+
+	mf bytes.Buffer
+}
+
+var sha = map[int]func() hash.Hash{
+	1:   sha1.New,
+	256: sha256.New,
+	512: sha512.New,
+}
+
+func init() {
+	cli.Register("export.ovf", &ovfx{})
+}
+
+func (cmd *ovfx) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.name, "name", "", "Specifies target name (defaults to source name)")
+	f.BoolVar(&cmd.force, "f", false, "Overwrite existing")
+	f.BoolVar(&cmd.images, "i", false, "Include image files (*.{iso,img})")
+	f.IntVar(&cmd.sha, "sha", 0, "Generate manifest using SHA 1, 256, 512 or 0 to skip")
+}
+
+func (cmd *ovfx) Usage() string {
+	return "DIR"
+}
+
+func (cmd *ovfx) Description() string {
+	return `Export VM.
+
+Examples:
+  govc export.ovf -vm $vm DIR`
+}
+
+func (cmd *ovfx) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ovfx) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		// TODO: output summary similar to ovftool's
+		return flag.ErrHelp
+	}
+
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	if cmd.sha != 0 {
+		if _, ok := sha[cmd.sha]; !ok {
+			return fmt.Errorf("unknown hash: sha%d", cmd.sha)
+		}
+	}
+
+	if cmd.name == "" {
+		cmd.name = vm.Name()
+	}
+
+	cmd.dest = filepath.Join(f.Arg(0), cmd.name)
+
+	target := filepath.Join(cmd.dest, cmd.name+".ovf")
+
+	if !cmd.force {
+		if _, err = os.Stat(target); err == nil {
+			return fmt.Errorf("file already exists: %s", target)
+		}
+	}
+
+	if err = os.MkdirAll(cmd.dest, 0750); err != nil {
+		return err
+	}
+
+	lease, err := vm.Export(ctx)
+	if err != nil {
+		return err
+	}
+
+	info, err := lease.Wait(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	u := lease.StartUpdater(ctx, info)
+	defer u.Done()
+
+	cdp := types.OvfCreateDescriptorParams{
+		Name: cmd.name,
+	}
+
+	for _, i := range info.Items {
+		if !cmd.include(&i) {
+			continue
+		}
+
+		if !strings.HasPrefix(i.Path, cmd.name) {
+			i.Path = cmd.name + "-" + i.Path
+		}
+
+		err = cmd.Download(ctx, lease, i)
+		if err != nil {
+			return err
+		}
+
+		cdp.OvfFiles = append(cdp.OvfFiles, i.File())
+	}
+
+	if err = lease.Complete(ctx); err != nil {
+		return err
+	}
+
+	m := ovf.NewManager(vm.Client())
+
+	desc, err := m.CreateDescriptor(ctx, vm, cdp)
+	if err != nil {
+		return err
+	}
+
+	file, err := os.Create(target)
+	if err != nil {
+		return err
+	}
+
+	var w io.Writer = file
+	h, ok := cmd.newHash()
+	if ok {
+		w = io.MultiWriter(file, h)
+	}
+
+	_, err = io.WriteString(w, desc.OvfDescriptor)
+	if err != nil {
+		return err
+	}
+
+	if err = file.Close(); err != nil {
+		return err
+	}
+
+	if cmd.sha == 0 {
+		return nil
+	}
+
+	cmd.addHash(filepath.Base(target), h)
+
+	file, err = os.Create(filepath.Join(cmd.dest, cmd.name+".mf"))
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(file, &cmd.mf)
+	if err != nil {
+		return err
+	}
+
+	return file.Close()
+}
+
+func (cmd *ovfx) include(item *nfc.FileItem) bool {
+	if cmd.images {
+		return true
+	}
+
+	return filepath.Ext(item.Path) == ".vmdk"
+}
+
+func (cmd *ovfx) newHash() (hash.Hash, bool) {
+	if h, ok := sha[cmd.sha]; ok {
+		return h(), true
+	}
+
+	return nil, false
+}
+
+func (cmd *ovfx) addHash(p string, h hash.Hash) {
+	_, _ = fmt.Fprintf(&cmd.mf, "SHA%d(%s)= %x\n", cmd.sha, p, h.Sum(nil))
+}
+
+func (cmd *ovfx) Download(ctx context.Context, lease *nfc.Lease, item nfc.FileItem) error {
+	path := filepath.Join(cmd.dest, item.Path)
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("Downloading %s... ", item.Path))
+	defer logger.Wait()
+
+	opts := soap.Download{
+		Progress: logger,
+	}
+
+	if h, ok := cmd.newHash(); ok {
+		opts.Writer = h
+
+		defer cmd.addHash(item.Path, h)
+	}
+
+	return lease.DownloadFile(ctx, path, item, opts)
+}

--- a/vendor/github.com/vmware/govmomi/govc/extension/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/extension/info.go
@@ -1,0 +1,120 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extension
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("extension.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *info) Usage() string {
+	return "[KEY]..."
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m, err := object.GetExtensionManager(c)
+	if err != nil {
+		return err
+	}
+
+	list, err := m.List(ctx)
+	if err != nil {
+		return err
+	}
+
+	var res infoResult
+
+	if f.NArg() == 0 {
+		res.Extensions = list
+	} else {
+		exts := make(map[string]types.Extension)
+		for _, e := range list {
+			exts[e.Key] = e
+		}
+
+		for _, key := range f.Args() {
+			if e, ok := exts[key]; ok {
+				res.Extensions = append(res.Extensions, e)
+			} else {
+				return fmt.Errorf("extension %s not found", key)
+			}
+		}
+	}
+
+	return cmd.WriteResult(&res)
+}
+
+type infoResult struct {
+	Extensions []types.Extension
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
+
+	for _, e := range r.Extensions {
+		fmt.Fprintf(tw, "Name:\t%s\n", e.Key)
+		fmt.Fprintf(tw, "  Version:\t%s\n", e.Version)
+		fmt.Fprintf(tw, "  Description:\t%s\n", e.Description.GetDescription().Summary)
+		fmt.Fprintf(tw, "  Company:\t%s\n", e.Company)
+		fmt.Fprintf(tw, "  Last heartbeat time:\t%s\n", e.LastHeartbeatTime)
+		fmt.Fprintf(tw, "  Subject name:\t%s\n", e.SubjectName)
+		fmt.Fprintf(tw, "  Type:\t%s\n", e.Type)
+	}
+
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/extension/register.go
+++ b/vendor/github.com/vmware/govmomi/govc/extension/register.go
@@ -1,0 +1,81 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extension
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"os"
+	"time"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type register struct {
+	*flags.ClientFlag
+
+	update bool
+}
+
+func init() {
+	cli.Register("extension.register", &register{})
+}
+
+func (cmd *register) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.update, "update", false, "Update extension")
+}
+
+func (cmd *register) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *register) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m, err := object.GetExtensionManager(c)
+	if err != nil {
+		return err
+	}
+
+	var e types.Extension
+	e.Description = new(types.Description)
+
+	if err = json.NewDecoder(os.Stdin).Decode(&e); err != nil {
+		return err
+	}
+
+	e.LastHeartbeatTime = time.Now().UTC()
+
+	if cmd.update {
+		return m.Update(ctx, e)
+	}
+
+	return m.Register(ctx, e)
+}

--- a/vendor/github.com/vmware/govmomi/govc/extension/setcert.go
+++ b/vendor/github.com/vmware/govmomi/govc/extension/setcert.go
@@ -1,0 +1,179 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extension
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type setcert struct {
+	*flags.ClientFlag
+
+	cert string
+	org  string
+
+	encodedCert bytes.Buffer
+}
+
+func init() {
+	cli.Register("extension.setcert", &setcert{})
+}
+
+func (cmd *setcert) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.cert, "cert-pem", "-", "PEM encoded certificate")
+	f.StringVar(&cmd.org, "org", "VMware", "Organization for generated certificate")
+}
+
+func (cmd *setcert) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *setcert) Usage() string {
+	return "ID"
+}
+
+func (cmd *setcert) Description() string {
+	return `Set certificate for the extension ID.
+
+The '-cert-pem' option can be one of the following:
+'-' : Read the certificate from stdin
+'+' : Generate a new key pair and save locally to ID.crt and ID.key
+... : Any other value is passed as-is to ExtensionManager.SetCertificate
+
+Examples:
+  govc extension.setcert -cert-pem + -org Example com.example.extname`
+}
+
+func (cmd *setcert) create(id string) error {
+	certFile, err := os.Create(id + ".crt")
+	if err != nil {
+		return err
+	}
+	defer certFile.Close()
+
+	keyFile, err := os.Create(id + ".key")
+	if err != nil {
+		return err
+	}
+	defer keyFile.Close()
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return err
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(5 * 365 * 24 * time.Hour) // 5 years
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{cmd.org},
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return err
+	}
+
+	err = pem.Encode(&cmd.encodedCert, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	if err != nil {
+		return err
+	}
+
+	_, err = certFile.Write(cmd.encodedCert.Bytes())
+	if err != nil {
+		return err
+	}
+
+	err = pem.Encode(keyFile, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cmd *setcert) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	key := f.Arg(0)
+
+	if cmd.cert == "-" {
+		b, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+		cmd.cert = string(b)
+	} else if strings.HasPrefix(cmd.cert, "+") {
+		if err := cmd.create(key); err != nil {
+			return fmt.Errorf("creating certificate: %s", err)
+		}
+		if cmd.cert == "++" {
+			return nil // just generate a cert, useful for testing
+		}
+		cmd.cert = cmd.encodedCert.String()
+	}
+
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m, err := object.GetExtensionManager(c)
+	if err != nil {
+		return err
+	}
+
+	return m.SetCertificate(ctx, key, cmd.cert)
+}

--- a/vendor/github.com/vmware/govmomi/govc/extension/unregister.go
+++ b/vendor/github.com/vmware/govmomi/govc/extension/unregister.go
@@ -1,0 +1,66 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extension
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type unregister struct {
+	*flags.ClientFlag
+}
+
+func init() {
+	cli.Register("extension.unregister", &unregister{})
+}
+
+func (cmd *unregister) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+}
+
+func (cmd *unregister) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *unregister) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m, err := object.GetExtensionManager(c)
+	if err != nil {
+		return err
+	}
+
+	for _, key := range f.Args() {
+		if err = m.Unregister(ctx, key); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/fields/add.go
+++ b/vendor/github.com/vmware/govmomi/govc/fields/add.go
@@ -1,0 +1,82 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fields
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type add struct {
+	*flags.ClientFlag
+	kind string
+}
+
+func init() {
+	cli.Register("fields.add", &add{})
+}
+
+func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.kind, "type", "", "Managed object type")
+}
+
+func (cmd *add) Usage() string {
+	return "NAME"
+}
+
+func (cmd *add) Description() string {
+	return `Add a custom field type with NAME.
+
+Examples:
+  govc fields.add my-field-name # adds a field to all managed object types
+  govc fields.add -type VirtualMachine my-vm-field-name # adds a field to the VirtualMachine type`
+}
+
+func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m, err := object.GetCustomFieldsManager(c)
+	if err != nil {
+		return err
+	}
+
+	name := f.Arg(0)
+
+	def, err := m.Add(ctx, name, cmd.kind, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%d\n", def.Key)
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/fields/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/fields/info.go
@@ -1,0 +1,170 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fields
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*flags.DatacenterFlag
+
+	name string
+}
+
+func init() {
+	cli.Register("fields.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.name, "n", "", "Filter by custom field name")
+}
+
+func (cmd *info) Usage() string {
+	return "PATH..."
+}
+
+func (cmd *info) Description() string {
+	return `Display custom field values for PATH.
+
+Also known as "Custom Attributes".
+
+Examples:
+  govc fields.info vm/*
+  govc fields.info -n my-field-name vm/*`
+}
+
+type Info struct {
+	Object types.ManagedObjectReference
+	Path   string
+	Name   string
+	Key    string
+	Value  string
+}
+
+type infoResult struct {
+	Info []Info
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
+
+	for _, info := range r.Info {
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\n", info.Path, info.Key, info.Value)
+	}
+
+	return tw.Flush()
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m, err := object.GetCustomFieldsManager(c)
+	if err != nil {
+		return err
+	}
+
+	paths := make(map[types.ManagedObjectReference]string)
+	var refs []types.ManagedObjectReference
+
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	for _, arg := range f.Args() {
+		elements, ferr := finder.ManagedObjectList(ctx, arg)
+		if ferr != nil {
+			return ferr
+		}
+
+		if len(elements) == 0 {
+			return fmt.Errorf("object '%s' not found", arg)
+		}
+
+		for _, e := range elements {
+			ref := e.Object.Reference()
+			refs = append(refs, ref)
+			paths[ref] = e.Path
+		}
+	}
+
+	var objs []mo.ManagedEntity
+	err = property.DefaultCollector(c).Retrieve(ctx, refs, []string{"name", "customValue"}, &objs)
+	if err != nil {
+		return err
+	}
+
+	matches := func(key int32) bool {
+		return true
+	}
+
+	if cmd.name != "" {
+		fkey, cerr := m.FindKey(ctx, cmd.name)
+		if cerr != nil {
+			return err
+		}
+		matches = func(key int32) bool {
+			return key == fkey
+		}
+	}
+
+	field, err := m.Field(ctx)
+	if err != nil {
+		return err
+	}
+
+	var res infoResult
+
+	for _, obj := range objs {
+		for i := range obj.CustomValue {
+			val := obj.CustomValue[i].(*types.CustomFieldStringValue)
+
+			if !matches(val.Key) {
+				continue
+			}
+
+			res.Info = append(res.Info, Info{
+				Object: obj.Self,
+				Path:   paths[obj.Self],
+				Name:   obj.Name,
+				Key:    field.ByKey(val.Key).Name,
+				Value:  val.Value,
+			})
+		}
+	}
+
+	return cmd.WriteResult(&res)
+}

--- a/vendor/github.com/vmware/govmomi/govc/fields/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/fields/ls.go
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fields
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type ls struct {
+	*flags.ClientFlag
+	kind string
+}
+
+func init() {
+	cli.Register("fields.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.kind, "type", "", "Filter by a Managed Object Type")
+}
+
+func (cmd *ls) Description() string {
+	return `List custom field definitions.
+
+Examples:
+  govc fields.ls
+  govc fields.ls -type VirtualMachine`
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m, err := object.GetCustomFieldsManager(c)
+	if err != nil {
+		return err
+	}
+
+	field, err := m.Field(ctx)
+	if err != nil {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(os.Stdout, 3, 0, 2, ' ', 0)
+
+	for _, def := range field {
+		if cmd.kind == "" || cmd.kind == def.ManagedObjectType {
+			fmt.Fprintf(tw, "%d\t%s\t%s\n", def.Key, def.Name, def.ManagedObjectType)
+		}
+	}
+
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/fields/rename.go
+++ b/vendor/github.com/vmware/govmomi/govc/fields/rename.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fields
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type rename struct {
+	*flags.ClientFlag
+}
+
+func init() {
+	cli.Register("fields.rename", &rename{})
+}
+
+func (cmd *rename) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+}
+
+func (cmd *rename) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *rename) Usage() string {
+	return "KEY NAME"
+}
+
+func (cmd *rename) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 2 {
+		return flag.ErrHelp
+	}
+
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m, err := object.GetCustomFieldsManager(c)
+	if err != nil {
+		return err
+	}
+
+	key, err := m.FindKey(ctx, f.Arg(0))
+	if err != nil {
+		return err
+	}
+
+	name := f.Arg(1)
+
+	return m.Rename(ctx, key, name)
+}

--- a/vendor/github.com/vmware/govmomi/govc/fields/rm.go
+++ b/vendor/github.com/vmware/govmomi/govc/fields/rm.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fields
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type rm struct {
+	*flags.ClientFlag
+}
+
+func init() {
+	cli.Register("fields.rm", &rm{})
+}
+
+func (cmd *rm) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+}
+
+func (cmd *rm) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *rm) Usage() string {
+	return "KEY..."
+}
+
+func (cmd *rm) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m, err := object.GetCustomFieldsManager(c)
+	if err != nil {
+		return err
+	}
+
+	for _, name := range f.Args() {
+		key, err := m.FindKey(ctx, name)
+		if err != nil {
+			return err
+		}
+
+		if err := m.Remove(ctx, key); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/fields/set.go
+++ b/vendor/github.com/vmware/govmomi/govc/fields/set.go
@@ -1,0 +1,112 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fields
+
+import (
+	"context"
+	"flag"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type set struct {
+	*flags.DatacenterFlag
+	add  bool
+	kind string
+}
+
+func init() {
+	cli.Register("fields.set", &set{})
+}
+
+func (cmd *set) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.kind, "type", "", "Managed object type on which to add "+
+		"the field if it does not exist. This flag is ignored unless -add=true")
+	f.BoolVar(&cmd.add, "add", false, "Adds the field if it does not exist. "+
+		"Use the -type flag to specify the managed object type to which the "+
+		"field is added. Using -add and omitting -kind causes a new, global "+
+		"field to be created if a field with the provided name does not "+
+		"already exist.")
+}
+
+func (cmd *set) Usage() string {
+	return "KEY VALUE PATH..."
+}
+
+func (cmd *set) Description() string {
+	return `Set custom field values for PATH.
+
+Examples:
+  govc fields.set my-field-name field-value vm/my-vm
+  govc fields.set -add my-new-global-field-name field-value vm/my-vm
+  govc fields.set -add -type VirtualMachine my-new-vm-field-name field-value vm/my-vm`
+}
+
+func (cmd *set) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() < 3 {
+		return flag.ErrHelp
+	}
+
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m, err := object.GetCustomFieldsManager(c)
+	if err != nil {
+		return err
+	}
+
+	args := f.Args()
+
+	key, err := m.FindKey(ctx, args[0])
+	if err != nil {
+		if !(cmd.add && strings.Contains(err.Error(), "key name not found")) {
+			return err
+		}
+		// Add the missing field.
+		def, err := m.Add(ctx, args[0], cmd.kind, nil, nil)
+		if err != nil {
+			return err
+		}
+		// Assign the new field's key to the "key" var used below when
+		// setting the key/value pair on the provided list of objects.
+		key = def.Key
+	}
+
+	val := args[1]
+
+	objs, err := cmd.ManagedObjects(ctx, args[2:])
+	if err != nil {
+		return err
+	}
+
+	for _, ref := range objs {
+		err := m.Set(ctx, ref, key, val)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/client.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/client.go
@@ -1,0 +1,711 @@
+/*
+Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"context"
+	"crypto/sha1"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/sts"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+const (
+	envURL           = "GOVC_URL"
+	envUsername      = "GOVC_USERNAME"
+	envPassword      = "GOVC_PASSWORD"
+	envCertificate   = "GOVC_CERTIFICATE"
+	envPrivateKey    = "GOVC_PRIVATE_KEY"
+	envInsecure      = "GOVC_INSECURE"
+	envPersist       = "GOVC_PERSIST_SESSION"
+	envMinAPIVersion = "GOVC_MIN_API_VERSION"
+	envVimNamespace  = "GOVC_VIM_NAMESPACE"
+	envVimVersion    = "GOVC_VIM_VERSION"
+	envTLSCaCerts    = "GOVC_TLS_CA_CERTS"
+	envTLSKnownHosts = "GOVC_TLS_KNOWN_HOSTS"
+
+	defaultMinVimVersion = "5.5"
+)
+
+const cDescr = "ESX or vCenter URL"
+
+type ClientFlag struct {
+	common
+
+	*DebugFlag
+
+	url           *url.URL
+	username      string
+	password      string
+	cert          string
+	key           string
+	insecure      bool
+	persist       bool
+	minAPIVersion string
+	vimNamespace  string
+	vimVersion    string
+	tlsCaCerts    string
+	tlsKnownHosts string
+	client        *vim25.Client
+
+	Login func(context.Context, *vim25.Client) error
+}
+
+var (
+	home          = os.Getenv("GOVMOMI_HOME")
+	clientFlagKey = flagKey("client")
+)
+
+func init() {
+	if home == "" {
+		home = filepath.Join(os.Getenv("HOME"), ".govmomi")
+	}
+}
+
+func NewClientFlag(ctx context.Context) (*ClientFlag, context.Context) {
+	if v := ctx.Value(clientFlagKey); v != nil {
+		return v.(*ClientFlag), ctx
+	}
+
+	v := &ClientFlag{}
+	v.Login = v.login
+	v.DebugFlag, ctx = NewDebugFlag(ctx)
+	ctx = context.WithValue(ctx, clientFlagKey, v)
+	return v, ctx
+}
+
+func (flag *ClientFlag) URLWithoutPassword() *url.URL {
+	if flag.url == nil {
+		return nil
+	}
+
+	withoutCredentials := *flag.url
+	withoutCredentials.User = url.User(flag.url.User.Username())
+	return &withoutCredentials
+}
+
+func (flag *ClientFlag) Userinfo() *url.Userinfo {
+	return flag.url.User
+}
+
+func (flag *ClientFlag) IsSecure() bool {
+	return !flag.insecure
+}
+
+func (flag *ClientFlag) String() string {
+	url := flag.URLWithoutPassword()
+	if url == nil {
+		return ""
+	}
+
+	return url.String()
+}
+
+func (flag *ClientFlag) Set(s string) error {
+	var err error
+
+	flag.url, err = soap.ParseURL(s)
+
+	return err
+}
+
+func (flag *ClientFlag) Register(ctx context.Context, f *flag.FlagSet) {
+	flag.RegisterOnce(func() {
+		flag.DebugFlag.Register(ctx, f)
+
+		{
+			flag.Set(os.Getenv(envURL))
+			usage := fmt.Sprintf("%s [%s]", cDescr, envURL)
+			f.Var(flag, "u", usage)
+		}
+
+		{
+			flag.username = os.Getenv(envUsername)
+			flag.password = os.Getenv(envPassword)
+		}
+
+		{
+			value := os.Getenv(envCertificate)
+			usage := fmt.Sprintf("Certificate [%s]", envCertificate)
+			f.StringVar(&flag.cert, "cert", value, usage)
+		}
+
+		{
+			value := os.Getenv(envPrivateKey)
+			usage := fmt.Sprintf("Private key [%s]", envPrivateKey)
+			f.StringVar(&flag.key, "key", value, usage)
+		}
+
+		{
+			insecure := false
+			switch env := strings.ToLower(os.Getenv(envInsecure)); env {
+			case "1", "true":
+				insecure = true
+			}
+
+			usage := fmt.Sprintf("Skip verification of server certificate [%s]", envInsecure)
+			f.BoolVar(&flag.insecure, "k", insecure, usage)
+		}
+
+		{
+			persist := true
+			switch env := strings.ToLower(os.Getenv(envPersist)); env {
+			case "0", "false":
+				persist = false
+			}
+
+			usage := fmt.Sprintf("Persist session to disk [%s]", envPersist)
+			f.BoolVar(&flag.persist, "persist-session", persist, usage)
+		}
+
+		{
+			env := os.Getenv(envMinAPIVersion)
+			if env == "" {
+				env = defaultMinVimVersion
+			}
+
+			flag.minAPIVersion = env
+		}
+
+		{
+			value := os.Getenv(envVimNamespace)
+			if value == "" {
+				value = vim25.Namespace
+			}
+			usage := fmt.Sprintf("Vim namespace [%s]", envVimNamespace)
+			f.StringVar(&flag.vimNamespace, "vim-namespace", value, usage)
+		}
+
+		{
+			value := os.Getenv(envVimVersion)
+			if value == "" {
+				value = vim25.Version
+			}
+			usage := fmt.Sprintf("Vim version [%s]", envVimVersion)
+			f.StringVar(&flag.vimVersion, "vim-version", value, usage)
+		}
+
+		{
+			value := os.Getenv(envTLSCaCerts)
+			usage := fmt.Sprintf("TLS CA certificates file [%s]", envTLSCaCerts)
+			f.StringVar(&flag.tlsCaCerts, "tls-ca-certs", value, usage)
+		}
+
+		{
+			value := os.Getenv(envTLSKnownHosts)
+			usage := fmt.Sprintf("TLS known hosts file [%s]", envTLSKnownHosts)
+			f.StringVar(&flag.tlsKnownHosts, "tls-known-hosts", value, usage)
+		}
+	})
+}
+
+func (flag *ClientFlag) Process(ctx context.Context) error {
+	return flag.ProcessOnce(func() error {
+		err := flag.DebugFlag.Process(ctx)
+		if err != nil {
+			return err
+		}
+
+		if flag.url == nil {
+			return errors.New("specify an " + cDescr)
+		}
+
+		flag.username, err = session.Secret(flag.username)
+		if err != nil {
+			return err
+		}
+		flag.password, err = session.Secret(flag.password)
+		if err != nil {
+			return err
+		}
+
+		// Override username if set
+		if flag.username != "" {
+			var password string
+			var ok bool
+
+			if flag.url.User != nil {
+				password, ok = flag.url.User.Password()
+			}
+
+			if ok {
+				flag.url.User = url.UserPassword(flag.username, password)
+			} else {
+				flag.url.User = url.User(flag.username)
+			}
+		}
+
+		// Override password if set
+		if flag.password != "" {
+			var username string
+
+			if flag.url.User != nil {
+				username = flag.url.User.Username()
+			}
+
+			flag.url.User = url.UserPassword(username, flag.password)
+		}
+
+		return nil
+	})
+}
+
+// configure TLS and retry settings before making any connections
+func (flag *ClientFlag) configure(sc *soap.Client) (soap.RoundTripper, error) {
+	if flag.cert != "" {
+		cert, err := tls.LoadX509KeyPair(flag.cert, flag.key)
+		if err != nil {
+			return nil, fmt.Errorf("%s=%q %s=%q: %s", envCertificate, flag.cert, envPrivateKey, flag.key, err)
+		}
+
+		sc.SetCertificate(cert)
+	}
+
+	// Set namespace and version
+	sc.Namespace = "urn:" + flag.vimNamespace
+	sc.Version = flag.vimVersion
+
+	sc.UserAgent = fmt.Sprintf("govc/%s", Version)
+
+	if err := flag.SetRootCAs(sc); err != nil {
+		return nil, err
+	}
+
+	if err := sc.LoadThumbprints(flag.tlsKnownHosts); err != nil {
+		return nil, err
+	}
+
+	if t, ok := sc.Transport.(*http.Transport); ok {
+		var err error
+
+		value := os.Getenv("GOVC_TLS_HANDSHAKE_TIMEOUT")
+		if value != "" {
+			t.TLSHandshakeTimeout, err = time.ParseDuration(value)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// Retry twice when a temporary I/O error occurs.
+	// This means a maximum of 3 attempts.
+	return vim25.Retry(sc, vim25.TemporaryNetworkError(3)), nil
+}
+
+func (flag *ClientFlag) sessionFile() string {
+	url := flag.URLWithoutPassword()
+
+	// Key session file off of full URI and insecure setting.
+	// Hash key to get a predictable, canonical format.
+	key := fmt.Sprintf("%s#insecure=%t", url.String(), flag.insecure)
+	name := fmt.Sprintf("%040x", sha1.Sum([]byte(key)))
+	return filepath.Join(home, "sessions", name)
+}
+
+func (flag *ClientFlag) saveClient(c *vim25.Client) error {
+	if !flag.persist {
+		return nil
+	}
+
+	p := flag.sessionFile()
+	err := os.MkdirAll(filepath.Dir(p), 0700)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(p, os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	err = json.NewEncoder(f).Encode(c)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (flag *ClientFlag) restoreClient(c *vim25.Client) (bool, error) {
+	if !flag.persist {
+		return false, nil
+	}
+
+	f, err := os.Open(flag.sessionFile())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	defer f.Close()
+
+	dec := json.NewDecoder(f)
+	err = dec.Decode(c)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (flag *ClientFlag) loadClient() (*vim25.Client, error) {
+	c := new(vim25.Client)
+	ok, err := flag.restoreClient(c)
+	if err != nil {
+		return nil, err
+	}
+
+	if !ok || !c.Valid() {
+		return nil, nil
+	}
+
+	c.RoundTripper, err = flag.configure(c.Client)
+	if err != nil {
+		return nil, err
+	}
+
+	m := session.NewManager(c)
+	u, err := m.UserSession(context.TODO())
+	if err != nil {
+		if soap.IsSoapFault(err) {
+			fault := soap.ToSoapFault(err).VimFault()
+			// If the PropertyCollector is not found, the saved session for this URL is not valid
+			if _, ok := fault.(types.ManagedObjectNotFound); ok {
+				return nil, nil
+			}
+		}
+
+		return nil, err
+	}
+
+	// If the session is nil, the client is not authenticated
+	if u == nil {
+		return nil, nil
+	}
+
+	return c, nil
+}
+
+func (flag *ClientFlag) SetRootCAs(c *soap.Client) error {
+	if flag.tlsCaCerts != "" {
+		return c.SetRootCAs(flag.tlsCaCerts)
+	}
+	return nil
+}
+
+func (flag *ClientFlag) login(ctx context.Context, c *vim25.Client) error {
+	m := session.NewManager(c)
+	u := flag.url.User
+	name := u.Username()
+
+	if name == "" && !c.IsVC() {
+		// If no username is provided, try to acquire a local ticket.
+		// When invoked remotely, ESX returns an InvalidRequestFault.
+		// So, rather than return an error here, fallthrough to Login() with the original User to
+		// to avoid what would be a confusing error message.
+		luser, lerr := flag.localTicket(ctx, m)
+		if lerr == nil {
+			// We are running directly on an ESX or Workstation host and can use the ticket with Login()
+			u = luser
+			name = u.Username()
+		}
+	}
+	if name == "" {
+		// Skip auto-login if we don't have a username
+		flag.persist = true // Not persisting, but this avoids the call to Logout()
+		return nil          // Avoid SaveSession for non-authenticated session
+	}
+
+	return m.Login(ctx, u)
+}
+
+func (flag *ClientFlag) newClient() (*vim25.Client, error) {
+	ctx := context.TODO()
+	sc := soap.NewClient(flag.url, flag.insecure)
+
+	rt, err := flag.configure(sc)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := vim25.NewClient(ctx, rt)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set client, since we didn't pass it in the constructor
+	c.Client = sc
+
+	if flag.vimVersion == "" {
+		if err = c.UseServiceVersion(); err != nil {
+			return nil, err
+		}
+		flag.vimVersion = c.Version
+	}
+
+	if err := flag.Login(ctx, c); err != nil {
+		return nil, err
+	}
+
+	return c, flag.saveClient(c)
+}
+
+func (flag *ClientFlag) localTicket(ctx context.Context, m *session.Manager) (*url.Userinfo, error) {
+	ticket, err := m.AcquireLocalTicket(ctx, os.Getenv("USER"))
+	if err != nil {
+		return nil, err
+	}
+
+	password, err := ioutil.ReadFile(ticket.PasswordFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return url.UserPassword(ticket.UserName, string(password)), nil
+}
+
+func isDevelopmentVersion(apiVersion string) bool {
+	// Skip version check for development builds which can be in the form of "r4A70F" or "6.5.x"
+	return strings.Count(apiVersion, ".") == 0 || strings.HasSuffix(apiVersion, ".x")
+}
+
+// apiVersionValid returns whether or not the API version supported by the
+// server the client is connected to is not recent enough.
+func apiVersionValid(c *vim25.Client, minVersionString string) error {
+	if minVersionString == "-" {
+		// Disable version check
+		return nil
+	}
+
+	apiVersion := c.ServiceContent.About.ApiVersion
+	if isDevelopmentVersion(apiVersion) {
+		return nil
+	}
+
+	realVersion, err := ParseVersion(apiVersion)
+	if err != nil {
+		return fmt.Errorf("error parsing API version %q: %s", apiVersion, err)
+	}
+
+	minVersion, err := ParseVersion(minVersionString)
+	if err != nil {
+		return fmt.Errorf("error parsing %s=%q: %s", envMinAPIVersion, minVersionString, err)
+	}
+
+	if !minVersion.Lte(realVersion) {
+		err = fmt.Errorf("require API version %q, connected to API version %q (set %s to override)",
+			minVersionString,
+			c.ServiceContent.About.ApiVersion,
+			envMinAPIVersion)
+		return err
+	}
+
+	return nil
+}
+
+func (flag *ClientFlag) Client() (*vim25.Client, error) {
+	if flag.client != nil {
+		return flag.client, nil
+	}
+
+	c, err := flag.loadClient()
+	if err != nil {
+		return nil, err
+	}
+
+	// loadClient returns nil if it was unable to load a session from disk
+	if c == nil {
+		c, err = flag.newClient()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Check that the endpoint has the right API version
+	err = apiVersionValid(c, flag.minAPIVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	flag.client = c
+	return flag.client, nil
+}
+
+func (flag *ClientFlag) Logout(ctx context.Context) error {
+	if flag.persist || flag.client == nil {
+		return nil
+	}
+
+	m := session.NewManager(flag.client)
+
+	return m.Logout(ctx)
+}
+
+func (flag *ClientFlag) WithRestClient(ctx context.Context, f func(*rest.Client) error) error {
+	vc, err := flag.Client()
+	if err != nil {
+		return err
+	}
+
+	c := rest.NewClient(vc)
+	if err != nil {
+		return err
+	}
+
+	// TODO: rest.Client session cookie should be persisted as the soap.Client session cookie is.
+	if vc.Certificate() == nil {
+		if err = c.Login(ctx, flag.Userinfo()); err != nil {
+			return err
+		}
+	} else {
+		// TODO: session.login should support rest.Client SSO login to avoid this env var (depends on the TODO above)
+		token := os.Getenv("GOVC_LOGIN_TOKEN")
+		if token == "" {
+			return errors.New("GOVC_LOGIN_TOKEN must be set for rest.Client SSO login")
+		}
+		signer := &sts.Signer{
+			Certificate: c.Certificate(),
+			Token:       token,
+		}
+
+		if err = c.LoginByToken(c.WithSigner(ctx, signer)); err != nil {
+			return err
+		}
+	}
+
+	defer func() {
+		if err := c.Logout(ctx); err != nil {
+			log.Printf("user logout error: %v", err)
+		}
+	}()
+
+	return f(c)
+}
+
+// Environ returns the govc environment variables for this connection
+func (flag *ClientFlag) Environ(extra bool) []string {
+	var env []string
+	add := func(k, v string) {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	u := *flag.url
+	if u.User != nil {
+		add(envUsername, u.User.Username())
+
+		if p, ok := u.User.Password(); ok {
+			add(envPassword, p)
+		}
+
+		u.User = nil
+	}
+
+	if u.Path == vim25.Path {
+		u.Path = ""
+	}
+	u.Fragment = ""
+	u.RawQuery = ""
+
+	add(envURL, strings.TrimPrefix(u.String(), "https://"))
+
+	keys := []string{
+		envCertificate,
+		envPrivateKey,
+		envInsecure,
+		envPersist,
+		envMinAPIVersion,
+		envVimNamespace,
+		envVimVersion,
+	}
+
+	for _, k := range keys {
+		if v := os.Getenv(k); v != "" {
+			add(k, v)
+		}
+	}
+
+	if extra {
+		add("GOVC_URL_SCHEME", flag.url.Scheme)
+
+		v := strings.SplitN(u.Host, ":", 2)
+		add("GOVC_URL_HOST", v[0])
+		if len(v) == 2 {
+			add("GOVC_URL_PORT", v[1])
+		}
+
+		add("GOVC_URL_PATH", flag.url.Path)
+
+		if f := flag.url.Fragment; f != "" {
+			add("GOVC_URL_FRAGMENT", f)
+		}
+
+		if q := flag.url.RawQuery; q != "" {
+			add("GOVC_URL_QUERY", q)
+		}
+	}
+
+	return env
+}
+
+// WithCancel calls the given function, returning when complete or canceled via SIGINT.
+func (flag *ClientFlag) WithCancel(ctx context.Context, f func(context.Context) error) error {
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT)
+
+	wctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	done := make(chan bool)
+	var werr error
+
+	go func() {
+		defer close(done)
+		werr = f(wctx)
+	}()
+
+	select {
+	case <-sig:
+		cancel()
+		<-done // Wait for f() to complete
+	case <-done:
+	}
+
+	return werr
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/cluster.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/cluster.go
@@ -1,0 +1,204 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/view"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ClusterFlag struct {
+	common
+
+	*DatacenterFlag
+
+	Name string
+
+	cluster *object.ClusterComputeResource
+	pc      *property.Collector
+}
+
+var clusterFlagKey = flagKey("cluster")
+
+func NewClusterFlag(ctx context.Context) (*ClusterFlag, context.Context) {
+	if v := ctx.Value(clusterFlagKey); v != nil {
+		return v.(*ClusterFlag), ctx
+	}
+
+	v := &ClusterFlag{}
+	v.DatacenterFlag, ctx = NewDatacenterFlag(ctx)
+	ctx = context.WithValue(ctx, clusterFlagKey, v)
+	return v, ctx
+}
+
+func (f *ClusterFlag) Register(ctx context.Context, fs *flag.FlagSet) {
+	f.RegisterOnce(func() {
+		f.DatacenterFlag.Register(ctx, fs)
+
+		env := "GOVC_CLUSTER"
+		value := os.Getenv(env)
+		usage := fmt.Sprintf("Cluster [%s]", env)
+		fs.StringVar(&f.Name, "cluster", value, usage)
+	})
+}
+
+// RegisterPlacement registers the -cluster flag without using GOVC_CLUSTER env as the default value,
+// usage is specific to VM placement.
+func (f *ClusterFlag) RegisterPlacement(ctx context.Context, fs *flag.FlagSet) {
+	f.RegisterOnce(func() {
+		f.DatacenterFlag.Register(ctx, fs)
+
+		fs.StringVar(&f.Name, "cluster", "", "Use cluster for VM placement via DRS")
+	})
+}
+
+func (f *ClusterFlag) Process(ctx context.Context) error {
+	return f.ProcessOnce(func() error {
+		if err := f.DatacenterFlag.Process(ctx); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func (f *ClusterFlag) Cluster() (*object.ClusterComputeResource, error) {
+	if f.cluster != nil {
+		return f.cluster, nil
+	}
+
+	finder, err := f.Finder()
+	if err != nil {
+		return nil, err
+	}
+
+	if f.cluster, err = finder.ClusterComputeResourceOrDefault(context.TODO(), f.Name); err != nil {
+		return nil, err
+	}
+
+	f.pc = property.DefaultCollector(f.cluster.Client())
+
+	return f.cluster, nil
+}
+
+func (f *ClusterFlag) ClusterIfSpecified() (*object.ClusterComputeResource, error) {
+	if f.Name == "" {
+		return nil, nil
+	}
+	return f.Cluster()
+}
+
+func (f *ClusterFlag) Reconfigure(ctx context.Context, spec types.BaseComputeResourceConfigSpec) error {
+	cluster, err := f.Cluster()
+	if err != nil {
+		return err
+	}
+
+	task, err := cluster.Reconfigure(ctx, spec, true)
+	if err != nil {
+		return err
+	}
+
+	logger := f.ProgressLogger(fmt.Sprintf("Reconfigure %s...", cluster.InventoryPath))
+	defer logger.Wait()
+
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}
+
+func (f *ClusterFlag) objectMap(ctx context.Context, kind string, names []string) (map[string]types.ManagedObjectReference, error) {
+	cluster, err := f.Cluster()
+	if err != nil {
+		return nil, err
+	}
+
+	objects := make(map[string]types.ManagedObjectReference, len(names))
+	for _, name := range names {
+		objects[name] = types.ManagedObjectReference{}
+	}
+
+	m := view.NewManager(cluster.Client())
+	v, err := m.CreateContainerView(ctx, cluster.Reference(), []string{kind}, true)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		_ = v.Destroy(ctx)
+	}()
+
+	var entities []mo.ManagedEntity
+
+	err = v.Retrieve(ctx, []string{"ManagedEntity"}, []string{"name"}, &entities)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, e := range entities {
+		if _, ok := objects[e.Name]; ok {
+			objects[e.Name] = e.Self
+		}
+	}
+
+	for name, ref := range objects {
+		if ref.Value == "" {
+			return nil, fmt.Errorf("%s %q not found", kind, name)
+		}
+	}
+
+	return objects, nil
+}
+
+func (f *ClusterFlag) ObjectList(ctx context.Context, kind string, names []string) ([]types.ManagedObjectReference, error) {
+	objs, err := f.objectMap(ctx, kind, names)
+	if err != nil {
+		return nil, err
+	}
+
+	var refs []types.ManagedObjectReference
+
+	for _, name := range names { // preserve order
+		refs = append(refs, objs[name])
+	}
+
+	return refs, nil
+}
+
+func (f *ClusterFlag) Names(ctx context.Context, refs []types.ManagedObjectReference) (map[types.ManagedObjectReference]string, error) {
+	names := make(map[types.ManagedObjectReference]string, len(refs))
+
+	if len(refs) != 0 {
+		var objs []mo.ManagedEntity
+		err := f.pc.Retrieve(ctx, refs, []string{"name"}, &objs)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, obj := range objs {
+			names[obj.Self] = obj.Name
+		}
+	}
+
+	return names, nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/common.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/common.go
@@ -1,0 +1,38 @@
+/*
+Copyright (c) 2015-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package flags
+
+import "sync"
+
+// Key type for storing flag instances in a context.Context.
+type flagKey string
+
+// Type to help flags out with only registering/processing once.
+type common struct {
+	register sync.Once
+	process  sync.Once
+}
+
+func (c *common) RegisterOnce(fn func()) {
+	c.register.Do(fn)
+}
+
+func (c *common) ProcessOnce(fn func() error) (err error) {
+	c.process.Do(func() {
+		err = fn()
+	})
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/datacenter.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/datacenter.go
@@ -1,0 +1,221 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type DatacenterFlag struct {
+	common
+
+	*ClientFlag
+	*OutputFlag
+
+	Name   string
+	dc     *object.Datacenter
+	finder *find.Finder
+	err    error
+}
+
+var datacenterFlagKey = flagKey("datacenter")
+
+func NewDatacenterFlag(ctx context.Context) (*DatacenterFlag, context.Context) {
+	if v := ctx.Value(datacenterFlagKey); v != nil {
+		return v.(*DatacenterFlag), ctx
+	}
+
+	v := &DatacenterFlag{}
+	v.ClientFlag, ctx = NewClientFlag(ctx)
+	v.OutputFlag, ctx = NewOutputFlag(ctx)
+	ctx = context.WithValue(ctx, datacenterFlagKey, v)
+	return v, ctx
+}
+
+func (flag *DatacenterFlag) Register(ctx context.Context, f *flag.FlagSet) {
+	flag.RegisterOnce(func() {
+		flag.ClientFlag.Register(ctx, f)
+		flag.OutputFlag.Register(ctx, f)
+
+		env := "GOVC_DATACENTER"
+		value := os.Getenv(env)
+		usage := fmt.Sprintf("Datacenter [%s]", env)
+		f.StringVar(&flag.Name, "dc", value, usage)
+	})
+}
+
+func (flag *DatacenterFlag) Process(ctx context.Context) error {
+	return flag.ProcessOnce(func() error {
+		if err := flag.ClientFlag.Process(ctx); err != nil {
+			return err
+		}
+		if err := flag.OutputFlag.Process(ctx); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func (flag *DatacenterFlag) Finder(all ...bool) (*find.Finder, error) {
+	if flag.finder != nil {
+		return flag.finder, nil
+	}
+
+	c, err := flag.Client()
+	if err != nil {
+		return nil, err
+	}
+
+	allFlag := false
+	if len(all) == 1 {
+		allFlag = all[0]
+	}
+	finder := find.NewFinder(c, allFlag)
+
+	// Datacenter is not required (ls command for example).
+	// Set for relative func if dc flag is given or
+	// if there is a single (default) Datacenter
+	ctx := context.TODO()
+	if flag.Name == "" {
+		flag.dc, flag.err = finder.DefaultDatacenter(ctx)
+	} else {
+		if flag.dc, err = finder.Datacenter(ctx, flag.Name); err != nil {
+			return nil, err
+		}
+	}
+
+	finder.SetDatacenter(flag.dc)
+
+	flag.finder = finder
+
+	return flag.finder, nil
+}
+
+func (flag *DatacenterFlag) Datacenter() (*object.Datacenter, error) {
+	if flag.dc != nil {
+		return flag.dc, nil
+	}
+
+	_, err := flag.Finder()
+	if err != nil {
+		return nil, err
+	}
+
+	if flag.err != nil {
+		// Should only happen if no dc is specified and len(dcs) > 1
+		return nil, flag.err
+	}
+
+	return flag.dc, err
+}
+
+func (flag *DatacenterFlag) DatacenterIfSpecified() (*object.Datacenter, error) {
+	if flag.Name == "" {
+		return nil, nil
+	}
+	return flag.Datacenter()
+}
+
+func (flag *DatacenterFlag) ManagedObject(ctx context.Context, arg string) (types.ManagedObjectReference, error) {
+	var ref types.ManagedObjectReference
+
+	finder, err := flag.Finder()
+	if err != nil {
+		return ref, err
+	}
+
+	if ref.FromString(arg) {
+		if strings.HasPrefix(ref.Type, "com.vmware.content.") {
+			return ref, nil // special case for content library
+		}
+		pc := property.DefaultCollector(flag.client)
+		var content []types.ObjectContent
+		err = pc.RetrieveOne(ctx, ref, []string{"name"}, &content)
+		if err == nil {
+			return ref, nil
+		}
+	}
+
+	l, err := finder.ManagedObjectList(ctx, arg)
+	if err != nil {
+		return ref, err
+	}
+
+	switch len(l) {
+	case 0:
+		return ref, fmt.Errorf("%s not found", arg)
+	case 1:
+		return l[0].Object.Reference(), nil
+	default:
+		var objs []types.ManagedObjectReference
+		for _, o := range l {
+			objs = append(objs, o.Object.Reference())
+		}
+		return ref, fmt.Errorf("%d objects at path %q: %s", len(l), arg, objs)
+	}
+}
+
+func (flag *DatacenterFlag) ManagedObjects(ctx context.Context, args []string) ([]types.ManagedObjectReference, error) {
+	var refs []types.ManagedObjectReference
+
+	c, err := flag.Client()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(args) == 0 {
+		refs = append(refs, c.ServiceContent.RootFolder)
+		return refs, nil
+	}
+
+	finder, err := flag.Finder()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, arg := range args {
+		var ref types.ManagedObjectReference
+		if ref.FromString(arg) {
+			// e.g. output from object.collect
+			refs = append(refs, ref)
+			continue
+		}
+		elements, err := finder.ManagedObjectList(ctx, arg)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(elements) == 0 {
+			return nil, fmt.Errorf("object '%s' not found", arg)
+		}
+
+		for _, e := range elements {
+			refs = append(refs, e.Object.Reference())
+		}
+	}
+
+	return refs, nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/datastore.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/datastore.go
@@ -1,0 +1,146 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type DatastoreFlag struct {
+	common
+
+	*DatacenterFlag
+
+	Name string
+
+	ds *object.Datastore
+}
+
+var datastoreFlagKey = flagKey("datastore")
+
+// NewCustomDatastoreFlag creates and returns a new DatastoreFlag without
+// trying to retrieve an existing one from the specified context.
+func NewCustomDatastoreFlag(ctx context.Context) (*DatastoreFlag, context.Context) {
+	v := &DatastoreFlag{}
+	v.DatacenterFlag, ctx = NewDatacenterFlag(ctx)
+	return v, ctx
+}
+
+func NewDatastoreFlag(ctx context.Context) (*DatastoreFlag, context.Context) {
+	if v := ctx.Value(datastoreFlagKey); v != nil {
+		return v.(*DatastoreFlag), ctx
+	}
+
+	v, ctx := NewCustomDatastoreFlag(ctx)
+	ctx = context.WithValue(ctx, datastoreFlagKey, v)
+	return v, ctx
+}
+
+func (f *DatastoreFlag) Register(ctx context.Context, fs *flag.FlagSet) {
+	f.RegisterOnce(func() {
+		f.DatacenterFlag.Register(ctx, fs)
+
+		env := "GOVC_DATASTORE"
+		value := os.Getenv(env)
+		usage := fmt.Sprintf("Datastore [%s]", env)
+		fs.StringVar(&f.Name, "ds", value, usage)
+	})
+}
+
+func (f *DatastoreFlag) Process(ctx context.Context) error {
+	return f.ProcessOnce(func() error {
+		if err := f.DatacenterFlag.Process(ctx); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func (f *DatastoreFlag) Args(args []string) []object.DatastorePath {
+	var files []object.DatastorePath
+
+	for _, arg := range args {
+		var p object.DatastorePath
+
+		if p.FromString(arg) {
+			f.Name = p.Datastore
+		} else {
+			p.Datastore = f.Name
+			p.Path = arg
+		}
+
+		files = append(files, p)
+	}
+
+	return files
+}
+
+func (f *DatastoreFlag) Datastore() (*object.Datastore, error) {
+	if f.ds != nil {
+		return f.ds, nil
+	}
+
+	var p object.DatastorePath
+	if p.FromString(f.Name) {
+		// Example use case:
+		//   -ds "$(govc object.collect -s vm/foo config.files.logDirectory)"
+		f.Name = p.Datastore
+	}
+
+	finder, err := f.Finder()
+	if err != nil {
+		return nil, err
+	}
+
+	if f.ds, err = finder.DatastoreOrDefault(context.TODO(), f.Name); err != nil {
+		return nil, err
+	}
+
+	return f.ds, nil
+}
+
+func (flag *DatastoreFlag) DatastoreIfSpecified() (*object.Datastore, error) {
+	if flag.Name == "" {
+		return nil, nil
+	}
+	return flag.Datastore()
+}
+
+func (f *DatastoreFlag) DatastorePath(name string) (string, error) {
+	ds, err := f.Datastore()
+	if err != nil {
+		return "", err
+	}
+
+	return ds.Path(name), nil
+}
+
+func (f *DatastoreFlag) Stat(ctx context.Context, file string) (types.BaseFileInfo, error) {
+	ds, err := f.Datastore()
+	if err != nil {
+		return nil, err
+	}
+
+	return ds.Stat(ctx, file)
+
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/debug.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/debug.go
@@ -1,0 +1,103 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/vmware/govmomi/vim25/debug"
+)
+
+type DebugFlag struct {
+	common
+
+	enable bool
+}
+
+var debugFlagKey = flagKey("debug")
+
+func NewDebugFlag(ctx context.Context) (*DebugFlag, context.Context) {
+	if v := ctx.Value(debugFlagKey); v != nil {
+		return v.(*DebugFlag), ctx
+	}
+
+	v := &DebugFlag{}
+	ctx = context.WithValue(ctx, debugFlagKey, v)
+	return v, ctx
+}
+
+func (flag *DebugFlag) Register(ctx context.Context, f *flag.FlagSet) {
+	flag.RegisterOnce(func() {
+		env := "GOVC_DEBUG"
+		enable := false
+		switch env := strings.ToLower(os.Getenv(env)); env {
+		case "1", "true":
+			enable = true
+		}
+
+		usage := fmt.Sprintf("Store debug logs [%s]", env)
+		f.BoolVar(&flag.enable, "debug", enable, usage)
+	})
+}
+
+func (flag *DebugFlag) Process(ctx context.Context) error {
+	if !flag.enable {
+		return nil
+	}
+
+	return flag.ProcessOnce(func() error {
+		// Base path for storing debug logs.
+		r := os.Getenv("GOVC_DEBUG_PATH")
+		switch r {
+		case "-":
+			debug.SetProvider(&debug.LogProvider{})
+			return nil
+		case "":
+			r = home
+		}
+		r = filepath.Join(r, "debug")
+
+		// Path for this particular run.
+		run := os.Getenv("GOVC_DEBUG_PATH_RUN")
+		if run == "" {
+			now := time.Now().Format("2006-01-02T15-04-05.999999999")
+			r = filepath.Join(r, now)
+		} else {
+			// reuse the same path
+			r = filepath.Join(r, run)
+			_ = os.RemoveAll(r)
+		}
+
+		err := os.MkdirAll(r, 0700)
+		if err != nil {
+			return err
+		}
+
+		p := debug.FileProvider{
+			Path: r,
+		}
+
+		debug.SetProvider(&p)
+		return nil
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/empty.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/empty.go
@@ -1,0 +1,31 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"context"
+	"flag"
+)
+
+type EmptyFlag struct{}
+
+func (flag *EmptyFlag) Register(ctx context.Context, f *flag.FlagSet) {
+}
+
+func (flag *EmptyFlag) Process(ctx context.Context) error {
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/folder.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/folder.go
@@ -1,0 +1,131 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/vmware/govmomi/object"
+)
+
+type FolderFlag struct {
+	common
+
+	*DatacenterFlag
+
+	name   string
+	folder *object.Folder
+}
+
+var folderFlagKey = flagKey("folder")
+
+func NewFolderFlag(ctx context.Context) (*FolderFlag, context.Context) {
+	if v := ctx.Value(folderFlagKey); v != nil {
+		return v.(*FolderFlag), ctx
+	}
+
+	v := &FolderFlag{}
+	v.DatacenterFlag, ctx = NewDatacenterFlag(ctx)
+	ctx = context.WithValue(ctx, folderFlagKey, v)
+	return v, ctx
+}
+
+func (flag *FolderFlag) Register(ctx context.Context, f *flag.FlagSet) {
+	flag.RegisterOnce(func() {
+		flag.DatacenterFlag.Register(ctx, f)
+
+		env := "GOVC_FOLDER"
+		value := os.Getenv(env)
+		usage := fmt.Sprintf("Inventory folder [%s]", env)
+		f.StringVar(&flag.name, "folder", value, usage)
+	})
+}
+
+func (flag *FolderFlag) Process(ctx context.Context) error {
+	return flag.ProcessOnce(func() error {
+		if err := flag.DatacenterFlag.Process(ctx); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func (flag *FolderFlag) Folder() (*object.Folder, error) {
+	if flag.folder != nil {
+		return flag.folder, nil
+	}
+
+	finder, err := flag.Finder()
+	if err != nil {
+		return nil, err
+	}
+
+	if flag.folder, err = finder.FolderOrDefault(context.TODO(), flag.name); err != nil {
+		return nil, err
+	}
+
+	return flag.folder, nil
+}
+
+func (flag *FolderFlag) FolderOrDefault(kind string) (*object.Folder, error) {
+	if flag.folder != nil {
+		return flag.folder, nil
+	}
+
+	if flag.name != "" {
+		return flag.Folder()
+	}
+
+	// RootFolder, no dc required
+	if kind == "/" {
+		client, err := flag.Client()
+		if err != nil {
+			return nil, err
+		}
+
+		flag.folder = object.NewRootFolder(client)
+		return flag.folder, nil
+	}
+
+	dc, err := flag.Datacenter()
+	if err != nil {
+		return nil, err
+	}
+
+	folders, err := dc.Folders(context.TODO())
+	if err != nil {
+		return nil, err
+	}
+
+	switch kind {
+	case "vm":
+		flag.folder = folders.VmFolder
+	case "host":
+		flag.folder = folders.HostFolder
+	case "datastore":
+		flag.folder = folders.DatastoreFolder
+	case "network":
+		flag.folder = folders.NetworkFolder
+	default:
+		panic(kind)
+	}
+
+	return flag.folder, nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/host_connect.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/host_connect.go
@@ -1,0 +1,101 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type HostConnectFlag struct {
+	common
+
+	types.HostConnectSpec
+
+	noverify bool
+}
+
+var hostConnectFlagKey = flagKey("hostConnect")
+
+func NewHostConnectFlag(ctx context.Context) (*HostConnectFlag, context.Context) {
+	if v := ctx.Value(hostConnectFlagKey); v != nil {
+		return v.(*HostConnectFlag), ctx
+	}
+
+	v := &HostConnectFlag{}
+	ctx = context.WithValue(ctx, hostConnectFlagKey, v)
+	return v, ctx
+}
+
+func (flag *HostConnectFlag) Register(ctx context.Context, f *flag.FlagSet) {
+	flag.RegisterOnce(func() {
+		f.StringVar(&flag.HostName, "hostname", "", "Hostname or IP address of the host")
+		f.StringVar(&flag.UserName, "username", "", "Username of administration account on the host")
+		f.StringVar(&flag.Password, "password", "", "Password of administration account on the host")
+		f.StringVar(&flag.SslThumbprint, "thumbprint", "", "SHA-1 thumbprint of the host's SSL certificate")
+		f.BoolVar(&flag.Force, "force", false, "Force when host is managed by another VC")
+
+		f.BoolVar(&flag.noverify, "noverify", false, "Accept host thumbprint without verification")
+	})
+}
+
+func (flag *HostConnectFlag) Process(ctx context.Context) error {
+	return nil
+}
+
+// Spec attempts to fill in SslThumbprint if empty.
+// First checks GOVC_TLS_KNOWN_HOSTS, if not found and noverify=true then
+// use object.HostCertificateInfo to get the thumbprint.
+func (flag *HostConnectFlag) Spec(c *vim25.Client) types.HostConnectSpec {
+	spec := flag.HostConnectSpec
+
+	if spec.SslThumbprint == "" {
+		spec.SslThumbprint = c.Thumbprint(spec.HostName)
+
+		if spec.SslThumbprint == "" && flag.noverify {
+			var info object.HostCertificateInfo
+			t := c.Transport.(*http.Transport)
+			_ = info.FromURL(&url.URL{Host: spec.HostName}, t.TLSClientConfig)
+			spec.SslThumbprint = info.ThumbprintSHA1
+		}
+	}
+
+	return spec
+}
+
+// Fault checks if error is SSLVerifyFault, including the thumbprint if so
+func (flag *HostConnectFlag) Fault(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if f, ok := err.(types.HasFault); ok {
+		switch fault := f.Fault().(type) {
+		case *types.SSLVerifyFault:
+			return fmt.Errorf("%s thumbprint=%s", err, fault.Thumbprint)
+		}
+	}
+
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/host_system.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/host_system.go
@@ -1,0 +1,141 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/vmware/govmomi/object"
+)
+
+type HostSystemFlag struct {
+	common
+
+	*ClientFlag
+	*DatacenterFlag
+	*SearchFlag
+
+	name string
+	host *object.HostSystem
+	pool *object.ResourcePool
+}
+
+var hostSystemFlagKey = flagKey("hostSystem")
+
+func NewHostSystemFlag(ctx context.Context) (*HostSystemFlag, context.Context) {
+	if v := ctx.Value(hostSystemFlagKey); v != nil {
+		return v.(*HostSystemFlag), ctx
+	}
+
+	v := &HostSystemFlag{}
+	v.ClientFlag, ctx = NewClientFlag(ctx)
+	v.DatacenterFlag, ctx = NewDatacenterFlag(ctx)
+	v.SearchFlag, ctx = NewSearchFlag(ctx, SearchHosts)
+	ctx = context.WithValue(ctx, hostSystemFlagKey, v)
+	return v, ctx
+}
+
+func (flag *HostSystemFlag) Register(ctx context.Context, f *flag.FlagSet) {
+	flag.RegisterOnce(func() {
+		flag.ClientFlag.Register(ctx, f)
+		flag.DatacenterFlag.Register(ctx, f)
+		flag.SearchFlag.Register(ctx, f)
+
+		env := "GOVC_HOST"
+		value := os.Getenv(env)
+		usage := fmt.Sprintf("Host system [%s]", env)
+		f.StringVar(&flag.name, "host", value, usage)
+	})
+}
+
+func (flag *HostSystemFlag) Process(ctx context.Context) error {
+	return flag.ProcessOnce(func() error {
+		if err := flag.ClientFlag.Process(ctx); err != nil {
+			return err
+		}
+		if err := flag.DatacenterFlag.Process(ctx); err != nil {
+			return err
+		}
+		if err := flag.SearchFlag.Process(ctx); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func (flag *HostSystemFlag) HostSystemIfSpecified() (*object.HostSystem, error) {
+	if flag.host != nil {
+		return flag.host, nil
+	}
+
+	// Use search flags if specified.
+	if flag.SearchFlag.IsSet() {
+		host, err := flag.SearchFlag.HostSystem()
+		if err != nil {
+			return nil, err
+		}
+
+		flag.host = host
+		return flag.host, nil
+	}
+
+	// Never look for a default host system.
+	// A host system parameter is optional for vm creation. It uses a mandatory
+	// resource pool parameter to determine where the vm should be placed.
+	if flag.name == "" {
+		return nil, nil
+	}
+
+	finder, err := flag.Finder()
+	if err != nil {
+		return nil, err
+	}
+
+	flag.host, err = finder.HostSystem(context.TODO(), flag.name)
+	return flag.host, err
+}
+
+func (flag *HostSystemFlag) HostSystem() (*object.HostSystem, error) {
+	host, err := flag.HostSystemIfSpecified()
+	if err != nil {
+		return nil, err
+	}
+
+	if host != nil {
+		return host, nil
+	}
+
+	finder, err := flag.Finder()
+	if err != nil {
+		return nil, err
+	}
+
+	flag.host, err = finder.DefaultHostSystem(context.TODO())
+	return flag.host, err
+}
+
+func (flag *HostSystemFlag) HostNetworkSystem() (*object.HostNetworkSystem, error) {
+	host, err := flag.HostSystem()
+	if err != nil {
+		return nil, err
+	}
+
+	return host.ConfigManager().NetworkSystem(context.TODO())
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/int32.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/int32.go
@@ -1,0 +1,72 @@
+/*
+Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+)
+
+// This flag type is internal to stdlib:
+// https://github.com/golang/go/blob/master/src/cmd/internal/obj/flag.go
+type int32Value int32
+
+func (i *int32Value) Set(s string) error {
+	v, err := strconv.ParseInt(s, 0, 32)
+	*i = int32Value(v)
+	return err
+}
+
+func (i *int32Value) Get() interface{} {
+	return int32(*i)
+}
+
+func (i *int32Value) String() string {
+	return fmt.Sprintf("%v", *i)
+}
+
+// NewInt32 behaves as flag.IntVar, but using an int32 type.
+func NewInt32(v *int32) flag.Value {
+	return (*int32Value)(v)
+}
+
+type int32ptrValue struct {
+	val **int32
+}
+
+func (i *int32ptrValue) Set(s string) error {
+	v, err := strconv.ParseInt(s, 0, 32)
+	*i.val = new(int32)
+	**i.val = int32(v)
+	return err
+}
+
+func (i *int32ptrValue) Get() interface{} {
+	if i.val == nil || *i.val == nil {
+		return nil
+	}
+	return *i.val
+}
+
+func (i *int32ptrValue) String() string {
+	return fmt.Sprintf("%v", i.Get())
+}
+
+func NewOptionalInt32(v **int32) flag.Value {
+	return &int32ptrValue{val: v}
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/int64.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/int64.go
@@ -1,0 +1,72 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+)
+
+// This flag type is internal to stdlib:
+// https://github.com/golang/go/blob/master/src/cmd/internal/obj/flag.go
+type int64Value int64
+
+func (i *int64Value) Set(s string) error {
+	v, err := strconv.ParseInt(s, 0, 64)
+	*i = int64Value(v)
+	return err
+}
+
+func (i *int64Value) Get() interface{} {
+	return int64(*i)
+}
+
+func (i *int64Value) String() string {
+	return fmt.Sprintf("%v", *i)
+}
+
+// NewInt64 behaves as flag.IntVar, but using an int64 type.
+func NewInt64(v *int64) flag.Value {
+	return (*int64Value)(v)
+}
+
+type int64ptrValue struct {
+	val **int64
+}
+
+func (i *int64ptrValue) Set(s string) error {
+	v, err := strconv.ParseInt(s, 0, 64)
+	*i.val = new(int64)
+	**i.val = int64(v)
+	return err
+}
+
+func (i *int64ptrValue) Get() interface{} {
+	if i.val == nil || *i.val == nil {
+		return nil
+	}
+	return **i.val
+}
+
+func (i *int64ptrValue) String() string {
+	return fmt.Sprintf("%v", i.Get())
+}
+
+func NewOptionalInt64(v **int64) flag.Value {
+	return &int64ptrValue{val: v}
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/list.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/list.go
@@ -1,0 +1,30 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import "fmt"
+
+type StringList []string
+
+func (l *StringList) String() string {
+	return fmt.Sprint(*l)
+}
+
+func (l *StringList) Set(value string) error {
+	*l = append(*l, value)
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/network.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/network.go
@@ -1,0 +1,147 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type NetworkFlag struct {
+	common
+
+	*DatacenterFlag
+
+	name    string
+	net     object.NetworkReference
+	adapter string
+	address string
+	isset   bool
+}
+
+var networkFlagKey = flagKey("network")
+
+func NewNetworkFlag(ctx context.Context) (*NetworkFlag, context.Context) {
+	if v := ctx.Value(networkFlagKey); v != nil {
+		return v.(*NetworkFlag), ctx
+	}
+
+	v := &NetworkFlag{}
+	v.DatacenterFlag, ctx = NewDatacenterFlag(ctx)
+	ctx = context.WithValue(ctx, networkFlagKey, v)
+	return v, ctx
+}
+
+func (flag *NetworkFlag) Register(ctx context.Context, f *flag.FlagSet) {
+	flag.RegisterOnce(func() {
+		flag.DatacenterFlag.Register(ctx, f)
+
+		env := "GOVC_NETWORK"
+		value := os.Getenv(env)
+		flag.name = value
+		usage := fmt.Sprintf("Network [%s]", env)
+		f.Var(flag, "net", usage)
+		f.StringVar(&flag.adapter, "net.adapter", "e1000", "Network adapter type")
+		f.StringVar(&flag.address, "net.address", "", "Network hardware address")
+	})
+}
+
+func (flag *NetworkFlag) Process(ctx context.Context) error {
+	return flag.ProcessOnce(func() error {
+		if err := flag.DatacenterFlag.Process(ctx); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func (flag *NetworkFlag) String() string {
+	return flag.name
+}
+
+func (flag *NetworkFlag) Set(name string) error {
+	flag.name = name
+	flag.isset = true
+	return nil
+}
+
+func (flag *NetworkFlag) IsSet() bool {
+	return flag.isset
+}
+
+func (flag *NetworkFlag) Network() (object.NetworkReference, error) {
+	if flag.net != nil {
+		return flag.net, nil
+	}
+
+	finder, err := flag.Finder()
+	if err != nil {
+		return nil, err
+	}
+
+	if flag.net, err = finder.NetworkOrDefault(context.TODO(), flag.name); err != nil {
+		return nil, err
+	}
+
+	return flag.net, nil
+}
+
+func (flag *NetworkFlag) Device() (types.BaseVirtualDevice, error) {
+	net, err := flag.Network()
+	if err != nil {
+		return nil, err
+	}
+
+	backing, err := net.EthernetCardBackingInfo(context.TODO())
+	if err != nil {
+		return nil, err
+	}
+
+	device, err := object.EthernetCardTypes().CreateEthernetCard(flag.adapter, backing)
+	if err != nil {
+		return nil, err
+	}
+
+	if flag.address != "" {
+		card := device.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+		card.AddressType = string(types.VirtualEthernetCardMacTypeManual)
+		card.MacAddress = flag.address
+	}
+
+	return device, nil
+}
+
+// Change applies update backing and hardware address changes to the given network device.
+func (flag *NetworkFlag) Change(device types.BaseVirtualDevice, update types.BaseVirtualDevice) {
+	current := device.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+	changed := update.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+
+	current.Backing = changed.Backing
+
+	if changed.MacAddress != "" {
+		current.MacAddress = changed.MacAddress
+	}
+
+	if changed.AddressType != "" {
+		current.AddressType = changed.AddressType
+	}
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/optional_bool.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/optional_bool.go
@@ -1,0 +1,55 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+)
+
+type optionalBool struct {
+	val **bool
+}
+
+func (b *optionalBool) Set(s string) error {
+	v, err := strconv.ParseBool(s)
+	*b.val = &v
+	return err
+}
+
+func (b *optionalBool) Get() interface{} {
+	if *b.val == nil {
+		return nil
+	}
+	return **b.val
+}
+
+func (b *optionalBool) String() string {
+	if b.val == nil || *b.val == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", **b.val)
+}
+
+func (b *optionalBool) IsBoolFlag() bool { return true }
+
+// NewOptionalBool returns a flag.Value implementation where there is no default value.
+// This avoids sending a default value over the wire as using flag.BoolVar() would.
+func NewOptionalBool(v **bool) flag.Value {
+	return &optionalBool{v}
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/output.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/output.go
@@ -1,0 +1,251 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/kr/pretty"
+	"github.com/vmware/govmomi/vim25/progress"
+)
+
+type OutputWriter interface {
+	Write(io.Writer) error
+}
+
+type OutputFlag struct {
+	common
+
+	JSON bool
+	TTY  bool
+	Dump bool
+	Out  io.Writer
+}
+
+var outputFlagKey = flagKey("output")
+
+func NewOutputFlag(ctx context.Context) (*OutputFlag, context.Context) {
+	if v := ctx.Value(outputFlagKey); v != nil {
+		return v.(*OutputFlag), ctx
+	}
+
+	v := &OutputFlag{Out: os.Stdout}
+	ctx = context.WithValue(ctx, outputFlagKey, v)
+	return v, ctx
+}
+
+func (flag *OutputFlag) Register(ctx context.Context, f *flag.FlagSet) {
+	flag.RegisterOnce(func() {
+		f.BoolVar(&flag.JSON, "json", false, "Enable JSON output")
+		f.BoolVar(&flag.Dump, "dump", false, "Enable Go output")
+	})
+}
+
+func (flag *OutputFlag) Process(ctx context.Context) error {
+	return flag.ProcessOnce(func() error {
+		if !flag.JSON {
+			// Assume we have a tty if not outputting JSON
+			flag.TTY = true
+		}
+
+		return nil
+	})
+}
+
+// Log outputs the specified string, prefixed with the current time.
+// A newline is not automatically added. If the specified string
+// starts with a '\r', the current line is cleared first.
+func (flag *OutputFlag) Log(s string) (int, error) {
+	if len(s) > 0 && s[0] == '\r' {
+		flag.Write([]byte{'\r', 033, '[', 'K'})
+		s = s[1:]
+	}
+
+	return flag.WriteString(time.Now().Format("[02-01-06 15:04:05] ") + s)
+}
+
+func (flag *OutputFlag) Write(b []byte) (int, error) {
+	if !flag.TTY {
+		return 0, nil
+	}
+
+	n, err := os.Stdout.Write(b)
+	os.Stdout.Sync()
+	return n, err
+}
+
+func (flag *OutputFlag) WriteString(s string) (int, error) {
+	return flag.Write([]byte(s))
+}
+
+func (flag *OutputFlag) All() bool {
+	return flag.JSON || flag.Dump
+}
+
+func dumpValue(val interface{}) interface{} {
+	type dumper interface {
+		Dump() interface{}
+	}
+
+	if d, ok := val.(dumper); ok {
+		return d.Dump()
+	}
+
+	rval := reflect.ValueOf(val)
+	if rval.Type().Kind() != reflect.Ptr {
+		return val
+	}
+
+	rval = rval.Elem()
+	if rval.Type().Kind() == reflect.Struct {
+		f := rval.Field(0)
+		if f.Type().Kind() == reflect.Slice {
+			// common case for the various 'type infoResult'
+			if f.Len() == 1 {
+				return f.Index(0).Interface()
+			}
+			return f.Interface()
+		}
+	}
+
+	return val
+}
+
+func (flag *OutputFlag) WriteResult(result OutputWriter) error {
+	var err error
+
+	if flag.JSON {
+		err = json.NewEncoder(flag.Out).Encode(result)
+	} else if flag.Dump {
+		pretty.Fprintf(flag.Out, "%# v\n", dumpValue(result))
+	} else {
+		err = result.Write(flag.Out)
+	}
+
+	return err
+}
+
+type progressLogger struct {
+	flag   *OutputFlag
+	prefix string
+
+	wg sync.WaitGroup
+
+	sink chan chan progress.Report
+	done chan struct{}
+}
+
+func newProgressLogger(flag *OutputFlag, prefix string) *progressLogger {
+	p := &progressLogger{
+		flag:   flag,
+		prefix: prefix,
+
+		sink: make(chan chan progress.Report),
+		done: make(chan struct{}),
+	}
+
+	p.wg.Add(1)
+
+	go p.loopA()
+
+	return p
+}
+
+// loopA runs before Sink() has been called.
+func (p *progressLogger) loopA() {
+	var err error
+
+	defer p.wg.Done()
+
+	tick := time.NewTicker(100 * time.Millisecond)
+	defer tick.Stop()
+
+	called := false
+
+	for stop := false; !stop; {
+		select {
+		case ch := <-p.sink:
+			err = p.loopB(tick, ch)
+			stop = true
+			called = true
+		case <-p.done:
+			stop = true
+		case <-tick.C:
+			line := fmt.Sprintf("\r%s", p.prefix)
+			p.flag.Log(line)
+		}
+	}
+
+	if err != nil && err != io.EOF {
+		p.flag.Log(fmt.Sprintf("\r%sError: %s\n", p.prefix, err))
+	} else if called {
+		p.flag.Log(fmt.Sprintf("\r%sOK\n", p.prefix))
+	}
+}
+
+// loopA runs after Sink() has been called.
+func (p *progressLogger) loopB(tick *time.Ticker, ch <-chan progress.Report) error {
+	var r progress.Report
+	var ok bool
+	var err error
+
+	for ok = true; ok; {
+		select {
+		case r, ok = <-ch:
+			if !ok {
+				break
+			}
+			err = r.Error()
+		case <-tick.C:
+			line := fmt.Sprintf("\r%s", p.prefix)
+			if r != nil {
+				line += fmt.Sprintf("(%.0f%%", r.Percentage())
+				detail := r.Detail()
+				if detail != "" {
+					line += fmt.Sprintf(", %s", detail)
+				}
+				line += ")"
+			}
+			p.flag.Log(line)
+		}
+	}
+
+	return err
+}
+
+func (p *progressLogger) Sink() chan<- progress.Report {
+	ch := make(chan progress.Report)
+	p.sink <- ch
+	return ch
+}
+
+func (p *progressLogger) Wait() {
+	close(p.done)
+	p.wg.Wait()
+}
+
+func (flag *OutputFlag) ProgressLogger(prefix string) *progressLogger {
+	return newProgressLogger(flag, prefix)
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/resource_allocation_info.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/resource_allocation_info.go
@@ -1,0 +1,85 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"context"
+	"flag"
+	"strconv"
+	"strings"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type sharesInfo types.SharesInfo
+
+func (s *sharesInfo) String() string {
+	return string(s.Level)
+}
+
+func (s *sharesInfo) Set(val string) error {
+	switch val {
+	case string(types.SharesLevelNormal), string(types.SharesLevelLow), string(types.SharesLevelHigh):
+		s.Level = types.SharesLevel(val)
+	default:
+		n, err := strconv.Atoi(val)
+		if err != nil {
+			return err
+		}
+
+		s.Level = types.SharesLevelCustom
+		s.Shares = int32(n)
+	}
+
+	return nil
+}
+
+type ResourceAllocationFlag struct {
+	cpu, mem              *types.ResourceAllocationInfo
+	ExpandableReservation bool
+}
+
+func NewResourceAllocationFlag(cpu, mem *types.ResourceAllocationInfo) *ResourceAllocationFlag {
+	return &ResourceAllocationFlag{cpu, mem, true}
+}
+
+func (r *ResourceAllocationFlag) Register(ctx context.Context, f *flag.FlagSet) {
+	opts := []struct {
+		name  string
+		units string
+		*types.ResourceAllocationInfo
+	}{
+		{"CPU", "MHz", r.cpu},
+		{"Memory", "MB", r.mem},
+	}
+
+	for _, opt := range opts {
+		prefix := strings.ToLower(opt.name)[:3]
+		shares := (*sharesInfo)(opt.Shares)
+
+		f.Var(NewOptionalInt64(&opt.Limit), prefix+".limit", opt.name+" limit in "+opt.units)
+		f.Var(NewOptionalInt64(&opt.Reservation), prefix+".reservation", opt.name+" reservation in "+opt.units)
+		if r.ExpandableReservation {
+			f.Var(NewOptionalBool(&opt.ExpandableReservation), prefix+".expandable", opt.name+" expandable reservation")
+		}
+		f.Var(shares, prefix+".shares", opt.name+" shares level or number")
+	}
+}
+
+func (s *ResourceAllocationFlag) Process(ctx context.Context) error {
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/resource_pool.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/resource_pool.go
@@ -1,0 +1,92 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/vmware/govmomi/object"
+)
+
+type ResourcePoolFlag struct {
+	common
+
+	*DatacenterFlag
+
+	name string
+	pool *object.ResourcePool
+}
+
+var resourcePoolFlagKey = flagKey("resourcePool")
+
+func NewResourcePoolFlag(ctx context.Context) (*ResourcePoolFlag, context.Context) {
+	if v := ctx.Value(resourcePoolFlagKey); v != nil {
+		return v.(*ResourcePoolFlag), ctx
+	}
+
+	v := &ResourcePoolFlag{}
+	v.DatacenterFlag, ctx = NewDatacenterFlag(ctx)
+	ctx = context.WithValue(ctx, resourcePoolFlagKey, v)
+	return v, ctx
+}
+
+func (flag *ResourcePoolFlag) Register(ctx context.Context, f *flag.FlagSet) {
+	flag.RegisterOnce(func() {
+		flag.DatacenterFlag.Register(ctx, f)
+
+		env := "GOVC_RESOURCE_POOL"
+		value := os.Getenv(env)
+		usage := fmt.Sprintf("Resource pool [%s]", env)
+		f.StringVar(&flag.name, "pool", value, usage)
+	})
+}
+
+func (flag *ResourcePoolFlag) Process(ctx context.Context) error {
+	return flag.ProcessOnce(func() error {
+		if err := flag.DatacenterFlag.Process(ctx); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func (flag *ResourcePoolFlag) ResourcePool() (*object.ResourcePool, error) {
+	if flag.pool != nil {
+		return flag.pool, nil
+	}
+
+	finder, err := flag.Finder()
+	if err != nil {
+		return nil, err
+	}
+
+	if flag.pool, err = finder.ResourcePoolOrDefault(context.TODO(), flag.name); err != nil {
+		return nil, err
+	}
+
+	return flag.pool, nil
+}
+
+func (flag *ResourcePoolFlag) ResourcePoolIfSpecified() (*object.ResourcePool, error) {
+	if flag.name == "" {
+		return nil, nil
+	}
+	return flag.ResourcePool()
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/search.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/search.go
@@ -1,0 +1,434 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+const (
+	SearchVirtualMachines = iota + 1
+	SearchHosts
+	SearchVirtualApps
+)
+
+type SearchFlag struct {
+	common
+
+	*ClientFlag
+	*DatacenterFlag
+
+	t      int
+	entity string
+
+	byDatastorePath string
+	byDNSName       string
+	byInventoryPath string
+	byIP            string
+	byUUID          string
+
+	isset bool
+}
+
+var searchFlagKey = flagKey("search")
+
+func NewSearchFlag(ctx context.Context, t int) (*SearchFlag, context.Context) {
+	if v := ctx.Value(searchFlagKey); v != nil {
+		return v.(*SearchFlag), ctx
+	}
+
+	v := &SearchFlag{
+		t: t,
+	}
+
+	v.ClientFlag, ctx = NewClientFlag(ctx)
+	v.DatacenterFlag, ctx = NewDatacenterFlag(ctx)
+
+	switch t {
+	case SearchVirtualMachines:
+		v.entity = "VM"
+	case SearchHosts:
+		v.entity = "host"
+	case SearchVirtualApps:
+		v.entity = "vapp"
+	default:
+		panic("invalid search type")
+	}
+
+	ctx = context.WithValue(ctx, searchFlagKey, v)
+	return v, ctx
+}
+
+func (flag *SearchFlag) Register(ctx context.Context, fs *flag.FlagSet) {
+	flag.RegisterOnce(func() {
+		flag.ClientFlag.Register(ctx, fs)
+		flag.DatacenterFlag.Register(ctx, fs)
+
+		register := func(v *string, f string, d string) {
+			f = fmt.Sprintf("%s.%s", strings.ToLower(flag.entity), f)
+			d = fmt.Sprintf(d, flag.entity)
+			fs.StringVar(v, f, "", d)
+		}
+
+		switch flag.t {
+		case SearchVirtualMachines:
+			register(&flag.byDatastorePath, "path", "Find %s by path to .vmx file")
+		}
+
+		switch flag.t {
+		case SearchVirtualMachines, SearchHosts:
+			register(&flag.byDNSName, "dns", "Find %s by FQDN")
+			register(&flag.byIP, "ip", "Find %s by IP address")
+			register(&flag.byUUID, "uuid", "Find %s by UUID")
+		}
+
+		register(&flag.byInventoryPath, "ipath", "Find %s by inventory path")
+	})
+}
+
+func (flag *SearchFlag) Process(ctx context.Context) error {
+	return flag.ProcessOnce(func() error {
+		if err := flag.ClientFlag.Process(ctx); err != nil {
+			return err
+		}
+		if err := flag.DatacenterFlag.Process(ctx); err != nil {
+			return err
+		}
+
+		flags := []string{
+			flag.byDatastorePath,
+			flag.byDNSName,
+			flag.byInventoryPath,
+			flag.byIP,
+			flag.byUUID,
+		}
+
+		flag.isset = false
+		for _, f := range flags {
+			if f != "" {
+				if flag.isset {
+					return errors.New("cannot use more than one search flag")
+				}
+				flag.isset = true
+			}
+		}
+
+		return nil
+	})
+}
+
+func (flag *SearchFlag) IsSet() bool {
+	return flag.isset
+}
+
+func (flag *SearchFlag) searchIndex(c *vim25.Client) *object.SearchIndex {
+	return object.NewSearchIndex(c)
+}
+
+func (flag *SearchFlag) searchByDatastorePath(c *vim25.Client, dc *object.Datacenter) (object.Reference, error) {
+	ctx := context.TODO()
+	switch flag.t {
+	case SearchVirtualMachines:
+		return flag.searchIndex(c).FindByDatastorePath(ctx, dc, flag.byDatastorePath)
+	default:
+		panic("unsupported type")
+	}
+}
+
+func (flag *SearchFlag) searchByDNSName(c *vim25.Client, dc *object.Datacenter) (object.Reference, error) {
+	ctx := context.TODO()
+	switch flag.t {
+	case SearchVirtualMachines:
+		return flag.searchIndex(c).FindByDnsName(ctx, dc, flag.byDNSName, true)
+	case SearchHosts:
+		return flag.searchIndex(c).FindByDnsName(ctx, dc, flag.byDNSName, false)
+	default:
+		panic("unsupported type")
+	}
+}
+
+func (flag *SearchFlag) searchByInventoryPath(c *vim25.Client, dc *object.Datacenter) (object.Reference, error) {
+	// TODO(PN): The datacenter flag should not be set because it is ignored.
+	ctx := context.TODO()
+	return flag.searchIndex(c).FindByInventoryPath(ctx, flag.byInventoryPath)
+}
+
+func (flag *SearchFlag) searchByIP(c *vim25.Client, dc *object.Datacenter) (object.Reference, error) {
+	ctx := context.TODO()
+	switch flag.t {
+	case SearchVirtualMachines:
+		return flag.searchIndex(c).FindByIp(ctx, dc, flag.byIP, true)
+	case SearchHosts:
+		return flag.searchIndex(c).FindByIp(ctx, dc, flag.byIP, false)
+	default:
+		panic("unsupported type")
+	}
+}
+
+func (flag *SearchFlag) searchByUUID(c *vim25.Client, dc *object.Datacenter) (object.Reference, error) {
+	ctx := context.TODO()
+	isVM := false
+	switch flag.t {
+	case SearchVirtualMachines:
+		isVM = true
+	case SearchHosts:
+	default:
+		panic("unsupported type")
+	}
+
+	var ref object.Reference
+	var err error
+
+	for _, iu := range []*bool{nil, types.NewBool(true)} {
+		ref, err = flag.searchIndex(c).FindByUuid(ctx, dc, flag.byUUID, isVM, iu)
+		if err != nil {
+			if soap.IsSoapFault(err) {
+				fault := soap.ToSoapFault(err).VimFault()
+				if _, ok := fault.(types.InvalidArgument); ok {
+					continue
+				}
+			}
+			return nil, err
+		}
+		if ref != nil {
+			break
+		}
+	}
+
+	return ref, nil
+}
+
+func (flag *SearchFlag) search() (object.Reference, error) {
+	ctx := context.TODO()
+	var ref object.Reference
+	var err error
+
+	c, err := flag.Client()
+	if err != nil {
+		return nil, err
+	}
+
+	dc, err := flag.Datacenter()
+	if err != nil {
+		return nil, err
+	}
+
+	switch {
+	case flag.byDatastorePath != "":
+		ref, err = flag.searchByDatastorePath(c, dc)
+	case flag.byDNSName != "":
+		ref, err = flag.searchByDNSName(c, dc)
+	case flag.byInventoryPath != "":
+		ref, err = flag.searchByInventoryPath(c, dc)
+	case flag.byIP != "":
+		ref, err = flag.searchByIP(c, dc)
+	case flag.byUUID != "":
+		ref, err = flag.searchByUUID(c, dc)
+	default:
+		err = errors.New("no search flag specified")
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if ref == nil {
+		return nil, fmt.Errorf("no such %s", flag.entity)
+	}
+
+	// set the InventoryPath field
+	finder, err := flag.Finder()
+	if err != nil {
+		return nil, err
+	}
+	ref, err = finder.ObjectReference(ctx, ref.Reference())
+	if err != nil {
+		return nil, err
+	}
+
+	return ref, nil
+}
+
+func (flag *SearchFlag) VirtualMachine() (*object.VirtualMachine, error) {
+	ref, err := flag.search()
+	if err != nil {
+		return nil, err
+	}
+
+	vm, ok := ref.(*object.VirtualMachine)
+	if !ok {
+		return nil, fmt.Errorf("expected VirtualMachine entity, got %s", ref.Reference().Type)
+	}
+
+	return vm, nil
+}
+
+func (flag *SearchFlag) VirtualMachines(args []string) ([]*object.VirtualMachine, error) {
+	ctx := context.TODO()
+	var out []*object.VirtualMachine
+
+	if flag.IsSet() {
+		vm, err := flag.VirtualMachine()
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, vm)
+		return out, nil
+	}
+
+	// List virtual machines
+	if len(args) == 0 {
+		return nil, errors.New("no argument")
+	}
+
+	finder, err := flag.Finder()
+	if err != nil {
+		return nil, err
+	}
+
+	var nfe error
+
+	// List virtual machines for every argument
+	for _, arg := range args {
+		vms, err := finder.VirtualMachineList(ctx, arg)
+		if err != nil {
+			if _, ok := err.(*find.NotFoundError); ok {
+				// Let caller decide how to handle NotFoundError
+				nfe = err
+				continue
+			}
+			return nil, err
+		}
+
+		out = append(out, vms...)
+	}
+
+	return out, nfe
+}
+
+func (flag *SearchFlag) VirtualApp() (*object.VirtualApp, error) {
+	ref, err := flag.search()
+	if err != nil {
+		return nil, err
+	}
+
+	app, ok := ref.(*object.VirtualApp)
+	if !ok {
+		return nil, fmt.Errorf("expected VirtualApp entity, got %s", ref.Reference().Type)
+	}
+
+	return app, nil
+}
+
+func (flag *SearchFlag) VirtualApps(args []string) ([]*object.VirtualApp, error) {
+	ctx := context.TODO()
+	var out []*object.VirtualApp
+
+	if flag.IsSet() {
+		app, err := flag.VirtualApp()
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, app)
+		return out, nil
+	}
+
+	// List virtual apps
+	if len(args) == 0 {
+		return nil, errors.New("no argument")
+	}
+
+	finder, err := flag.Finder()
+	if err != nil {
+		return nil, err
+	}
+
+	// List virtual apps for every argument
+	for _, arg := range args {
+		apps, err := finder.VirtualAppList(ctx, arg)
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, apps...)
+	}
+
+	return out, nil
+}
+
+func (flag *SearchFlag) HostSystem() (*object.HostSystem, error) {
+	ref, err := flag.search()
+	if err != nil {
+		return nil, err
+	}
+
+	host, ok := ref.(*object.HostSystem)
+	if !ok {
+		return nil, fmt.Errorf("expected HostSystem entity, got %s", ref.Reference().Type)
+	}
+
+	return host, nil
+}
+
+func (flag *SearchFlag) HostSystems(args []string) ([]*object.HostSystem, error) {
+	ctx := context.TODO()
+	var out []*object.HostSystem
+
+	if flag.IsSet() {
+		host, err := flag.HostSystem()
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, host)
+		return out, nil
+	}
+
+	// List host system
+	if len(args) == 0 {
+		return nil, errors.New("no argument")
+	}
+
+	finder, err := flag.Finder()
+	if err != nil {
+		return nil, err
+	}
+
+	// List host systems for every argument
+	for _, arg := range args {
+		vms, err := finder.HostSystemList(ctx, arg)
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, vms...)
+	}
+
+	return out, nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/storage_pod.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/storage_pod.go
@@ -1,0 +1,78 @@
+package flags
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/vmware/govmomi/object"
+)
+
+type StoragePodFlag struct {
+	common
+
+	*DatacenterFlag
+
+	Name string
+
+	sp *object.StoragePod
+}
+
+var storagePodFlagKey = flagKey("storagePod")
+
+func NewStoragePodFlag(ctx context.Context) (*StoragePodFlag, context.Context) {
+	if v := ctx.Value(storagePodFlagKey); v != nil {
+		return v.(*StoragePodFlag), ctx
+	}
+
+	v := &StoragePodFlag{}
+	v.DatacenterFlag, ctx = NewDatacenterFlag(ctx)
+	ctx = context.WithValue(ctx, storagePodFlagKey, v)
+	return v, ctx
+}
+
+func (f *StoragePodFlag) Register(ctx context.Context, fs *flag.FlagSet) {
+	f.RegisterOnce(func() {
+		f.DatacenterFlag.Register(ctx, fs)
+
+		env := "GOVC_DATASTORE_CLUSTER"
+		value := os.Getenv(env)
+		usage := fmt.Sprintf("Datastore cluster [%s]", env)
+		fs.StringVar(&f.Name, "datastore-cluster", value, usage)
+	})
+}
+
+func (f *StoragePodFlag) Process(ctx context.Context) error {
+	return f.DatacenterFlag.Process(ctx)
+}
+
+func (f *StoragePodFlag) Isset() bool {
+	return f.Name != ""
+}
+
+func (f *StoragePodFlag) StoragePod() (*object.StoragePod, error) {
+	ctx := context.TODO()
+	if f.sp != nil {
+		return f.sp, nil
+	}
+
+	finder, err := f.Finder()
+	if err != nil {
+		return nil, err
+	}
+
+	if f.Isset() {
+		f.sp, err = finder.DatastoreCluster(ctx, f.Name)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		f.sp, err = finder.DefaultDatastoreCluster(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return f.sp, nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/version.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/version.go
@@ -1,0 +1,66 @@
+/*
+Copyright (c) 2014-2020 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"strconv"
+	"strings"
+)
+
+const Version = "0.22.1"
+
+var GitVersion string
+
+type version []int
+
+func ParseVersion(s string) (version, error) {
+	v := make(version, 0)
+	ds := strings.Split(s, "-")
+	ps := strings.Split(ds[0], ".")
+	for _, p := range ps {
+		i, err := strconv.Atoi(p)
+		if err != nil {
+			return nil, err
+		}
+
+		v = append(v, i)
+	}
+
+	return v, nil
+}
+
+func (v version) Lte(u version) bool {
+	lv := len(v)
+	lu := len(u)
+
+	for i := 0; i < lv; i++ {
+		// Everything up to here has been equal and v has more elements than u.
+		if i >= lu {
+			return false
+		}
+
+		// Move to next digit if equal.
+		if v[i] == u[i] {
+			continue
+		}
+
+		return v[i] < u[i]
+	}
+
+	// Equal.
+	return true
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/virtual_app.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/virtual_app.go
@@ -1,0 +1,106 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/vmware/govmomi/object"
+)
+
+type VirtualAppFlag struct {
+	common
+
+	*DatacenterFlag
+	*SearchFlag
+
+	name string
+	app  *object.VirtualApp
+}
+
+var virtualAppFlagKey = flagKey("virtualApp")
+
+func NewVirtualAppFlag(ctx context.Context) (*VirtualAppFlag, context.Context) {
+	if v := ctx.Value(virtualAppFlagKey); v != nil {
+		return v.(*VirtualAppFlag), ctx
+	}
+
+	v := &VirtualAppFlag{}
+	v.DatacenterFlag, ctx = NewDatacenterFlag(ctx)
+	v.SearchFlag, ctx = NewSearchFlag(ctx, SearchVirtualApps)
+	ctx = context.WithValue(ctx, virtualAppFlagKey, v)
+	return v, ctx
+}
+
+func (flag *VirtualAppFlag) Register(ctx context.Context, f *flag.FlagSet) {
+	flag.RegisterOnce(func() {
+		flag.DatacenterFlag.Register(ctx, f)
+		flag.SearchFlag.Register(ctx, f)
+
+		env := "GOVC_VAPP"
+		value := os.Getenv(env)
+		usage := fmt.Sprintf("Virtual App [%s]", env)
+		f.StringVar(&flag.name, "vapp", value, usage)
+	})
+}
+
+func (flag *VirtualAppFlag) Process(ctx context.Context) error {
+	return flag.ProcessOnce(func() error {
+		if err := flag.DatacenterFlag.Process(ctx); err != nil {
+			return err
+		}
+		if err := flag.SearchFlag.Process(ctx); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func (flag *VirtualAppFlag) VirtualApp() (*object.VirtualApp, error) {
+	ctx := context.TODO()
+
+	if flag.app != nil {
+		return flag.app, nil
+	}
+
+	// Use search flags if specified.
+	if flag.SearchFlag.IsSet() {
+		app, err := flag.SearchFlag.VirtualApp()
+		if err != nil {
+			return nil, err
+		}
+
+		flag.app = app
+		return flag.app, nil
+	}
+
+	// Never look for a default virtual app.
+	if flag.name == "" {
+		return nil, nil
+	}
+
+	finder, err := flag.Finder()
+	if err != nil {
+		return nil, err
+	}
+
+	flag.app, err = finder.VirtualApp(ctx, flag.name)
+	return flag.app, err
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/virtual_machine.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/virtual_machine.go
@@ -1,0 +1,112 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/vmware/govmomi/object"
+)
+
+type VirtualMachineFlag struct {
+	common
+
+	*ClientFlag
+	*DatacenterFlag
+	*SearchFlag
+
+	name string
+	vm   *object.VirtualMachine
+}
+
+var virtualMachineFlagKey = flagKey("virtualMachine")
+
+func NewVirtualMachineFlag(ctx context.Context) (*VirtualMachineFlag, context.Context) {
+	if v := ctx.Value(virtualMachineFlagKey); v != nil {
+		return v.(*VirtualMachineFlag), ctx
+	}
+
+	v := &VirtualMachineFlag{}
+	v.ClientFlag, ctx = NewClientFlag(ctx)
+	v.DatacenterFlag, ctx = NewDatacenterFlag(ctx)
+	v.SearchFlag, ctx = NewSearchFlag(ctx, SearchVirtualMachines)
+	ctx = context.WithValue(ctx, virtualMachineFlagKey, v)
+	return v, ctx
+}
+
+func (flag *VirtualMachineFlag) Register(ctx context.Context, f *flag.FlagSet) {
+	flag.RegisterOnce(func() {
+		flag.ClientFlag.Register(ctx, f)
+		flag.DatacenterFlag.Register(ctx, f)
+		flag.SearchFlag.Register(ctx, f)
+
+		env := "GOVC_VM"
+		value := os.Getenv(env)
+		usage := fmt.Sprintf("Virtual machine [%s]", env)
+		f.StringVar(&flag.name, "vm", value, usage)
+	})
+}
+
+func (flag *VirtualMachineFlag) Process(ctx context.Context) error {
+	return flag.ProcessOnce(func() error {
+		if err := flag.ClientFlag.Process(ctx); err != nil {
+			return err
+		}
+		if err := flag.DatacenterFlag.Process(ctx); err != nil {
+			return err
+		}
+		if err := flag.SearchFlag.Process(ctx); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func (flag *VirtualMachineFlag) VirtualMachine() (*object.VirtualMachine, error) {
+	ctx := context.TODO()
+
+	if flag.vm != nil {
+		return flag.vm, nil
+	}
+
+	// Use search flags if specified.
+	if flag.SearchFlag.IsSet() {
+		vm, err := flag.SearchFlag.VirtualMachine()
+		if err != nil {
+			return nil, err
+		}
+
+		flag.vm = vm
+		return flag.vm, nil
+	}
+
+	// Never look for a default virtual machine.
+	if flag.name == "" {
+		return nil, nil
+	}
+
+	finder, err := flag.Finder()
+	if err != nil {
+		return nil, err
+	}
+
+	flag.vm, err = finder.VirtualMachine(ctx, flag.name)
+	return flag.vm, err
+}

--- a/vendor/github.com/vmware/govmomi/govc/folder/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/folder/create.go
@@ -1,0 +1,105 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package folder
+
+import (
+	"context"
+	"flag"
+	"path"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type create struct {
+	*flags.DatacenterFlag
+
+	pod bool
+}
+
+func init() {
+	cli.Register("folder.create", &create{})
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.pod, "pod", false, "Create folder(s) of type StoragePod (DatastoreCluster)")
+}
+
+func (cmd *create) Usage() string {
+	return "PATH..."
+}
+
+func (cmd *create) Description() string {
+	return `Create folder with PATH.
+
+Examples:
+  govc folder.create /dc1/vm/folder-foo
+  govc object.mv /dc1/vm/vm-foo-* /dc1/vm/folder-foo
+  govc folder.create -pod /dc1/datastore/sdrs
+  govc object.mv /dc1/datastore/iscsi-* /dc1/datastore/sdrs`
+}
+
+func (cmd *create) Process(ctx context.Context) error {
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	for _, arg := range f.Args() {
+		dir := path.Dir(arg)
+		name := path.Base(arg)
+
+		if dir == "" {
+			dir = "/"
+		}
+
+		folder, err := finder.Folder(ctx, dir)
+		if err != nil {
+			return err
+		}
+
+		var create func() error
+		if cmd.pod {
+			create = func() error {
+				_, err = folder.CreateStoragePod(ctx, name)
+				return err
+			}
+		} else {
+			create = func() error {
+				_, err = folder.CreateFolder(ctx, name)
+				return err
+			}
+		}
+
+		err = create()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/folder/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/folder/info.go
@@ -1,0 +1,147 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package folder
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+	*flags.DatacenterFlag
+}
+
+func init() {
+	cli.Register("folder.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *info) Usage() string {
+	return "[PATH]..."
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	args := f.Args()
+	if len(args) == 0 {
+		args = []string{"/"}
+	}
+
+	var props []string
+	var res infoResult
+
+	if !cmd.OutputFlag.All() {
+		props = []string{
+			"name",
+			"childEntity",
+			"childType",
+		}
+	}
+
+	for _, arg := range args {
+		object, err := finder.FolderList(ctx, arg)
+		if err != nil {
+			return err
+		}
+		res.objects = append(res.objects, object...)
+	}
+
+	if len(res.objects) != 0 {
+		refs := make([]types.ManagedObjectReference, 0, len(res.objects))
+		for _, o := range res.objects {
+			refs = append(refs, o.Reference())
+		}
+
+		pc := property.DefaultCollector(c)
+		err = pc.Retrieve(ctx, refs, props, &res.Folders)
+		if err != nil {
+			return err
+		}
+	}
+
+	return cmd.WriteResult(&res)
+}
+
+type infoResult struct {
+	Folders []mo.Folder
+	objects []*object.Folder
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	// Maintain order via r.objects as Property collector does not always return results in order.
+	objects := make(map[types.ManagedObjectReference]mo.Folder, len(r.Folders))
+	for _, o := range r.Folders {
+		objects[o.Reference()] = o
+	}
+
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for _, o := range r.objects {
+		info := objects[o.Reference()]
+		fmt.Fprintf(tw, "Name:\t%s\n", info.Name)
+		fmt.Fprintf(tw, "  Path:\t%s\n", o.InventoryPath)
+		fmt.Fprintf(tw, "  Types:\t%v\n", strings.Join(info.ChildType, ","))
+		fmt.Fprintf(tw, "  Children:\t%d\n", len(info.ChildEntity))
+	}
+
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/account/account.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/account/account.go
@@ -1,0 +1,74 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package account
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type AccountFlag struct {
+	*flags.ClientFlag
+	*flags.DatacenterFlag
+	*flags.HostSystemFlag
+
+	types.HostAccountSpec
+}
+
+func newAccountFlag(ctx context.Context) (*AccountFlag, context.Context) {
+	f := &AccountFlag{}
+	f.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	f.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	f.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	return f, ctx
+}
+
+func (f *AccountFlag) Register(ctx context.Context, fs *flag.FlagSet) {
+	f.ClientFlag.Register(ctx, fs)
+	f.DatacenterFlag.Register(ctx, fs)
+	f.HostSystemFlag.Register(ctx, fs)
+
+	fs.StringVar(&f.Id, "id", "", "The ID of the specified account")
+	fs.StringVar(&f.Password, "password", "", "The password for the specified account id")
+	fs.StringVar(&f.Description, "description", "", "The description of the specified account")
+}
+
+func (f *AccountFlag) Process(ctx context.Context) error {
+	if err := f.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := f.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := f.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (f *AccountFlag) HostAccountManager(ctx context.Context) (*object.HostAccountManager, error) {
+	h, err := f.HostSystem()
+	if err != nil {
+		return nil, err
+	}
+
+	return h.ConfigManager().AccountManager(ctx)
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/account/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/account/create.go
@@ -1,0 +1,59 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package account
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+)
+
+type create struct {
+	*AccountFlag
+}
+
+func init() {
+	cli.Register("host.account.create", &create{})
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.AccountFlag, ctx = newAccountFlag(ctx)
+	cmd.AccountFlag.Register(ctx, f)
+}
+
+func (cmd *create) Description() string {
+	return `Create local account on HOST.
+
+Examples:
+  govc host.account.create -id $USER -password password-for-esx60`
+}
+
+func (cmd *create) Process(ctx context.Context) error {
+	if err := cmd.AccountFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	m, err := cmd.AccountFlag.HostAccountManager(ctx)
+	if err != nil {
+		return err
+	}
+	return m.Create(ctx, &cmd.HostAccountSpec)
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/account/remove.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/account/remove.go
@@ -1,0 +1,59 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package account
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+)
+
+type remove struct {
+	*AccountFlag
+}
+
+func init() {
+	cli.Register("host.account.remove", &remove{})
+}
+
+func (cmd *remove) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.AccountFlag, ctx = newAccountFlag(ctx)
+	cmd.AccountFlag.Register(ctx, f)
+}
+
+func (cmd *remove) Description() string {
+	return `Remove local account on HOST.
+
+Examples:
+  govc host.account.remove -id $USER`
+}
+
+func (cmd *remove) Process(ctx context.Context) error {
+	if err := cmd.AccountFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
+	m, err := cmd.AccountFlag.HostAccountManager(ctx)
+	if err != nil {
+		return err
+	}
+	return m.Remove(ctx, cmd.HostAccountSpec.Id)
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/account/update.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/account/update.go
@@ -1,0 +1,59 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package account
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+)
+
+type update struct {
+	*AccountFlag
+}
+
+func init() {
+	cli.Register("host.account.update", &update{})
+}
+
+func (cmd *update) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.AccountFlag, ctx = newAccountFlag(ctx)
+	cmd.AccountFlag.Register(ctx, f)
+}
+
+func (cmd *update) Description() string {
+	return `Update local account on HOST.
+
+Examples:
+  govc host.account.update -id root -password password-for-esx60`
+}
+
+func (cmd *update) Process(ctx context.Context) error {
+	if err := cmd.AccountFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *update) Run(ctx context.Context, f *flag.FlagSet) error {
+	m, err := cmd.AccountFlag.HostAccountManager(ctx)
+	if err != nil {
+		return err
+	}
+	return m.Update(ctx, &cmd.HostAccountSpec)
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/add.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/add.go
@@ -1,0 +1,116 @@
+/*
+Copyright (c) 2015-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package host
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type add struct {
+	*flags.FolderFlag
+	*flags.HostConnectFlag
+
+	connect bool
+}
+
+func init() {
+	cli.Register("host.add", &add{})
+}
+
+func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.FolderFlag, ctx = flags.NewFolderFlag(ctx)
+	cmd.FolderFlag.Register(ctx, f)
+
+	cmd.HostConnectFlag, ctx = flags.NewHostConnectFlag(ctx)
+	cmd.HostConnectFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.connect, "connect", true, "Immediately connect to host")
+}
+
+func (cmd *add) Process(ctx context.Context) error {
+	if err := cmd.FolderFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostConnectFlag.Process(ctx); err != nil {
+		return err
+	}
+	if cmd.HostName == "" {
+		return flag.ErrHelp
+	}
+	if cmd.UserName == "" {
+		return flag.ErrHelp
+	}
+	if cmd.Password == "" {
+		return flag.ErrHelp
+	}
+	return nil
+}
+
+func (cmd *add) Description() string {
+	return `Add host to datacenter.
+
+The host is added to the folder specified by the 'folder' flag. If not given,
+this defaults to the host folder in the specified or default datacenter.
+
+Examples:
+  thumbprint=$(govc about.cert -k -u host.example.com -thumbprint | awk '{print $2}')
+  govc host.add -hostname host.example.com -username root -password pass -thumbprint $thumbprint
+  govc host.add -hostname 10.0.6.1 -username root -password pass -noverify`
+}
+
+func (cmd *add) Add(ctx context.Context, parent *object.Folder) error {
+	spec := cmd.Spec(parent.Client())
+
+	req := types.AddStandaloneHost_Task{
+		This:         parent.Reference(),
+		Spec:         spec,
+		AddConnected: cmd.connect,
+	}
+
+	res, err := methods.AddStandaloneHost_Task(ctx, parent.Client(), &req)
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("adding %s to folder %s... ", spec.HostName, parent.InventoryPath))
+	defer logger.Wait()
+
+	task := object.NewTask(parent.Client(), res.Returnval)
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}
+
+func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 0 {
+		return flag.ErrHelp
+	}
+
+	folder, err := cmd.FolderOrDefault("host")
+	if err != nil {
+		return err
+	}
+
+	return cmd.Fault(cmd.Add(ctx, folder))
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/autostart/add.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/autostart/add.go
@@ -1,0 +1,88 @@
+/*
+Copyright (c) 2015-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autostart
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type add struct {
+	*AutostartFlag
+	// from types.AutoStartPowerInfo
+	StartOrder       int32
+	StartDelay       int32
+	WaitForHeartbeat string
+	StartAction      string
+	StopDelay        int32
+	StopAction       string
+}
+
+func init() {
+	cli.Register("host.autostart.add", &add{})
+}
+
+var waitHeartbeatTypes = []string{
+	string(types.AutoStartWaitHeartbeatSettingSystemDefault),
+	string(types.AutoStartWaitHeartbeatSettingYes),
+	string(types.AutoStartWaitHeartbeatSettingNo),
+}
+
+func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.AutostartFlag, ctx = newAutostartFlag(ctx)
+	cmd.AutostartFlag.Register(ctx, f)
+
+	cmd.StartOrder = -1
+	cmd.StartDelay = -1
+	cmd.StopDelay = -1
+	f.Var(flags.NewInt32(&cmd.StartOrder), "start-order", "Start Order")
+	f.Var(flags.NewInt32(&cmd.StartDelay), "start-delay", "Start Delay")
+	f.Var(flags.NewInt32(&cmd.StopDelay), "stop-delay", "Stop Delay")
+	f.StringVar(&cmd.StartAction, "start-action", "powerOn", "Start Action")
+	f.StringVar(&cmd.StopAction, "stop-action", "systemDefault", "Stop Action")
+	f.StringVar(&cmd.WaitForHeartbeat, "wait", waitHeartbeatTypes[0],
+		fmt.Sprintf("Wait for Hearbeat Setting (%s)", strings.Join(waitHeartbeatTypes, "|")))
+}
+
+func (cmd *add) Process(ctx context.Context) error {
+	if err := cmd.AutostartFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *add) Usage() string {
+	return "VM..."
+}
+
+func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
+	powerInfo := types.AutoStartPowerInfo{
+		StartOrder:       cmd.StartOrder,
+		StartDelay:       cmd.StartDelay,
+		WaitForHeartbeat: types.AutoStartWaitHeartbeatSetting(cmd.WaitForHeartbeat),
+		StartAction:      cmd.StartAction,
+		StopDelay:        cmd.StopDelay,
+		StopAction:       cmd.StopAction,
+	}
+	return cmd.ReconfigureVMs(f.Args(), powerInfo)
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/autostart/autostart.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/autostart/autostart.go
@@ -1,0 +1,177 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autostart
+
+import (
+	"context"
+	"errors"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type AutostartFlag struct {
+	*flags.ClientFlag
+	*flags.DatacenterFlag
+	*flags.HostSystemFlag
+}
+
+func newAutostartFlag(ctx context.Context) (*AutostartFlag, context.Context) {
+	f := &AutostartFlag{}
+	f.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	f.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	f.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	return f, ctx
+}
+
+func (f *AutostartFlag) Register(ctx context.Context, fs *flag.FlagSet) {
+	f.ClientFlag.Register(ctx, fs)
+	f.DatacenterFlag.Register(ctx, fs)
+	f.HostSystemFlag.Register(ctx, fs)
+}
+
+func (f *AutostartFlag) Process(ctx context.Context) error {
+	if err := f.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := f.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := f.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+// VirtualMachines returns list of virtual machine objects based on the
+// arguments specified on the command line. This helper is defined in
+// flags.SearchFlag as well, but that pulls in other virtual machine flags that
+// are not relevant here.
+func (f *AutostartFlag) VirtualMachines(args []string) ([]*object.VirtualMachine, error) {
+	ctx := context.TODO()
+	if len(args) == 0 {
+		return nil, errors.New("no argument")
+	}
+
+	finder, err := f.Finder()
+	if err != nil {
+		return nil, err
+	}
+
+	var out []*object.VirtualMachine
+	for _, arg := range args {
+		vms, err := finder.VirtualMachineList(ctx, arg)
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, vms...)
+	}
+
+	return out, nil
+}
+
+func (f *AutostartFlag) HostAutoStartManager() (*mo.HostAutoStartManager, error) {
+	ctx := context.TODO()
+	h, err := f.HostSystem()
+	if err != nil {
+		return nil, err
+	}
+
+	var mhs mo.HostSystem
+	err = h.Properties(ctx, h.Reference(), []string{"configManager.autoStartManager"}, &mhs)
+	if err != nil {
+		return nil, err
+	}
+
+	var mhas mo.HostAutoStartManager
+	err = h.Properties(ctx, *mhs.ConfigManager.AutoStartManager, nil, &mhas)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mhas, nil
+}
+
+func (f *AutostartFlag) ReconfigureDefaults(template types.AutoStartDefaults) error {
+	ctx := context.TODO()
+	c, err := f.Client()
+	if err != nil {
+		return err
+	}
+
+	mhas, err := f.HostAutoStartManager()
+	if err != nil {
+		return err
+	}
+
+	req := types.ReconfigureAutostart{
+		This: mhas.Reference(),
+		Spec: types.HostAutoStartManagerConfig{
+			Defaults: &template,
+		},
+	}
+
+	_, err = methods.ReconfigureAutostart(ctx, c, &req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (f *AutostartFlag) ReconfigureVMs(args []string, template types.AutoStartPowerInfo) error {
+	ctx := context.TODO()
+	c, err := f.Client()
+	if err != nil {
+		return err
+	}
+
+	mhas, err := f.HostAutoStartManager()
+	if err != nil {
+		return err
+	}
+
+	req := types.ReconfigureAutostart{
+		This: mhas.Reference(),
+		Spec: types.HostAutoStartManagerConfig{
+			PowerInfo: make([]types.AutoStartPowerInfo, 0),
+		},
+	}
+
+	vms, err := f.VirtualMachines(args)
+	if err != nil {
+		return err
+	}
+
+	for _, vm := range vms {
+		pi := template
+		pi.Key = vm.Reference()
+		req.Spec.PowerInfo = append(req.Spec.PowerInfo, pi)
+	}
+
+	_, err = methods.ReconfigureAutostart(ctx, c, &req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/autostart/configure.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/autostart/configure.go
@@ -1,0 +1,58 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autostart
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type configure struct {
+	*AutostartFlag
+
+	types.AutoStartDefaults
+}
+
+func init() {
+	cli.Register("host.autostart.configure", &configure{})
+}
+
+func (cmd *configure) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.AutostartFlag, ctx = newAutostartFlag(ctx)
+	cmd.AutostartFlag.Register(ctx, f)
+
+	f.Var(flags.NewOptionalBool(&cmd.Enabled), "enabled", "Enable autostart")
+	f.Var(flags.NewInt32(&cmd.StartDelay), "start-delay", "Start delay")
+	f.StringVar(&cmd.StopAction, "stop-action", "", "Stop action")
+	f.Var(flags.NewInt32(&cmd.StopDelay), "stop-delay", "Stop delay")
+	f.Var(flags.NewOptionalBool(&cmd.WaitForHeartbeat), "wait-for-heartbeat", "Wait for hearbeat")
+}
+
+func (cmd *configure) Process(ctx context.Context) error {
+	if err := cmd.AutostartFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *configure) Run(ctx context.Context, f *flag.FlagSet) error {
+	return cmd.ReconfigureDefaults(cmd.AutoStartDefaults)
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/autostart/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/autostart/info.go
@@ -1,0 +1,140 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autostart
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+type info struct {
+	cli.Command
+
+	*AutostartFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("host.autostart.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.AutostartFlag, ctx = newAutostartFlag(ctx)
+	cmd.AutostartFlag.Register(ctx, f)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.AutostartFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	client, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	mhas, err := cmd.HostAutoStartManager()
+	if err != nil {
+		return err
+	}
+
+	return cmd.WriteResult(&infoResult{client, mhas})
+}
+
+type infoResult struct {
+	client *vim25.Client
+	mhas   *mo.HostAutoStartManager
+}
+
+func (r *infoResult) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.mhas)
+}
+
+// vmPaths resolves the paths for the VMs in the result.
+func (r *infoResult) vmPaths() (map[string]string, error) {
+	ctx := context.TODO()
+	paths := make(map[string]string)
+	for _, info := range r.mhas.Config.PowerInfo {
+		mes, err := mo.Ancestors(ctx, r.client, r.client.ServiceContent.PropertyCollector, info.Key)
+		if err != nil {
+			return nil, err
+		}
+
+		path := ""
+		for _, me := range mes {
+			// Skip root entity in building inventory path.
+			if me.Parent == nil {
+				continue
+			}
+			path += "/" + me.Name
+		}
+
+		paths[info.Key.Value] = path
+	}
+
+	return paths, nil
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	paths, err := r.vmPaths()
+	if err != nil {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
+
+	fmt.Fprintf(tw, "VM")
+	fmt.Fprintf(tw, "\tStartAction")
+	fmt.Fprintf(tw, "\tStartDelay")
+	fmt.Fprintf(tw, "\tStartOrder")
+	fmt.Fprintf(tw, "\tStopAction")
+	fmt.Fprintf(tw, "\tStopDelay")
+	fmt.Fprintf(tw, "\tWaitForHeartbeat")
+	fmt.Fprintf(tw, "\n")
+
+	for _, info := range r.mhas.Config.PowerInfo {
+		fmt.Fprintf(tw, "%s", paths[info.Key.Value])
+		fmt.Fprintf(tw, "\t%s", info.StartAction)
+		fmt.Fprintf(tw, "\t%d", info.StartDelay)
+		fmt.Fprintf(tw, "\t%d", info.StartOrder)
+		fmt.Fprintf(tw, "\t%s", info.StopAction)
+		fmt.Fprintf(tw, "\t%d", info.StopDelay)
+		fmt.Fprintf(tw, "\t%s", info.WaitForHeartbeat)
+		fmt.Fprintf(tw, "\n")
+	}
+
+	_ = tw.Flush()
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/autostart/remove.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/autostart/remove.go
@@ -1,0 +1,62 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autostart
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type remove struct {
+	*AutostartFlag
+}
+
+func init() {
+	cli.Register("host.autostart.remove", &remove{})
+}
+
+func (cmd *remove) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.AutostartFlag, ctx = newAutostartFlag(ctx)
+	cmd.AutostartFlag.Register(ctx, f)
+}
+
+func (cmd *remove) Process(ctx context.Context) error {
+	if err := cmd.AutostartFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *remove) Usage() string {
+	return "VM..."
+}
+
+func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
+	var powerInfo = types.AutoStartPowerInfo{
+		StartAction:      "none",
+		StartDelay:       -1,
+		StartOrder:       -1,
+		StopAction:       "none",
+		StopDelay:        -1,
+		WaitForHeartbeat: types.AutoStartWaitHeartbeatSettingSystemDefault,
+	}
+
+	return cmd.ReconfigureVMs(f.Args(), powerInfo)
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/cert/csr.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/cert/csr.go
@@ -1,0 +1,74 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cert
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type csr struct {
+	*flags.HostSystemFlag
+
+	ip bool
+}
+
+func init() {
+	cli.Register("host.cert.csr", &csr{})
+}
+
+func (cmd *csr) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.ip, "ip", false, "Use IP address as CN")
+}
+
+func (cmd *csr) Description() string {
+	return `Generate a certificate-signing request (CSR) for HOST.`
+}
+
+func (cmd *csr) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *csr) Run(ctx context.Context, f *flag.FlagSet) error {
+	host, err := cmd.HostSystem()
+	if err != nil {
+		return err
+	}
+
+	m, err := host.ConfigManager().CertificateManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	output, err := m.GenerateCertificateSigningRequest(ctx, cmd.ip)
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Println(output)
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/cert/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/cert/info.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cert
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type info struct {
+	*flags.HostSystemFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("host.cert.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *info) Description() string {
+	return `Display SSL certificate info for HOST.`
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	host, err := cmd.HostSystem()
+	if err != nil {
+		return err
+	}
+
+	m, err := host.ConfigManager().CertificateManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	info, err := m.CertificateInfo(ctx)
+	if err != nil {
+		return err
+	}
+
+	return cmd.WriteResult(info)
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/cert/install.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/cert/install.go
@@ -1,0 +1,91 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cert
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type install struct {
+	*flags.HostSystemFlag
+}
+
+func init() {
+	cli.Register("host.cert.import", &install{})
+}
+
+func (cmd *install) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+}
+
+func (cmd *install) Usage() string {
+	return "FILE"
+}
+
+func (cmd *install) Description() string {
+	return `Install SSL certificate FILE on HOST.
+
+If FILE name is "-", read certificate from stdin.`
+}
+
+func (cmd *install) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *install) Run(ctx context.Context, f *flag.FlagSet) error {
+	host, err := cmd.HostSystem()
+	if err != nil {
+		return err
+	}
+
+	m, err := host.ConfigManager().CertificateManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	var cert string
+
+	name := f.Arg(0)
+	if name == "-" || name == "" {
+		var buf bytes.Buffer
+		if _, err := io.Copy(&buf, os.Stdin); err != nil {
+			return err
+		}
+		cert = buf.String()
+	} else {
+		b, err := ioutil.ReadFile(filepath.Clean(name))
+		if err != nil {
+			return err
+		}
+		cert = string(b)
+	}
+
+	return m.InstallServerCertificate(ctx, cert)
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/date/change.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/date/change.go
@@ -1,0 +1,103 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package date
+
+import (
+	"context"
+	"flag"
+	"strings"
+	"time"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type change struct {
+	*flags.HostSystemFlag
+
+	types.HostNtpConfig
+	types.HostDateTimeConfig
+	date string
+}
+
+func init() {
+	cli.Register("host.date.change", &change{})
+}
+
+type serverConfig types.HostNtpConfig
+
+func (s *serverConfig) String() string {
+	return strings.Join(s.Server, ",")
+}
+
+func (s *serverConfig) Set(v string) error {
+	s.Server = append(s.Server, v)
+	return nil
+}
+
+func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	f.Var((*serverConfig)(&cmd.HostNtpConfig), "server", "IP or FQDN for NTP server(s)")
+	f.StringVar(&cmd.TimeZone, "tz", "", "Change timezone of the host")
+	f.StringVar(&cmd.date, "date", "", "Update the date/time on the host")
+}
+
+func (cmd *change) Description() string {
+	return `Change date and time for HOST.
+
+Examples:
+  govc host.date.change -date "$(date -u)"
+  govc host.date.change -server time.vmware.com
+  govc host.service enable ntpd
+  govc host.service start ntpd`
+}
+
+func (cmd *change) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
+	host, err := cmd.HostSystem()
+	if err != nil {
+		return err
+	}
+
+	s, err := host.ConfigManager().DateTimeSystem(ctx)
+	if err != nil {
+		return err
+	}
+
+	if cmd.date != "" {
+		d, err := time.Parse(time.UnixDate, cmd.date)
+		if err != nil {
+			return err
+		}
+		return s.Update(ctx, d)
+	}
+
+	if len(cmd.HostNtpConfig.Server) > 0 {
+		cmd.NtpConfig = &cmd.HostNtpConfig
+	}
+
+	return s.UpdateConfig(ctx, cmd.HostDateTimeConfig)
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/date/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/date/info.go
@@ -1,0 +1,133 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package date
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/govc/host/service"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*flags.HostSystemFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("host.date.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *info) Description() string {
+	return `Display date and time info for HOST.`
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+type dateInfo struct {
+	types.HostDateTimeInfo
+	Service *types.HostService
+	Current *time.Time
+}
+
+func (info *dateInfo) servers() string {
+	if len(info.NtpConfig.Server) == 0 {
+		return "None"
+	}
+	return strings.Join(info.NtpConfig.Server, ", ")
+}
+
+func (info *dateInfo) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	fmt.Fprintf(tw, "Current date and time:\t%s\n", info.Current.Format(time.UnixDate))
+	if info.Service != nil {
+		fmt.Fprintf(tw, "NTP client status:\t%s\n", service.Policy(*info.Service))
+		fmt.Fprintf(tw, "NTP service status:\t%s\n", service.Status(*info.Service))
+	}
+	fmt.Fprintf(tw, "NTP servers:\t%s\n", info.servers())
+
+	return tw.Flush()
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	host, err := cmd.HostSystem()
+	if err != nil {
+		return err
+	}
+
+	s, err := host.ConfigManager().DateTimeSystem(ctx)
+	if err != nil {
+		return err
+	}
+
+	var hs mo.HostDateTimeSystem
+	if err = s.Properties(ctx, s.Reference(), nil, &hs); err != nil {
+		return nil
+	}
+
+	ss, err := host.ConfigManager().ServiceSystem(ctx)
+	if err != nil {
+		return err
+	}
+
+	services, err := ss.Service(ctx)
+	if err != nil {
+		return err
+	}
+
+	res := &dateInfo{HostDateTimeInfo: hs.DateTimeInfo}
+
+	for i, service := range services {
+		if service.Key == "ntpd" {
+			res.Service = &services[i]
+			break
+		}
+	}
+
+	res.Current, err = s.Query(ctx)
+	if err != nil {
+		return err
+	}
+
+	return cmd.WriteResult(res)
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/disconnect.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/disconnect.go
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package host
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type disconnect struct {
+	*flags.HostSystemFlag
+}
+
+func init() {
+	cli.Register("host.disconnect", &disconnect{})
+}
+
+func (cmd *disconnect) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+}
+
+func (cmd *disconnect) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *disconnect) Description() string {
+	return `Disconnect HOST from vCenter.`
+}
+
+func (cmd *disconnect) Disconnect(ctx context.Context, host *object.HostSystem) error {
+	task, err := host.Disconnect(ctx)
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("%s disconnecting... ", host.InventoryPath))
+	defer logger.Wait()
+
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}
+
+func (cmd *disconnect) Run(ctx context.Context, f *flag.FlagSet) error {
+	hosts, err := cmd.HostSystems(f.Args())
+	if err != nil {
+		return err
+	}
+
+	for _, host := range hosts {
+		err = cmd.Disconnect(ctx, host)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/esxcli/command.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/esxcli/command.go
@@ -1,0 +1,149 @@
+/*
+Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package esxcli
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/vmware/govmomi/internal"
+)
+
+type Command struct {
+	name []string
+	args []string
+}
+
+type CommandInfoItem struct {
+	Name        string `xml:"name"`
+	DisplayName string `xml:"displayName"`
+	Help        string `xml:"help"`
+}
+
+type CommandInfoParam struct {
+	CommandInfoItem
+	Aliases []string `xml:"aliases"`
+	Flag    bool     `xml:"flag"`
+}
+
+type CommandInfoHint struct {
+	Key   string `xml:"key"`
+	Value string `xml:"value"`
+}
+
+type CommandInfoHints []CommandInfoHint
+
+type CommandInfoMethod struct {
+	CommandInfoItem
+	Param []CommandInfoParam `xml:"param"`
+	Hints CommandInfoHints   `xml:"hints"`
+}
+
+type CommandInfo struct {
+	CommandInfoItem
+	Method []*CommandInfoMethod `xml:"method"`
+}
+
+func NewCommand(args []string) *Command {
+	c := &Command{}
+
+	for i, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			c.args = args[i:]
+			break
+		} else {
+			c.name = append(c.name, arg)
+		}
+	}
+
+	return c
+}
+
+func (c *Command) Namespace() string {
+	return strings.Join(c.name[:len(c.name)-1], ".")
+}
+
+func (c *Command) Name() string {
+	return c.name[len(c.name)-1]
+}
+
+func (c *Command) Method() string {
+	return "vim.EsxCLI." + strings.Join(c.name, ".")
+}
+
+func (c *Command) Moid() string {
+	return "ha-cli-handler-" + strings.Join(c.name[:len(c.name)-1], "-")
+}
+
+// Parse generates a flag.FlagSet based on the given []CommandInfoParam and
+// returns arguments for use with methods.ExecuteSoap
+func (c *Command) Parse(params []CommandInfoParam) ([]internal.ReflectManagedMethodExecuterSoapArgument, error) {
+	flags := flag.NewFlagSet(strings.Join(c.name, " "), flag.ExitOnError)
+	vals := make([]string, len(params))
+
+	for i, p := range params {
+		v := &vals[i]
+		for _, a := range p.Aliases {
+			a = strings.TrimPrefix(a[1:], "-")
+			flags.StringVar(v, a, "", p.Help)
+		}
+	}
+
+	err := flags.Parse(c.args)
+	if err != nil {
+		return nil, err
+	}
+
+	args := []internal.ReflectManagedMethodExecuterSoapArgument{}
+
+	for i, p := range params {
+		if vals[i] == "" {
+			continue
+		}
+		args = append(args, c.Argument(p.Name, vals[i]))
+	}
+
+	return args, nil
+}
+
+func (c *Command) Argument(name string, val string) internal.ReflectManagedMethodExecuterSoapArgument {
+	return internal.ReflectManagedMethodExecuterSoapArgument{
+		Name: name,
+		Val:  fmt.Sprintf("<%s>%s</%s>", name, val, name),
+	}
+}
+
+func (h CommandInfoHints) Formatter() string {
+	for _, hint := range h {
+		if hint.Key == "formatter" {
+			return hint.Value
+		}
+	}
+
+	return "simple"
+}
+
+func (h CommandInfoHints) Fields() []string {
+	for _, hint := range h {
+		if strings.HasPrefix(hint.Key, "fields:") {
+			return strings.Split(hint.Value, ",")
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/esxcli/esxcli.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/esxcli/esxcli.go
@@ -1,0 +1,181 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package esxcli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type esxcli struct {
+	*flags.HostSystemFlag
+
+	hints bool
+}
+
+func init() {
+	cli.Register("host.esxcli", &esxcli{})
+}
+
+func (cmd *esxcli) Usage() string {
+	return "COMMAND [ARG]..."
+}
+
+func (cmd *esxcli) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.hints, "hints", true, "Use command info hints when formatting output")
+}
+
+func (cmd *esxcli) Description() string {
+	return `Invoke esxcli command on HOST.
+
+Output is rendered in table form when possible, unless disabled with '-hints=false'.
+
+Examples:
+  govc host.esxcli network ip connection list
+  govc host.esxcli system settings advanced set -o /Net/GuestIPHack -i 1
+  govc host.esxcli network firewall ruleset set -r remoteSerialPort -e true
+  govc host.esxcli network firewall set -e false`
+}
+
+func (cmd *esxcli) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *esxcli) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	host, err := cmd.HostSystem()
+	if err != nil {
+		return err
+	}
+
+	e, err := NewExecutor(c, host)
+	if err != nil {
+		return err
+	}
+
+	res, err := e.Run(f.Args())
+	if err != nil {
+		return err
+	}
+
+	if len(res.Values) == 0 {
+		if res.String != "" {
+			fmt.Print(res.String)
+			if !strings.HasSuffix(res.String, "\n") {
+				fmt.Println()
+			}
+		}
+		return nil
+	}
+
+	return cmd.WriteResult(&result{res, cmd})
+}
+
+type result struct {
+	*Response
+	cmd *esxcli
+}
+
+func (r *result) Write(w io.Writer) error {
+	var formatType string
+	if r.cmd.hints {
+		formatType = r.Info.Hints.Formatter()
+	}
+
+	switch formatType {
+	case "table":
+		r.cmd.formatTable(w, r.Response)
+	default:
+		r.cmd.formatSimple(w, r.Response)
+	}
+
+	return nil
+}
+
+func (cmd *esxcli) formatSimple(w io.Writer, res *Response) {
+	var keys []string
+	for key := range res.Values[0] {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for i, rv := range res.Values {
+		if i > 0 {
+			fmt.Fprintln(tw)
+			_ = tw.Flush()
+		}
+		for _, key := range keys {
+			fmt.Fprintf(tw, "%s:\t%s\n", key, strings.Join(rv[key], ", "))
+		}
+	}
+
+	_ = tw.Flush()
+}
+
+func (cmd *esxcli) formatTable(w io.Writer, res *Response) {
+	fields := res.Info.Hints.Fields()
+	if len(fields) == 0 {
+		cmd.formatSimple(w, res)
+		return
+	}
+	tw := tabwriter.NewWriter(w, len(fields), 0, 2, ' ', 0)
+
+	var hr []string
+	for _, name := range fields {
+		hr = append(hr, strings.Repeat("-", len(name)))
+	}
+
+	fmt.Fprintln(tw, strings.Join(fields, "\t"))
+	fmt.Fprintln(tw, strings.Join(hr, "\t"))
+
+	for _, vals := range res.Values {
+		var row []string
+
+		for _, name := range fields {
+			key := strings.Replace(name, " ", "", -1)
+			if val, ok := vals[key]; ok {
+				row = append(row, strings.Join(val, ", "))
+			} else {
+				row = append(row, "")
+			}
+		}
+
+		fmt.Fprintln(tw, strings.Join(row, "\t"))
+	}
+
+	_ = tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/esxcli/executor.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/esxcli/executor.go
@@ -1,0 +1,167 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package esxcli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/vmware/govmomi/internal"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/xml"
+)
+
+type Executor struct {
+	c    *vim25.Client
+	host *object.HostSystem
+	mme  *internal.ReflectManagedMethodExecuter
+	dtm  *internal.InternalDynamicTypeManager
+	info map[string]*CommandInfo
+}
+
+func NewExecutor(c *vim25.Client, host *object.HostSystem) (*Executor, error) {
+	ctx := context.TODO()
+	e := &Executor{
+		c:    c,
+		host: host,
+		info: make(map[string]*CommandInfo),
+	}
+
+	{
+		req := internal.RetrieveManagedMethodExecuterRequest{
+			This: host.Reference(),
+		}
+
+		res, err := internal.RetrieveManagedMethodExecuter(ctx, c, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		e.mme = res.Returnval
+	}
+
+	{
+		req := internal.RetrieveDynamicTypeManagerRequest{
+			This: host.Reference(),
+		}
+
+		res, err := internal.RetrieveDynamicTypeManager(ctx, c, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		e.dtm = res.Returnval
+	}
+
+	return e, nil
+}
+
+func (e *Executor) CommandInfo(c *Command) (*CommandInfoMethod, error) {
+	ns := c.Namespace()
+	var info *CommandInfo
+	var ok bool
+
+	if info, ok = e.info[ns]; !ok {
+		req := internal.ExecuteSoapRequest{
+			Moid:   "ha-dynamic-type-manager-local-cli-cliinfo",
+			Method: "vim.CLIInfo.FetchCLIInfo",
+			Argument: []internal.ReflectManagedMethodExecuterSoapArgument{
+				c.Argument("typeName", "vim.EsxCLI."+ns),
+			},
+		}
+
+		info = new(CommandInfo)
+		if err := e.Execute(&req, info); err != nil {
+			return nil, err
+		}
+
+		e.info[ns] = info
+	}
+
+	name := c.Name()
+	for _, method := range info.Method {
+		if method.Name == name {
+			return method, nil
+		}
+	}
+
+	return nil, fmt.Errorf("method '%s' not found in name space '%s'", name, c.Namespace())
+}
+
+func (e *Executor) NewRequest(args []string) (*internal.ExecuteSoapRequest, *CommandInfoMethod, error) {
+	c := NewCommand(args)
+
+	info, err := e.CommandInfo(c)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sargs, err := c.Parse(info.Param)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sreq := internal.ExecuteSoapRequest{
+		Moid:     c.Moid(),
+		Method:   c.Method(),
+		Argument: sargs,
+	}
+
+	return &sreq, info, nil
+}
+
+func (e *Executor) Execute(req *internal.ExecuteSoapRequest, res interface{}) error {
+	ctx := context.TODO()
+	req.This = e.mme.ManagedObjectReference
+	req.Version = "urn:vim25/5.0"
+
+	x, err := internal.ExecuteSoap(ctx, e.c, req)
+	if err != nil {
+		return err
+	}
+
+	if x.Returnval != nil {
+		if x.Returnval.Fault != nil {
+			return errors.New(x.Returnval.Fault.FaultMsg)
+		}
+
+		if err := xml.Unmarshal([]byte(x.Returnval.Response), res); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (e *Executor) Run(args []string) (*Response, error) {
+	req, info, err := e.NewRequest(args)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &Response{
+		Info: info,
+	}
+
+	if err := e.Execute(req, res); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/esxcli/firewall_info.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/esxcli/firewall_info.go
@@ -1,0 +1,48 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package esxcli
+
+import "github.com/vmware/govmomi/object"
+
+type FirewallInfo struct {
+	Loaded        bool
+	Enabled       bool
+	DefaultAction string
+}
+
+// GetFirewallInfo via 'esxcli network firewall get'
+// The HostFirewallSystem type does not expose this data.
+// This helper can be useful in particular to determine if the firewall is enabled or disabled.
+func GetFirewallInfo(s *object.HostSystem) (*FirewallInfo, error) {
+	x, err := NewExecutor(s.Client(), s)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := x.Run([]string{"network", "firewall", "get"})
+	if err != nil {
+		return nil, err
+	}
+
+	info := &FirewallInfo{
+		Loaded:        res.Values[0]["Loaded"][0] == "true",
+		Enabled:       res.Values[0]["Enabled"][0] == "true",
+		DefaultAction: res.Values[0]["DefaultAction"][0],
+	}
+
+	return info, nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/esxcli/guest_info.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/esxcli/guest_info.go
@@ -1,0 +1,120 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package esxcli
+
+import (
+	"context"
+	"strings"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type hostInfo struct {
+	*Executor
+	wids map[string]string
+}
+
+type GuestInfo struct {
+	c     *vim25.Client
+	hosts map[string]*hostInfo
+}
+
+func NewGuestInfo(c *vim25.Client) *GuestInfo {
+	return &GuestInfo{
+		c:     c,
+		hosts: make(map[string]*hostInfo),
+	}
+}
+
+func (g *GuestInfo) hostInfo(ref *types.ManagedObjectReference) (*hostInfo, error) {
+	// cache exectuor and uuid -> worldid map
+	if h, ok := g.hosts[ref.Value]; ok {
+		return h, nil
+	}
+
+	host := object.NewHostSystem(g.c, *ref)
+
+	e, err := NewExecutor(g.c, host)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := e.Run([]string{"vm", "process", "list"})
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make(map[string]string, len(res.Values))
+
+	for _, process := range res.Values {
+		// Normalize uuid, esxcli and mo.VirtualMachine have different formats
+		uuid := strings.Replace(process["UUID"][0], " ", "", -1)
+		uuid = strings.Replace(uuid, "-", "", -1)
+
+		ids[uuid] = process["WorldID"][0]
+	}
+
+	h := &hostInfo{e, ids}
+	g.hosts[ref.Value] = h
+
+	return h, nil
+}
+
+// IpAddress attempts to find the guest IP address using esxcli.
+// ESX hosts must be configured with the /Net/GuestIPHack enabled.
+// For example:
+// $ govc host.esxcli -- system settings advanced set -o /Net/GuestIPHack -i 1
+func (g *GuestInfo) IpAddress(vm *object.VirtualMachine) (string, error) {
+	ctx := context.TODO()
+	const any = "0.0.0.0"
+	var mvm mo.VirtualMachine
+
+	pc := property.DefaultCollector(g.c)
+	err := pc.RetrieveOne(ctx, vm.Reference(), []string{"runtime.host", "config.uuid"}, &mvm)
+	if err != nil {
+		return "", err
+	}
+
+	h, err := g.hostInfo(mvm.Runtime.Host)
+	if err != nil {
+		return "", err
+	}
+
+	// Normalize uuid, esxcli and mo.VirtualMachine have different formats
+	uuid := strings.Replace(mvm.Config.Uuid, "-", "", -1)
+
+	if wid, ok := h.wids[uuid]; ok {
+		res, err := h.Run([]string{"network", "vm", "port", "list", "--world-id", wid})
+		if err != nil {
+			return "", err
+		}
+
+		for _, val := range res.Values {
+			if ip, ok := val["IPAddress"]; ok {
+				if ip[0] != any {
+					return ip[0], nil
+				}
+			}
+		}
+	}
+
+	return any, nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/esxcli/response.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/esxcli/response.go
@@ -1,0 +1,102 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package esxcli
+
+import (
+	"io"
+
+	"github.com/vmware/govmomi/vim25/xml"
+)
+
+type Values map[string][]string
+
+type Response struct {
+	Info   *CommandInfoMethod
+	Values []Values
+	String string
+}
+
+func (v Values) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	for {
+		t, err := d.Token()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+
+		if s, ok := t.(xml.StartElement); ok {
+			t, err = d.Token()
+			if err != nil {
+				return err
+			}
+
+			key := s.Name.Local
+			var val string
+			if c, ok := t.(xml.CharData); ok {
+				val = string(c)
+			}
+			v[key] = append(v[key], val)
+		}
+	}
+}
+
+func (r *Response) Type(start xml.StartElement) string {
+	for _, a := range start.Attr {
+		if a.Name.Local == "type" {
+			return a.Value
+		}
+	}
+	return ""
+}
+
+func (r *Response) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	stype := r.Type(start)
+
+	if stype != "ArrayOfDataObject" {
+		switch stype {
+		case "xsd:string":
+			return d.DecodeElement(&r.String, &start)
+		}
+		v := Values{}
+		if err := d.DecodeElement(&v, &start); err != nil {
+			return err
+		}
+		r.Values = append(r.Values, v)
+		return nil
+	}
+
+	for {
+		t, err := d.Token()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+
+		if s, ok := t.(xml.StartElement); ok {
+			if s.Name.Local == "DataObject" {
+				v := Values{}
+				if err := d.DecodeElement(&v, &s); err != nil {
+					return err
+				}
+				r.Values = append(r.Values, v)
+			}
+		}
+	}
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/firewall/find.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/firewall/find.go
@@ -1,0 +1,131 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package firewall
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/govc/host/esxcli"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type find struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+	*flags.HostSystemFlag
+
+	enabled bool
+	check   bool
+
+	types.HostFirewallRule
+}
+
+func init() {
+	cli.Register("firewall.ruleset.find", &find{})
+}
+
+func (cmd *find) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.check, "c", true, "Check if esx firewall is enabled")
+	f.BoolVar(&cmd.enabled, "enabled", true, "Find enabled rule sets if true, disabled if false")
+	f.StringVar((*string)(&cmd.Direction), "direction", string(types.HostFirewallRuleDirectionOutbound), "Direction")
+	f.StringVar((*string)(&cmd.PortType), "type", string(types.HostFirewallRulePortTypeDst), "Port type")
+	f.StringVar((*string)(&cmd.Protocol), "proto", string(types.HostFirewallRuleProtocolTcp), "Protocol")
+	f.Var(flags.NewInt32(&cmd.Port), "port", "Port")
+}
+
+func (cmd *find) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *find) Description() string {
+	return `Find firewall rulesets matching the given rule.
+
+For a complete list of rulesets: govc host.esxcli network firewall ruleset list
+For a complete list of rules:    govc host.esxcli network firewall ruleset rule list
+
+Examples:
+  govc firewall.ruleset.find -direction inbound -port 22
+  govc firewall.ruleset.find -direction outbound -port 2377`
+}
+
+func (cmd *find) Run(ctx context.Context, f *flag.FlagSet) error {
+	host, err := cmd.HostSystem()
+	if err != nil {
+		return err
+	}
+
+	fs, err := host.ConfigManager().FirewallSystem(ctx)
+	if err != nil {
+		return err
+	}
+
+	if cmd.check {
+		esxfw, err := esxcli.GetFirewallInfo(host)
+		if err != nil {
+			return err
+		}
+
+		if !esxfw.Enabled {
+			fmt.Fprintln(os.Stderr, "host firewall is disabled")
+		}
+	}
+
+	info, err := fs.Info(ctx)
+	if err != nil {
+		return err
+	}
+
+	if f.NArg() != 0 {
+		// TODO: f.Args() -> types.HostFirewallRulesetIpList
+		return flag.ErrHelp
+	}
+
+	rs := object.HostFirewallRulesetList(info.Ruleset)
+	matched, err := rs.EnabledByRule(cmd.HostFirewallRule, cmd.enabled)
+
+	if err != nil {
+		return err
+	}
+
+	for _, r := range matched {
+		fmt.Println(r.Key)
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/info.go
@@ -1,0 +1,163 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package host
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+	*flags.HostSystemFlag
+}
+
+func init() {
+	cli.Register("host.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	var res infoResult
+	var props []string
+
+	if cmd.OutputFlag.All() {
+		props = nil // Load everything
+	} else {
+		props = []string{"summary"} // Load summary
+	}
+
+	// We could do without the -host flag, leaving it for compat
+	host, err := cmd.HostSystemIfSpecified()
+	if err != nil {
+		return err
+	}
+
+	// Default only if there is a single host
+	if host == nil && f.NArg() == 0 {
+		host, err = cmd.HostSystem()
+		if err != nil {
+			return err
+		}
+	}
+
+	if host != nil {
+		res.objects = append(res.objects, host)
+	} else {
+		res.objects, err = cmd.HostSystems(f.Args())
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(res.objects) != 0 {
+		refs := make([]types.ManagedObjectReference, 0, len(res.objects))
+		for _, o := range res.objects {
+			refs = append(refs, o.Reference())
+		}
+
+		pc := property.DefaultCollector(c)
+		err = pc.Retrieve(ctx, refs, props, &res.HostSystems)
+		if err != nil {
+			return err
+		}
+	}
+
+	return cmd.WriteResult(&res)
+}
+
+type infoResult struct {
+	HostSystems []mo.HostSystem
+	objects     []*object.HostSystem
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	// Maintain order via r.objects as Property collector does not always return results in order.
+	objects := make(map[types.ManagedObjectReference]mo.HostSystem, len(r.HostSystems))
+	for _, o := range r.HostSystems {
+		objects[o.Reference()] = o
+	}
+
+	tw := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
+
+	for _, o := range r.objects {
+		host := objects[o.Reference()]
+		s := host.Summary
+		h := s.Hardware
+		z := s.QuickStats
+		ncpu := int32(h.NumCpuThreads)
+		cpuUsage := 100 * float64(z.OverallCpuUsage) / float64(ncpu*h.CpuMhz)
+		memUsage := 100 * float64(z.OverallMemoryUsage) / float64(h.MemorySize>>20)
+
+		fmt.Fprintf(tw, "Name:\t%s\n", s.Config.Name)
+		fmt.Fprintf(tw, "  Path:\t%s\n", o.InventoryPath)
+		fmt.Fprintf(tw, "  Manufacturer:\t%s\n", h.Vendor)
+		fmt.Fprintf(tw, "  Logical CPUs:\t%d CPUs @ %dMHz\n", ncpu, h.CpuMhz)
+		fmt.Fprintf(tw, "  Processor type:\t%s\n", h.CpuModel)
+		fmt.Fprintf(tw, "  CPU usage:\t%d MHz (%.1f%%)\n", z.OverallCpuUsage, cpuUsage)
+		fmt.Fprintf(tw, "  Memory:\t%dMB\n", h.MemorySize/(1024*1024))
+		fmt.Fprintf(tw, "  Memory usage:\t%d MB (%.1f%%)\n", z.OverallMemoryUsage, memUsage)
+		fmt.Fprintf(tw, "  Boot time:\t%s\n", s.Runtime.BootTime)
+		if s.Runtime.InMaintenanceMode {
+			fmt.Fprint(tw, "  State: Maintenance Mode")
+		} else {
+			fmt.Fprintf(tw, "  State:\t%s\n", s.Runtime.ConnectionState)
+		}
+	}
+
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/maintenance/enter.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/maintenance/enter.go
@@ -1,0 +1,93 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maintenance
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type enter struct {
+	*flags.HostSystemFlag
+
+	timeout  int32
+	evacuate bool
+}
+
+func init() {
+	cli.Register("host.maintenance.enter", &enter{})
+}
+
+func (cmd *enter) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	f.Var(flags.NewInt32(&cmd.timeout), "timeout", "Timeout")
+	f.BoolVar(&cmd.evacuate, "evacuate", false, "Evacuate powered off VMs")
+}
+
+func (cmd *enter) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *enter) Usage() string {
+	return "HOST..."
+}
+
+func (cmd *enter) Description() string {
+	return `Put HOST in maintenance mode.
+
+While this task is running and when the host is in maintenance mode,
+no VMs can be powered on and no provisioning operations can be performed on the host.`
+}
+
+func (cmd *enter) EnterMaintenanceMode(ctx context.Context, host *object.HostSystem) error {
+	task, err := host.EnterMaintenanceMode(ctx, cmd.timeout, cmd.evacuate, nil) // TODO: spec param
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("%s entering maintenance mode... ", host.InventoryPath))
+	defer logger.Wait()
+
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}
+
+func (cmd *enter) Run(ctx context.Context, f *flag.FlagSet) error {
+	hosts, err := cmd.HostSystems(f.Args())
+	if err != nil {
+		return err
+	}
+
+	for _, host := range hosts {
+		err = cmd.EnterMaintenanceMode(ctx, host)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/maintenance/exit.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/maintenance/exit.go
@@ -1,0 +1,94 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maintenance
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type exit struct {
+	*flags.HostSystemFlag
+
+	timeout int32
+}
+
+func init() {
+	cli.Register("host.maintenance.exit", &exit{})
+}
+
+func (cmd *exit) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	f.Var(flags.NewInt32(&cmd.timeout), "timeout", "Timeout")
+}
+
+func (cmd *exit) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *exit) Usage() string {
+	return "HOST..."
+}
+
+func (cmd *exit) Description() string {
+	return `Take HOST out of maintenance mode.
+
+This blocks if any concurrent running maintenance-only host configurations operations are being performed.
+For example, if VMFS volumes are being upgraded.
+
+The 'timeout' flag is the number of seconds to wait for the exit maintenance mode to succeed.
+If the timeout is less than or equal to zero, there is no timeout.`
+}
+
+func (cmd *exit) ExitMaintenanceMode(ctx context.Context, host *object.HostSystem) error {
+	task, err := host.ExitMaintenanceMode(ctx, cmd.timeout)
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("%s exiting maintenance mode... ", host.InventoryPath))
+	defer logger.Wait()
+
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}
+
+func (cmd *exit) Run(ctx context.Context, f *flag.FlagSet) error {
+	hosts, err := cmd.HostSystems(f.Args())
+	if err != nil {
+		return err
+	}
+
+	for _, host := range hosts {
+		err = cmd.ExitMaintenanceMode(ctx, host)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/option/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/option/ls.go
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package option
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/govc/option"
+)
+
+type ls struct {
+	*option.List
+	*flags.HostSystemFlag
+}
+
+func init() {
+	cli.Register("host.option.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.List = &option.List{}
+	cmd.List.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.List.ClientFlag.Register(ctx, f)
+
+	cmd.List.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.List.OutputFlag.Register(ctx, f)
+
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.List.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ls) Description() string {
+	return option.ListDescription + `
+
+Examples:
+  govc host.option.ls
+  govc host.option.ls Config.HostAgent.
+  govc host.option.ls Config.HostAgent.plugins.solo.enableMob`
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	host, err := cmd.HostSystem()
+	if err != nil {
+		return err
+	}
+
+	m, err := host.ConfigManager().OptionManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	return cmd.Query(ctx, f, m)
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/option/set.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/option/set.go
@@ -1,0 +1,76 @@
+/*
+Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package option
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/govc/option"
+)
+
+type set struct {
+	*option.Set
+	*flags.HostSystemFlag
+}
+
+func init() {
+	cli.Register("host.option.set", &set{})
+}
+
+func (cmd *set) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.Set = &option.Set{}
+	cmd.Set.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.Set.ClientFlag.Register(ctx, f)
+
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+}
+
+func (cmd *set) Process(ctx context.Context) error {
+	if err := cmd.Set.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *set) Description() string {
+	return option.SetDescription + `
+
+Examples:
+  govc host.option.set Config.HostAgent.plugins.solo.enableMob true
+  govc host.option.set Config.HostAgent.log.level verbose`
+}
+
+func (cmd *set) Run(ctx context.Context, f *flag.FlagSet) error {
+	host, err := cmd.HostSystem()
+	if err != nil {
+		return err
+	}
+
+	m, err := host.ConfigManager().OptionManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	return cmd.Update(ctx, f, m)
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/portgroup/add.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/portgroup/add.go
@@ -1,0 +1,73 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portgroup
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type add struct {
+	*flags.HostSystemFlag
+
+	spec types.HostPortGroupSpec
+}
+
+func init() {
+	cli.Register("host.portgroup.add", &add{})
+}
+
+func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.spec.VswitchName, "vswitch", "", "vSwitch Name")
+	f.Var(flags.NewInt32(&cmd.spec.VlanId), "vlan", "VLAN ID")
+}
+
+func (cmd *add) Description() string {
+	return `Add portgroup to HOST.
+
+Examples:
+  govc host.portgroup.add -vswitch vSwitch0 -vlan 3201 bridge`
+}
+
+func (cmd *add) Usage() string {
+	return "NAME"
+}
+
+func (cmd *add) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
+	ns, err := cmd.HostNetworkSystem()
+	if err != nil {
+		return err
+	}
+
+	cmd.spec.Name = f.Arg(0)
+
+	return ns.AddPortGroup(ctx, cmd.spec)
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/portgroup/change.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/portgroup/change.go
@@ -1,0 +1,118 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portgroup
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type change struct {
+	*flags.ClientFlag
+	*flags.HostSystemFlag
+
+	types.HostPortGroupSpec
+	types.HostNetworkSecurityPolicy
+}
+
+func init() {
+	cli.Register("host.portgroup.change", &change{})
+}
+
+func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	cmd.VlanId = -1
+	f.Var(flags.NewInt32(&cmd.VlanId), "vlan-id", "VLAN ID")
+	f.StringVar(&cmd.Name, "name", "", "Portgroup name")
+	f.StringVar(&cmd.VswitchName, "vswitch-name", "", "vSwitch name")
+
+	f.Var(flags.NewOptionalBool(&cmd.AllowPromiscuous), "allow-promiscuous", "Allow promiscuous mode")
+	f.Var(flags.NewOptionalBool(&cmd.ForgedTransmits), "forged-transmits", "Allow forged transmits")
+	f.Var(flags.NewOptionalBool(&cmd.MacChanges), "mac-changes", "Allow MAC changes")
+}
+
+func (cmd *change) Description() string {
+	return `Change configuration of HOST portgroup NAME.
+
+Examples:
+  govc host.portgroup.change -allow-promiscuous -forged-transmits -mac-changes "VM Network"
+  govc host.portgroup.change -vswitch-name vSwitch1 "Management Network"`
+}
+
+func (cmd *change) Usage() string {
+	return "NAME"
+}
+
+func (cmd *change) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	pg, err := networkInfoPortgroup(ctx, cmd.ClientFlag, cmd.HostSystemFlag)
+	if err != nil {
+		return err
+	}
+
+	ns, err := cmd.HostNetworkSystem()
+	if err != nil {
+		return err
+	}
+
+	name := f.Arg(0)
+	var current *types.HostPortGroupSpec
+
+	for _, g := range pg {
+		if g.Spec.Name == name {
+			current = &g.Spec
+			break
+		}
+	}
+
+	if current != nil {
+		if cmd.Name == "" {
+			cmd.Name = current.Name
+		}
+		if cmd.VswitchName == "" {
+			cmd.VswitchName = current.VswitchName
+		}
+		if cmd.VlanId < 0 {
+			cmd.VlanId = current.VlanId
+		}
+	}
+
+	cmd.HostPortGroupSpec.Policy.Security = &cmd.HostNetworkSecurityPolicy
+
+	return ns.UpdatePortGroup(ctx, name, cmd.HostPortGroupSpec)
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/portgroup/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/portgroup/info.go
@@ -1,0 +1,118 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portgroup
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/govc/host/vswitch"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+	*flags.HostSystemFlag
+}
+
+func init() {
+	cli.Register("host.portgroup.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func networkInfoPortgroup(ctx context.Context, c *flags.ClientFlag, h *flags.HostSystemFlag) ([]types.HostPortGroup, error) {
+	client, err := c.Client()
+	if err != nil {
+		return nil, err
+	}
+
+	ns, err := h.HostNetworkSystem()
+	if err != nil {
+		return nil, err
+	}
+
+	var mns mo.HostNetworkSystem
+
+	pc := property.DefaultCollector(client)
+	err = pc.RetrieveOne(ctx, ns.Reference(), []string{"networkInfo.portgroup"}, &mns)
+	if err != nil {
+		return nil, err
+	}
+
+	return mns.NetworkInfo.Portgroup, nil
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	pg, err := networkInfoPortgroup(ctx, cmd.ClientFlag, cmd.HostSystemFlag)
+	if err != nil {
+		return err
+	}
+
+	r := &infoResult{pg}
+
+	return cmd.WriteResult(r)
+}
+
+type infoResult struct {
+	Portgroup []types.HostPortGroup
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for i, s := range r.Portgroup {
+		if i > 0 {
+			fmt.Fprintln(tw)
+		}
+		fmt.Fprintf(tw, "Name:\t%s\n", s.Spec.Name)
+		fmt.Fprintf(tw, "Virtual switch:\t%s\n", s.Spec.VswitchName)
+		fmt.Fprintf(tw, "VLAN ID:\t%d\n", s.Spec.VlanId)
+		fmt.Fprintf(tw, "Active ports:\t%d\n", len(s.Port))
+		vswitch.HostNetworkPolicy(tw, &s.ComputedPolicy)
+	}
+
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/portgroup/remove.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/portgroup/remove.go
@@ -1,0 +1,65 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portgroup
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type remove struct {
+	*flags.HostSystemFlag
+}
+
+func init() {
+	cli.Register("host.portgroup.remove", &remove{})
+}
+
+func (cmd *remove) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+}
+
+func (cmd *remove) Description() string {
+	return `Remove portgroup from HOST.
+
+Examples:
+  govc host.portgroup.remove bridge`
+}
+
+func (cmd *remove) Usage() string {
+	return "NAME"
+}
+
+func (cmd *remove) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
+	ns, err := cmd.HostNetworkSystem()
+	if err != nil {
+		return err
+	}
+
+	return ns.RemovePortGroup(ctx, f.Arg(0))
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/reconnect.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/reconnect.go
@@ -1,0 +1,96 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package host
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type reconnect struct {
+	*flags.HostSystemFlag
+	*flags.HostConnectFlag
+
+	types.HostSystemReconnectSpec
+}
+
+func init() {
+	cli.Register("host.reconnect", &reconnect{})
+}
+
+func (cmd *reconnect) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	cmd.HostConnectFlag, ctx = flags.NewHostConnectFlag(ctx)
+	cmd.HostConnectFlag.Register(ctx, f)
+
+	cmd.HostSystemReconnectSpec.SyncState = types.NewBool(false)
+	f.BoolVar(cmd.HostSystemReconnectSpec.SyncState, "sync-state", false, "Sync state")
+}
+
+func (cmd *reconnect) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostConnectFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *reconnect) Description() string {
+	return `Reconnect HOST to vCenter.
+
+This command can also be used to change connection properties (hostname, fingerprint, username, password),
+without disconnecting the host.`
+}
+
+func (cmd *reconnect) Reconnect(ctx context.Context, host *object.HostSystem) error {
+	task, err := host.Reconnect(ctx, &cmd.HostConnectSpec, &cmd.HostSystemReconnectSpec)
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("%s reconnecting... ", host.InventoryPath))
+	defer logger.Wait()
+
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}
+
+func (cmd *reconnect) Run(ctx context.Context, f *flag.FlagSet) error {
+	hosts, err := cmd.HostSystems(f.Args())
+	if err != nil {
+		return err
+	}
+
+	for _, host := range hosts {
+		err = cmd.Reconnect(ctx, host)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/remove.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/remove.go
@@ -1,0 +1,100 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package host
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+type remove struct {
+	*flags.HostSystemFlag
+}
+
+func init() {
+	cli.Register("host.remove", &remove{})
+}
+
+func (cmd *remove) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+}
+
+func (cmd *remove) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *remove) Usage() string {
+	return "HOST..."
+}
+
+func (cmd *remove) Description() string {
+	return `Remove HOST from vCenter.`
+}
+
+func (cmd *remove) Remove(ctx context.Context, host *object.HostSystem) error {
+	var h mo.HostSystem
+	err := host.Properties(ctx, host.Reference(), []string{"parent"}, &h)
+	if err != nil {
+		return err
+	}
+
+	remove := host.Destroy
+
+	if h.Parent.Type == "ComputeResource" {
+		// Standalone host.  From the docs:
+		// "Invoking remove on a HostSystem of standalone type throws a NotSupported fault.
+		//  A standalone HostSystem can be removeed only by invoking remove on its parent ComputeResource."
+		remove = object.NewComputeResource(host.Client(), *h.Parent).Destroy
+	}
+
+	task, err := remove(ctx)
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("%s removing... ", host.InventoryPath))
+	defer logger.Wait()
+
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}
+
+func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
+	hosts, err := cmd.HostSystems(f.Args())
+	if err != nil {
+		return err
+	}
+
+	for _, host := range hosts {
+		err = cmd.Remove(ctx, host)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/service/command.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/service/command.go
@@ -1,0 +1,125 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type service struct {
+	*flags.ClientFlag
+	*flags.HostSystemFlag
+}
+
+func init() {
+	cli.Register("host.service", &service{})
+}
+
+func (cmd *service) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+}
+
+func (cmd *service) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *service) Usage() string {
+	return "ACTION ID"
+}
+
+func (cmd *service) Description() string {
+	return `Apply host service ACTION to service ID.
+
+Where ACTION is one of: start, stop, restart, status, enable, disable
+
+Examples:
+  govc host.service enable TSM-SSH
+  govc host.service start TSM-SSH`
+}
+
+func (cmd *service) status(ctx context.Context, s *object.HostServiceSystem, id string) (string, error) {
+	services, err := s.Service(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	for _, service := range services {
+		if id == service.Key {
+			return Status(service), nil
+		}
+	}
+
+	return "N/A", nil
+}
+
+func (cmd *service) Run(ctx context.Context, f *flag.FlagSet) error {
+	host, err := cmd.HostSystem()
+	if err != nil {
+		return err
+	}
+
+	if f.NArg() != 2 {
+		return flag.ErrHelp
+	}
+
+	arg := f.Arg(0)
+	id := f.Arg(1)
+
+	s, err := host.ConfigManager().ServiceSystem(ctx)
+	if err != nil {
+		return err
+	}
+
+	switch arg {
+	case "start":
+		return s.Start(ctx, id)
+	case "stop":
+		return s.Stop(ctx, id)
+	case "restart":
+		return s.Restart(ctx, id)
+	case "status":
+		ss, err := cmd.status(ctx, s, id)
+		if err != nil {
+			return err
+		}
+		fmt.Println(ss)
+		return nil
+	case "enable":
+		return s.UpdatePolicy(ctx, id, string(types.HostServicePolicyOn))
+	case "disable":
+		return s.UpdatePolicy(ctx, id, string(types.HostServicePolicyOff))
+	}
+
+	return flag.ErrHelp
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/service/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/service/ls.go
@@ -1,0 +1,120 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ls struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+	*flags.HostSystemFlag
+}
+
+func init() {
+	cli.Register("host.service.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ls) Description() string {
+	return `List HOST services.`
+}
+
+func Status(s types.HostService) string {
+	if s.Running {
+		return "Running"
+	}
+	return "Stopped"
+}
+
+func Policy(s types.HostService) string {
+	switch types.HostServicePolicy(s.Policy) {
+	case types.HostServicePolicyOff:
+		return "Disabled"
+	case types.HostServicePolicyOn:
+		return "Enabled"
+	case types.HostServicePolicyAutomatic:
+		return "Automatic"
+	default:
+		return s.Policy
+	}
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	host, err := cmd.HostSystem()
+	if err != nil {
+		return err
+	}
+
+	s, err := host.ConfigManager().ServiceSystem(ctx)
+	if err != nil {
+		return err
+	}
+
+	services, err := s.Service(ctx)
+	if err != nil {
+		return err
+	}
+
+	return cmd.WriteResult(optionResult(services))
+}
+
+type optionResult []types.HostService
+
+func (services optionResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	fmt.Fprintf(tw, "%s\t%s\t%v\t%s\n", "Key", "Policy", "Status", "Label")
+
+	for _, s := range services {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", s.Key, s.Policy, Status(s), s.Label)
+	}
+
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/shutdown.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/shutdown.go
@@ -1,0 +1,123 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package host
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type shutdown struct {
+	*flags.HostSystemFlag
+	force  bool
+	reboot bool
+}
+
+func init() {
+	cli.Register("host.shutdown", &shutdown{})
+}
+
+func (cmd *shutdown) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.force, "f", false, "Force shutdown when host is not in maintenance mode")
+	f.BoolVar(&cmd.reboot, "r", false, "Reboot host")
+}
+
+func (cmd *shutdown) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *shutdown) Usage() string {
+	return `HOST...`
+}
+
+func (cmd *shutdown) Description() string {
+	return `Shutdown HOST.`
+}
+
+func (cmd *shutdown) Shutdown(ctx context.Context, host *object.HostSystem) error {
+	req := types.ShutdownHost_Task{
+		This:  host.Reference(),
+		Force: cmd.force,
+	}
+
+	res, err := methods.ShutdownHost_Task(ctx, host.Client(), &req)
+	if err != nil {
+		return err
+	}
+
+	task := object.NewTask(host.Client(), res.Returnval)
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("%s shutdown... ", host.InventoryPath))
+	defer logger.Wait()
+
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}
+
+func (cmd *shutdown) Reboot(ctx context.Context, host *object.HostSystem) error {
+	req := types.RebootHost_Task{
+		This:  host.Reference(),
+		Force: cmd.force,
+	}
+
+	res, err := methods.RebootHost_Task(ctx, host.Client(), &req)
+	if err != nil {
+		return err
+	}
+
+	task := object.NewTask(host.Client(), res.Returnval)
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("%s reboot... ", host.InventoryPath))
+	defer logger.Wait()
+
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}
+
+func (cmd *shutdown) Run(ctx context.Context, f *flag.FlagSet) error {
+	hosts, err := cmd.HostSystems(f.Args())
+	if err != nil {
+		return err
+	}
+
+	s := cmd.Shutdown
+	if cmd.reboot {
+		s = cmd.Reboot
+	}
+
+	for _, host := range hosts {
+		err = s(ctx, host)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/storage/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/storage/info.go
@@ -1,0 +1,245 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/units"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+var infoTypes = []string{"hba", "lun"}
+
+type infoType string
+
+func (t *infoType) Set(s string) error {
+	s = strings.ToLower(s)
+
+	for _, e := range infoTypes {
+		if s == e {
+			*t = infoType(s)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("invalid type")
+}
+
+func (t *infoType) String() string {
+	return string(*t)
+}
+
+func (t *infoType) Result(hss mo.HostStorageSystem) flags.OutputWriter {
+	switch string(*t) {
+	case "hba":
+		return hbaResult(hss)
+	case "lun":
+		return lunResult(hss)
+	default:
+		panic("unsupported")
+	}
+}
+
+type info struct {
+	*flags.HostSystemFlag
+	*flags.OutputFlag
+
+	typ        infoType
+	rescan     bool
+	refresh    bool
+	rescanvmfs bool
+	unclaimed  bool
+}
+
+func init() {
+	cli.Register("host.storage.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	err := cmd.typ.Set("lun")
+	if err != nil {
+		panic(err)
+	}
+
+	f.Var(&cmd.typ, "t", fmt.Sprintf("Type (%s)", strings.Join(infoTypes, ",")))
+
+	f.BoolVar(&cmd.rescan, "rescan", false, "Rescan all host bus adapters")
+	f.BoolVar(&cmd.refresh, "refresh", false, "Refresh the storage system provider")
+	f.BoolVar(&cmd.rescanvmfs, "rescan-vmfs", false, "Rescan for new VMFSs")
+	f.BoolVar(&cmd.unclaimed, "unclaimed", false, "Only show disks that can be used as new VMFS datastores")
+}
+
+func (cmd *info) Description() string {
+	return `Show HOST storage system information.
+
+Examples:
+  govc find / -type h | xargs -n1 govc host.storage.info -unclaimed -host`
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	host, err := cmd.HostSystem()
+	if err != nil {
+		return err
+	}
+
+	ss, err := host.ConfigManager().StorageSystem(ctx)
+	if err != nil {
+		return err
+	}
+
+	if cmd.rescan {
+		err = ss.RescanAllHba(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	if cmd.refresh {
+		err = ss.Refresh(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	if cmd.rescanvmfs {
+		err = ss.RescanVmfs(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	var hss mo.HostStorageSystem
+	err = ss.Properties(ctx, ss.Reference(), nil, &hss)
+	if err != nil {
+		return nil
+	}
+
+	if cmd.unclaimed {
+		ds, err := host.ConfigManager().DatastoreSystem(ctx)
+		if err != nil {
+			return err
+		}
+
+		disks, err := ds.QueryAvailableDisksForVmfs(ctx)
+		if err != nil {
+			return err
+		}
+
+		var luns []types.BaseScsiLun
+		for i := range disks {
+			luns = append(luns, &disks[i])
+		}
+		hss.StorageDeviceInfo.ScsiLun = luns
+	}
+
+	return cmd.WriteResult(cmd.typ.Result(hss))
+}
+
+type hbaResult mo.HostStorageSystem
+
+func (r hbaResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	fmt.Fprintf(tw, "Device\t")
+	fmt.Fprintf(tw, "PCI\t")
+	fmt.Fprintf(tw, "Driver\t")
+	fmt.Fprintf(tw, "Status\t")
+	fmt.Fprintf(tw, "Model\t")
+	fmt.Fprintf(tw, "\n")
+
+	for _, e := range r.StorageDeviceInfo.HostBusAdapter {
+		hba := e.GetHostHostBusAdapter()
+
+		fmt.Fprintf(tw, "%s\t", hba.Device)
+		fmt.Fprintf(tw, "%s\t", hba.Pci)
+		fmt.Fprintf(tw, "%s\t", hba.Driver)
+		fmt.Fprintf(tw, "%s\t", hba.Status)
+		fmt.Fprintf(tw, "%s\t", hba.Model)
+		fmt.Fprintf(tw, "\n")
+	}
+
+	return tw.Flush()
+}
+
+type lunResult mo.HostStorageSystem
+
+func (r lunResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	fmt.Fprintf(tw, "Name\t")
+	fmt.Fprintf(tw, "Type\t")
+	fmt.Fprintf(tw, "Capacity\t")
+	fmt.Fprintf(tw, "Model\t")
+	fmt.Fprintf(tw, "\n")
+
+	for _, e := range r.StorageDeviceInfo.ScsiLun {
+		var tags []string
+		var capacity int64
+
+		lun := e.GetScsiLun()
+		if disk, ok := e.(*types.HostScsiDisk); ok {
+			capacity = int64(disk.Capacity.Block) * int64(disk.Capacity.BlockSize)
+			if disk.LocalDisk != nil && *disk.LocalDisk {
+				tags = append(tags, "local")
+			}
+			if disk.Ssd != nil && *disk.Ssd {
+				tags = append(tags, "ssd")
+			}
+		}
+
+		fmt.Fprintf(tw, "%s\t", lun.DeviceName)
+		fmt.Fprintf(tw, "%s\t", lun.DeviceType)
+
+		if capacity == 0 {
+			fmt.Fprintf(tw, "-\t")
+		} else {
+			fmt.Fprintf(tw, "%s\t", units.ByteSize(capacity))
+		}
+
+		fmt.Fprintf(tw, "%s", lun.Model)
+		if len(tags) > 0 {
+			fmt.Fprintf(tw, " (%s)", strings.Join(tags, ","))
+		}
+		fmt.Fprintf(tw, "\n")
+	}
+
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/storage/mark.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/storage/mark.go
@@ -1,0 +1,141 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type mark struct {
+	*flags.HostSystemFlag
+
+	ssd   *bool
+	local *bool
+}
+
+func init() {
+	cli.Register("host.storage.mark", &mark{})
+}
+
+func (cmd *mark) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	f.Var(flags.NewOptionalBool(&cmd.ssd), "ssd", "Mark as SSD")
+	f.Var(flags.NewOptionalBool(&cmd.local), "local", "Mark as local")
+}
+
+func (cmd *mark) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *mark) Usage() string {
+	return "DEVICE_PATH"
+}
+
+func (cmd *mark) Description() string {
+	return `Mark device at DEVICE_PATH.`
+}
+
+func (cmd *mark) Mark(ctx context.Context, ss *object.HostStorageSystem, uuid string) error {
+	var err error
+	var task *object.Task
+
+	if cmd.ssd != nil {
+		if *cmd.ssd {
+			task, err = ss.MarkAsSsd(ctx, uuid)
+		} else {
+			task, err = ss.MarkAsNonSsd(ctx, uuid)
+		}
+
+		if err != nil {
+			return err
+		}
+
+		err = task.Wait(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	if cmd.local != nil {
+		if *cmd.local {
+			task, err = ss.MarkAsLocal(ctx, uuid)
+		} else {
+			task, err = ss.MarkAsNonLocal(ctx, uuid)
+		}
+
+		if err != nil {
+			return err
+		}
+
+		err = task.Wait(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (cmd *mark) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return fmt.Errorf("specify device path")
+	}
+
+	path := f.Args()[0]
+
+	host, err := cmd.HostSystem()
+	if err != nil {
+		return err
+	}
+
+	ss, err := host.ConfigManager().StorageSystem(ctx)
+	if err != nil {
+		return err
+	}
+
+	var hss mo.HostStorageSystem
+	err = ss.Properties(ctx, ss.Reference(), nil, &hss)
+	if err != nil {
+		return nil
+	}
+
+	for _, e := range hss.StorageDeviceInfo.ScsiLun {
+		disk, ok := e.(*types.HostScsiDisk)
+		if !ok {
+			continue
+		}
+
+		if disk.DevicePath == path {
+			return cmd.Mark(ctx, ss, disk.Uuid)
+		}
+	}
+
+	return fmt.Errorf("%s not found", path)
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/storage/partition.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/storage/partition.go
@@ -1,0 +1,126 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/units"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type partition struct {
+	*flags.HostSystemFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("host.storage.partition", &partition{})
+}
+
+func (cmd *partition) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *partition) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *partition) Usage() string {
+	return "DEVICE_PATH"
+}
+
+func (cmd *partition) Description() string {
+	return `Show partition table for device at DEVICE_PATH.`
+}
+
+func (cmd *partition) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return fmt.Errorf("specify device path")
+	}
+
+	path := f.Args()[0]
+
+	host, err := cmd.HostSystem()
+	if err != nil {
+		return err
+	}
+
+	ss, err := host.ConfigManager().StorageSystem(ctx)
+	if err != nil {
+		return err
+	}
+
+	var hss mo.HostStorageSystem
+	err = ss.Properties(ctx, ss.Reference(), nil, &hss)
+	if err != nil {
+		return nil
+	}
+
+	info, err := ss.RetrieveDiskPartitionInfo(ctx, path)
+	if err != nil {
+		return err
+	}
+
+	return cmd.WriteResult(partitionInfo(*info))
+}
+
+type partitionInfo types.HostDiskPartitionInfo
+
+func (p partitionInfo) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	fmt.Fprintf(tw, "Table format: %s\n", p.Spec.PartitionFormat)
+	fmt.Fprintf(tw, "Number of sectors: %d\n", p.Spec.TotalSectors)
+	fmt.Fprintf(tw, "\n")
+
+	fmt.Fprintf(tw, "Number\t")
+	fmt.Fprintf(tw, "Start\t")
+	fmt.Fprintf(tw, "End\t")
+	fmt.Fprintf(tw, "Size\t")
+	fmt.Fprintf(tw, "Type\t")
+	fmt.Fprintf(tw, "\n")
+
+	for _, e := range p.Spec.Partition {
+		sectors := e.EndSector - e.StartSector
+
+		fmt.Fprintf(tw, "%d\t", e.Partition)
+		fmt.Fprintf(tw, "%d\t", e.StartSector)
+		fmt.Fprintf(tw, "%d\t", e.EndSector)
+		fmt.Fprintf(tw, "%s\t", units.ByteSize(sectors*512))
+		fmt.Fprintf(tw, "%s\t", e.Type)
+		fmt.Fprintf(tw, "\n")
+	}
+
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/vnic/change.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/vnic/change.go
@@ -1,0 +1,92 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vnic
+
+import (
+	"context"
+	"errors"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+type change struct {
+	*flags.HostSystemFlag
+
+	mtu int32
+}
+
+func init() {
+	cli.Register("host.vnic.change", &change{})
+}
+
+func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	f.Var(flags.NewInt32(&cmd.mtu), "mtu", "vmk MTU")
+}
+
+func (cmd *change) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cmd *change) Usage() string {
+	return "DEVICE"
+}
+
+func (cmd *change) Description() string {
+	return `Change a virtual nic DEVICE.
+
+Examples:
+  govc host.vnic.change -host hostname -mtu 9000 vmk1`
+}
+
+func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	device := f.Arg(0)
+
+	ns, err := cmd.HostNetworkSystem()
+	if err != nil {
+		return err
+	}
+
+	var mns mo.HostNetworkSystem
+
+	err = ns.Properties(ctx, ns.Reference(), []string{"networkInfo"}, &mns)
+	if err != nil {
+		return err
+	}
+
+	for _, nic := range mns.NetworkInfo.Vnic {
+		if nic.Device == device {
+			nic.Spec.Mtu = cmd.mtu
+			return ns.UpdateVirtualNic(ctx, device, nic.Spec)
+		}
+	}
+
+	return errors.New(device + " not found")
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/vnic/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/vnic/info.go
@@ -1,0 +1,174 @@
+/*
+Copyright (c) 2015-2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vnic
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*flags.HostSystemFlag
+}
+
+func init() {
+	cli.Register("host.vnic.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+type Info struct {
+	Device   string
+	Network  string
+	Switch   string
+	Address  string
+	Stack    string
+	Services []string
+}
+
+type infoResult struct {
+	Info []Info
+}
+
+func (i *infoResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
+
+	for _, info := range i.Info {
+		fmt.Fprintf(tw, "Device:\t%s\n", info.Device)
+		fmt.Fprintf(tw, "Network label:\t%s\n", info.Network)
+		fmt.Fprintf(tw, "Switch:\t%s\n", info.Switch)
+		fmt.Fprintf(tw, "IP address:\t%s\n", info.Address)
+		fmt.Fprintf(tw, "TCP/IP stack:\t%s\n", info.Stack)
+		fmt.Fprintf(tw, "Enabled services:\t%s\n", strings.Join(info.Services, ", "))
+	}
+
+	return tw.Flush()
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	host, err := cmd.HostSystem()
+	if err != nil {
+		return err
+	}
+
+	ns, err := cmd.HostNetworkSystem()
+	if err != nil {
+		return err
+	}
+
+	var mns mo.HostNetworkSystem
+
+	m, err := host.ConfigManager().VirtualNicManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	minfo, err := m.Info(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = ns.Properties(ctx, ns.Reference(), []string{"networkInfo"}, &mns)
+	if err != nil {
+		return err
+	}
+
+	type dnet struct {
+		dvp mo.DistributedVirtualPortgroup
+		dvs mo.VmwareDistributedVirtualSwitch
+	}
+
+	dnets := make(map[string]*dnet)
+	var res infoResult
+
+	for _, nic := range mns.NetworkInfo.Vnic {
+		info := Info{Device: nic.Device}
+
+		if dvp := nic.Spec.DistributedVirtualPort; dvp != nil {
+			dn, ok := dnets[dvp.PortgroupKey]
+
+			if !ok {
+				dn = new(dnet)
+				o := object.NewDistributedVirtualPortgroup(host.Client(), types.ManagedObjectReference{
+					Type:  "DistributedVirtualPortgroup",
+					Value: dvp.PortgroupKey,
+				})
+
+				err = o.Properties(ctx, o.Reference(), []string{"name", "config.distributedVirtualSwitch"}, &dn.dvp)
+				if err != nil {
+					return err
+				}
+
+				err = o.Properties(ctx, *dn.dvp.Config.DistributedVirtualSwitch, []string{"name"}, &dn.dvs)
+				if err != nil {
+					return err
+				}
+
+				dnets[dvp.PortgroupKey] = dn
+			}
+
+			info.Network = dn.dvp.Name
+			info.Switch = dn.dvs.Name
+		} else {
+			info.Network = nic.Portgroup
+			for _, pg := range mns.NetworkInfo.Portgroup {
+				if pg.Spec.Name == nic.Portgroup {
+					info.Switch = pg.Spec.VswitchName
+					break
+				}
+			}
+		}
+
+		info.Address = nic.Spec.Ip.IpAddress
+		info.Stack = nic.Spec.NetStackInstanceKey
+
+		for _, nc := range minfo.NetConfig {
+			for _, dev := range nc.SelectedVnic {
+				key := nc.NicType + "." + nic.Key
+				if dev == key {
+					info.Services = append(info.Services, nc.NicType)
+				}
+			}
+
+		}
+
+		res.Info = append(res.Info, info)
+	}
+
+	return cmd.WriteResult(&res)
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/vnic/service.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/vnic/service.go
@@ -1,0 +1,114 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vnic
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type service struct {
+	*flags.HostSystemFlag
+
+	Enable bool
+}
+
+func init() {
+	cli.Register("host.vnic.service", &service{})
+}
+
+func (cmd *service) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.Enable, "enable", true, "Enable service")
+}
+
+func (cmd *service) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cmd *service) Usage() string {
+	return "SERVICE DEVICE"
+}
+
+func (cmd *service) Description() string {
+	nicTypes := []string{
+		string(types.HostVirtualNicManagerNicTypeVmotion),
+		string(types.HostVirtualNicManagerNicTypeFaultToleranceLogging),
+		string(types.HostVirtualNicManagerNicTypeVSphereReplication),
+		string(types.HostVirtualNicManagerNicTypeVSphereReplicationNFC),
+		string(types.HostVirtualNicManagerNicTypeManagement),
+		string(types.HostVirtualNicManagerNicTypeVsan),
+		string(types.HostVirtualNicManagerNicTypeVSphereProvisioning),
+	}
+
+	return fmt.Sprintf(`
+Enable or disable service on a virtual nic device.
+
+Where SERVICE is one of: %s
+Where DEVICE is one of: %s
+
+Examples:
+  govc host.vnic.service -host hostname -enable vsan vmk0
+  govc host.vnic.service -host hostname -enable=false vmotion vmk1`,
+		strings.Join(nicTypes, "|"),
+		strings.Join([]string{"vmk0", "vmk1", "..."}, "|"))
+}
+
+func (cmd *service) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 2 {
+		return flag.ErrHelp
+	}
+
+	service := f.Arg(0)
+	device := f.Arg(1)
+
+	host, err := cmd.HostSystem()
+	if err != nil {
+		return err
+	}
+
+	m, err := host.ConfigManager().VirtualNicManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	var method func(context.Context, string, string) error
+
+	if cmd.Enable {
+		method = m.SelectVnic
+	} else {
+		method = m.DeselectVnic
+	}
+
+	if method == nil {
+		return flag.ErrHelp
+	}
+
+	return method(ctx, service, device)
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/vswitch/add.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/vswitch/add.go
@@ -1,0 +1,73 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vswitch
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type add struct {
+	*flags.HostSystemFlag
+
+	nic  string
+	spec types.HostVirtualSwitchSpec
+}
+
+func init() {
+	cli.Register("host.vswitch.add", &add{})
+}
+
+func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	cmd.spec.NumPorts = 128 // default
+	f.Var(flags.NewInt32(&cmd.spec.NumPorts), "ports", "Number of ports")
+	f.Var(flags.NewInt32(&cmd.spec.Mtu), "mtu", "MTU")
+	f.StringVar(&cmd.nic, "nic", "", "Bridge nic device")
+}
+
+func (cmd *add) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *add) Usage() string {
+	return "NAME"
+}
+
+func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
+	ns, err := cmd.HostNetworkSystem()
+	if err != nil {
+		return err
+	}
+
+	if cmd.nic != "" {
+		cmd.spec.Bridge = &types.HostVirtualSwitchBondBridge{
+			NicDevice: []string{cmd.nic},
+		}
+	}
+
+	return ns.AddVirtualSwitch(ctx, f.Arg(0), &cmd.spec)
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/vswitch/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/vswitch/info.go
@@ -1,0 +1,134 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vswitch
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+	*flags.HostSystemFlag
+}
+
+func init() {
+	cli.Register("host.vswitch.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	client, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	ns, err := cmd.HostNetworkSystem()
+	if err != nil {
+		return err
+	}
+
+	var mns mo.HostNetworkSystem
+
+	pc := property.DefaultCollector(client)
+	err = pc.RetrieveOne(ctx, ns.Reference(), []string{"networkInfo.vswitch"}, &mns)
+	if err != nil {
+		return err
+	}
+
+	r := &infoResult{mns.NetworkInfo.Vswitch}
+
+	return cmd.WriteResult(r)
+}
+
+type infoResult struct {
+	Vswitch []types.HostVirtualSwitch
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for i, s := range r.Vswitch {
+		if i > 0 {
+			fmt.Fprintln(tw)
+		}
+		fmt.Fprintf(tw, "Name:\t%s\n", s.Name)
+		fmt.Fprintf(tw, "Portgroup:\t%s\n", keys("key-vim.host.PortGroup-", s.Portgroup))
+		fmt.Fprintf(tw, "Pnic:\t%s\n", keys("key-vim.host.PhysicalNic-", s.Pnic))
+		fmt.Fprintf(tw, "MTU:\t%d\n", s.Mtu)
+		fmt.Fprintf(tw, "Ports:\t%d\n", s.NumPorts)
+		fmt.Fprintf(tw, "Ports Available:\t%d\n", s.NumPortsAvailable)
+		HostNetworkPolicy(tw, s.Spec.Policy)
+	}
+
+	return tw.Flush()
+}
+
+func keys(key string, vals []string) string {
+	for i, val := range vals {
+		vals[i] = strings.TrimPrefix(val, key)
+	}
+	return strings.Join(vals, ", ")
+}
+
+func enabled(b *bool) string {
+	if b != nil && *b {
+		return "Yes"
+	}
+	return "No"
+}
+
+func HostNetworkPolicy(w io.Writer, p *types.HostNetworkPolicy) {
+	if p == nil || p.Security == nil {
+		return // e.g. Workstation
+	}
+	fmt.Fprintf(w, "Allow promiscuous mode:\t%s\n", enabled(p.Security.AllowPromiscuous))
+	fmt.Fprintf(w, "Allow forged transmits:\t%s\n", enabled(p.Security.ForgedTransmits))
+	fmt.Fprintf(w, "Allow MAC changes:\t%s\n", enabled(p.Security.MacChanges))
+}

--- a/vendor/github.com/vmware/govmomi/govc/host/vswitch/remove.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/vswitch/remove.go
@@ -1,0 +1,58 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vswitch
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type remove struct {
+	*flags.HostSystemFlag
+}
+
+func init() {
+	cli.Register("host.vswitch.remove", &remove{})
+}
+
+func (cmd *remove) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+}
+
+func (cmd *remove) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *remove) Usage() string {
+	return "NAME"
+}
+
+func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
+	ns, err := cmd.HostNetworkSystem()
+	if err != nil {
+		return err
+	}
+
+	return ns.RemoveVirtualSwitch(ctx, f.Arg(0))
+}

--- a/vendor/github.com/vmware/govmomi/govc/importx/archive.go
+++ b/vendor/github.com/vmware/govmomi/govc/importx/archive.go
@@ -1,0 +1,187 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package importx
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/vmware/govmomi/ovf"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+// ArchiveFlag doesn't register any flags;
+// only encapsulates some common archive related functionality.
+type ArchiveFlag struct {
+	Archive
+}
+
+func newArchiveFlag(ctx context.Context) (*ArchiveFlag, context.Context) {
+	return &ArchiveFlag{}, ctx
+}
+
+func (f *ArchiveFlag) Register(ctx context.Context, fs *flag.FlagSet) {
+}
+
+func (f *ArchiveFlag) Process(ctx context.Context) error {
+	return nil
+}
+
+func (f *ArchiveFlag) ReadOvf(fpath string) ([]byte, error) {
+	r, _, err := f.Open(fpath)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+
+	return ioutil.ReadAll(r)
+}
+
+func (f *ArchiveFlag) ReadEnvelope(data []byte) (*ovf.Envelope, error) {
+	e, err := ovf.Unmarshal(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ovf: %s", err)
+	}
+
+	return e, nil
+}
+
+type Archive interface {
+	Open(string) (io.ReadCloser, int64, error)
+}
+
+type TapeArchive struct {
+	Path string
+	Opener
+}
+
+type TapeArchiveEntry struct {
+	io.Reader
+	f io.Closer
+
+	Name string
+}
+
+func (t *TapeArchiveEntry) Close() error {
+	return t.f.Close()
+}
+
+func (t *TapeArchive) Open(name string) (io.ReadCloser, int64, error) {
+	f, _, err := t.OpenFile(t.Path)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	r := tar.NewReader(f)
+
+	for {
+		h, err := r.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, 0, err
+		}
+
+		matched, err := path.Match(name, path.Base(h.Name))
+		if err != nil {
+			return nil, 0, err
+		}
+
+		if matched {
+			return &TapeArchiveEntry{r, f, h.Name}, h.Size, nil
+		}
+	}
+
+	_ = f.Close()
+
+	return nil, 0, os.ErrNotExist
+}
+
+type FileArchive struct {
+	Path string
+	Opener
+}
+
+func (t *FileArchive) Open(name string) (io.ReadCloser, int64, error) {
+	fpath := name
+	if name != t.Path {
+		index := strings.LastIndex(t.Path, "/")
+		if index != -1 {
+			fpath = t.Path[:index] + "/" + name
+		}
+	}
+
+	return t.OpenFile(fpath)
+}
+
+type Opener struct {
+	*vim25.Client
+}
+
+func isRemotePath(path string) bool {
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		return true
+	}
+	return false
+}
+
+func (o Opener) OpenLocal(path string) (io.ReadCloser, int64, error) {
+	f, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return nil, 0, err
+	}
+
+	s, err := f.Stat()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return f, s.Size(), nil
+}
+
+func (o Opener) OpenFile(path string) (io.ReadCloser, int64, error) {
+	if isRemotePath(path) {
+		return o.OpenRemote(path)
+	}
+	return o.OpenLocal(path)
+}
+
+func (o Opener) OpenRemote(link string) (io.ReadCloser, int64, error) {
+	if o.Client == nil {
+		return nil, 0, errors.New("remote path not supported")
+	}
+
+	u, err := url.Parse(link)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return o.Download(context.Background(), u, &soap.DefaultDownload)
+}

--- a/vendor/github.com/vmware/govmomi/govc/importx/importable.go
+++ b/vendor/github.com/vmware/govmomi/govc/importx/importable.go
@@ -1,0 +1,59 @@
+/*
+Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package importx
+
+import (
+	"fmt"
+	"path"
+)
+
+type importable struct {
+	localPath  string
+	remotePath string
+}
+
+func (i importable) Ext() string {
+	return path.Ext(i.localPath)
+}
+
+func (i importable) Base() string {
+	return path.Base(i.localPath)
+}
+
+func (i importable) BaseClean() string {
+	b := i.Base()
+	e := i.Ext()
+	return b[:len(b)-len(e)]
+}
+
+func (i importable) RemoteSrcVMDK() string {
+	file := fmt.Sprintf("%s-src.vmdk", i.BaseClean())
+	return i.toRemotePath(file)
+}
+
+func (i importable) RemoteDstVMDK() string {
+	file := fmt.Sprintf("%s.vmdk", i.BaseClean())
+	return i.toRemotePath(file)
+}
+
+func (i importable) toRemotePath(p string) string {
+	if i.remotePath == "" {
+		return p
+	}
+
+	return path.Join(i.remotePath, p)
+}

--- a/vendor/github.com/vmware/govmomi/govc/importx/options.go
+++ b/vendor/github.com/vmware/govmomi/govc/importx/options.go
@@ -1,0 +1,205 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package importx
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/ovf"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type Property struct {
+	types.KeyValue
+	Spec *ovf.Property `json:",omitempty"`
+}
+
+type Network struct {
+	Name    string
+	Network string
+}
+
+type Options struct {
+	AllDeploymentOptions []string `json:",omitempty"`
+	Deployment           string   `json:",omitempty"`
+
+	AllDiskProvisioningOptions []string `json:",omitempty"`
+	DiskProvisioning           string
+
+	AllIPAllocationPolicyOptions []string `json:",omitempty"`
+	IPAllocationPolicy           string
+
+	AllIPProtocolOptions []string `json:",omitempty"`
+	IPProtocol           string
+
+	PropertyMapping []Property `json:",omitempty"`
+
+	NetworkMapping []Network `json:",omitempty"`
+
+	Annotation string `json:",omitempty"`
+
+	MarkAsTemplate bool
+	PowerOn        bool
+	InjectOvfEnv   bool
+	WaitForIP      bool
+	Name           *string
+}
+
+type OptionsFlag struct {
+	Options Options
+
+	path string
+}
+
+func newOptionsFlag(ctx context.Context) (*OptionsFlag, context.Context) {
+	return &OptionsFlag{}, ctx
+}
+
+func (flag *OptionsFlag) Register(ctx context.Context, f *flag.FlagSet) {
+	f.StringVar(&flag.path, "options", "", "Options spec file path for VM deployment")
+}
+
+func (flag *OptionsFlag) Process(ctx context.Context) error {
+	if len(flag.path) == 0 {
+		return nil
+	}
+
+	var err error
+	in := os.Stdin
+
+	if flag.path != "-" {
+		in, err = os.Open(flag.path)
+		if err != nil {
+			return err
+		}
+		defer in.Close()
+	}
+
+	return json.NewDecoder(in).Decode(&flag.Options)
+}
+
+func (flag *OptionsFlag) powerOn(vm *object.VirtualMachine, out *flags.OutputFlag) error {
+	if !flag.Options.PowerOn || flag.Options.MarkAsTemplate {
+		return nil
+	}
+
+	out.Log("Powering on VM...\n")
+
+	task, err := vm.PowerOn(context.Background())
+	if err != nil {
+		return err
+	}
+
+	return task.Wait(context.Background())
+}
+
+func (flag *OptionsFlag) markAsTemplate(vm *object.VirtualMachine, out *flags.OutputFlag) error {
+	if !flag.Options.MarkAsTemplate {
+		return nil
+	}
+
+	out.Log("Marking VM as template...\n")
+
+	return vm.MarkAsTemplate(context.Background())
+}
+
+func (flag *OptionsFlag) injectOvfEnv(vm *object.VirtualMachine, out *flags.OutputFlag) error {
+	if !flag.Options.InjectOvfEnv {
+		return nil
+	}
+
+	out.Log("Injecting OVF environment...\n")
+
+	var opts []types.BaseOptionValue
+
+	a := vm.Client().ServiceContent.About
+
+	// build up Environment in order to marshal to xml
+	var props []ovf.EnvProperty
+	for _, p := range flag.Options.PropertyMapping {
+		props = append(props, ovf.EnvProperty{
+			Key:   p.Key,
+			Value: p.Value,
+		})
+	}
+
+	env := ovf.Env{
+		EsxID: vm.Reference().Value,
+		Platform: &ovf.PlatformSection{
+			Kind:    a.Name,
+			Version: a.Version,
+			Vendor:  a.Vendor,
+			Locale:  "US",
+		},
+		Property: &ovf.PropertySection{
+			Properties: props,
+		},
+	}
+
+	opts = append(opts, &types.OptionValue{
+		Key:   "guestinfo.ovfEnv",
+		Value: env.MarshalManual(),
+	})
+
+	task, err := vm.Reconfigure(context.Background(), types.VirtualMachineConfigSpec{
+		ExtraConfig: opts,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return task.Wait(context.Background())
+}
+
+func (flag *OptionsFlag) waitForIP(vm *object.VirtualMachine, out *flags.OutputFlag) error {
+	if !flag.Options.PowerOn || !flag.Options.WaitForIP || flag.Options.MarkAsTemplate {
+		return nil
+	}
+
+	out.Log("Waiting for IP address...\n")
+	ip, err := vm.WaitForIP(context.Background())
+	if err != nil {
+		return err
+	}
+
+	out.Log(fmt.Sprintf("Received IP address: %s\n", ip))
+	return nil
+}
+
+func (flag *OptionsFlag) Deploy(vm *object.VirtualMachine, out *flags.OutputFlag) error {
+	deploy := []func(*object.VirtualMachine, *flags.OutputFlag) error{
+		flag.injectOvfEnv,
+		flag.markAsTemplate,
+		flag.powerOn,
+		flag.waitForIP,
+	}
+
+	for _, step := range deploy {
+		if err := step(vm, out); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/importx/ova.go
+++ b/vendor/github.com/vmware/govmomi/govc/importx/ova.go
@@ -1,0 +1,63 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package importx
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ova struct {
+	*ovfx
+}
+
+func init() {
+	cli.Register("import.ova", &ova{&ovfx{}})
+}
+
+func (cmd *ova) Usage() string {
+	return "PATH_TO_OVA"
+}
+
+func (cmd *ova) Run(ctx context.Context, f *flag.FlagSet) error {
+	fpath, err := cmd.Prepare(f)
+	if err != nil {
+		return err
+	}
+
+	archive := &TapeArchive{Path: fpath}
+	archive.Client = cmd.Client
+
+	cmd.Archive = archive
+
+	moref, err := cmd.Import(fpath)
+	if err != nil {
+		return err
+	}
+
+	vm := object.NewVirtualMachine(cmd.Client, *moref)
+	return cmd.Deploy(vm, cmd.OutputFlag)
+}
+
+func (cmd *ova) Import(fpath string) (*types.ManagedObjectReference, error) {
+	ovf := "*.ovf"
+	return cmd.ovfx.Import(ovf)
+}

--- a/vendor/github.com/vmware/govmomi/govc/importx/ovf.go
+++ b/vendor/github.com/vmware/govmomi/govc/importx/ovf.go
@@ -1,0 +1,324 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package importx
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"path"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/nfc"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/ovf"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ovfx struct {
+	*flags.DatastoreFlag
+	*flags.HostSystemFlag
+	*flags.OutputFlag
+	*flags.ResourcePoolFlag
+	*flags.FolderFlag
+
+	*ArchiveFlag
+	*OptionsFlag
+
+	Name string
+
+	Client       *vim25.Client
+	Datacenter   *object.Datacenter
+	Datastore    *object.Datastore
+	ResourcePool *object.ResourcePool
+}
+
+func init() {
+	cli.Register("import.ovf", &ovfx{})
+}
+
+func (cmd *ovfx) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+	cmd.ResourcePoolFlag, ctx = flags.NewResourcePoolFlag(ctx)
+	cmd.ResourcePoolFlag.Register(ctx, f)
+	cmd.FolderFlag, ctx = flags.NewFolderFlag(ctx)
+	cmd.FolderFlag.Register(ctx, f)
+
+	cmd.ArchiveFlag, ctx = newArchiveFlag(ctx)
+	cmd.ArchiveFlag.Register(ctx, f)
+	cmd.OptionsFlag, ctx = newOptionsFlag(ctx)
+	cmd.OptionsFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.Name, "name", "", "Name to use for new entity")
+}
+
+func (cmd *ovfx) Process(ctx context.Context) error {
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.ResourcePoolFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.ArchiveFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OptionsFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.FolderFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ovfx) Usage() string {
+	return "PATH_TO_OVF"
+}
+
+func (cmd *ovfx) Run(ctx context.Context, f *flag.FlagSet) error {
+	fpath, err := cmd.Prepare(f)
+	if err != nil {
+		return err
+	}
+
+	archive := &FileArchive{Path: fpath}
+	archive.Client = cmd.Client
+
+	cmd.Archive = archive
+
+	moref, err := cmd.Import(fpath)
+	if err != nil {
+		return err
+	}
+
+	vm := object.NewVirtualMachine(cmd.Client, *moref)
+	return cmd.Deploy(vm, cmd.OutputFlag)
+}
+
+func (cmd *ovfx) Prepare(f *flag.FlagSet) (string, error) {
+	var err error
+
+	args := f.Args()
+	if len(args) != 1 {
+		return "", errors.New("no file specified")
+	}
+
+	cmd.Client, err = cmd.DatastoreFlag.Client()
+	if err != nil {
+		return "", err
+	}
+
+	cmd.Datacenter, err = cmd.DatastoreFlag.Datacenter()
+	if err != nil {
+		return "", err
+	}
+
+	cmd.Datastore, err = cmd.DatastoreFlag.Datastore()
+	if err != nil {
+		return "", err
+	}
+
+	cmd.ResourcePool, err = cmd.ResourcePoolFlag.ResourcePoolIfSpecified()
+	if err != nil {
+		return "", err
+	}
+
+	return f.Arg(0), nil
+}
+
+func (cmd *ovfx) Map(op []Property) (p []types.KeyValue) {
+	for _, v := range op {
+		p = append(p, v.KeyValue)
+	}
+
+	return
+}
+
+func (cmd *ovfx) NetworkMap(e *ovf.Envelope) (p []types.OvfNetworkMapping) {
+	ctx := context.TODO()
+	finder, err := cmd.DatastoreFlag.Finder()
+	if err != nil {
+		return
+	}
+
+	networks := map[string]string{}
+
+	if e.Network != nil {
+		for _, net := range e.Network.Networks {
+			networks[net.Name] = net.Name
+		}
+	}
+
+	for _, net := range cmd.Options.NetworkMapping {
+		networks[net.Name] = net.Network
+	}
+
+	for src, dst := range networks {
+		if net, err := finder.Network(ctx, dst); err == nil {
+			p = append(p, types.OvfNetworkMapping{
+				Name:    src,
+				Network: net.Reference(),
+			})
+		}
+	}
+	return
+}
+
+func (cmd *ovfx) Import(fpath string) (*types.ManagedObjectReference, error) {
+	ctx := context.TODO()
+
+	o, err := cmd.ReadOvf(fpath)
+	if err != nil {
+		return nil, err
+	}
+
+	e, err := cmd.ReadEnvelope(o)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ovf: %s", err)
+	}
+
+	name := "Govc Virtual Appliance"
+	if e.VirtualSystem != nil {
+		name = e.VirtualSystem.ID
+		if e.VirtualSystem.Name != nil {
+			name = *e.VirtualSystem.Name
+		}
+	}
+
+	// Override name from options if specified
+	if cmd.Options.Name != nil {
+		name = *cmd.Options.Name
+	}
+
+	// Override name from arguments if specified
+	if cmd.Name != "" {
+		name = cmd.Name
+	}
+
+	cisp := types.OvfCreateImportSpecParams{
+		DiskProvisioning:   cmd.Options.DiskProvisioning,
+		EntityName:         name,
+		IpAllocationPolicy: cmd.Options.IPAllocationPolicy,
+		IpProtocol:         cmd.Options.IPProtocol,
+		OvfManagerCommonParams: types.OvfManagerCommonParams{
+			DeploymentOption: cmd.Options.Deployment,
+			Locale:           "US"},
+		PropertyMapping: cmd.Map(cmd.Options.PropertyMapping),
+		NetworkMapping:  cmd.NetworkMap(e),
+	}
+
+	host, err := cmd.HostSystemIfSpecified()
+	if err != nil {
+		return nil, err
+	}
+
+	if cmd.ResourcePool == nil {
+		if host == nil {
+			cmd.ResourcePool, err = cmd.ResourcePoolFlag.ResourcePool()
+		} else {
+			cmd.ResourcePool, err = host.ResourcePool(ctx)
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	m := ovf.NewManager(cmd.Client)
+	spec, err := m.CreateImportSpec(ctx, string(o), cmd.ResourcePool, cmd.Datastore, cisp)
+	if err != nil {
+		return nil, err
+	}
+	if spec.Error != nil {
+		return nil, errors.New(spec.Error[0].LocalizedMessage)
+	}
+	if spec.Warning != nil {
+		for _, w := range spec.Warning {
+			_, _ = cmd.Log(fmt.Sprintf("Warning: %s\n", w.LocalizedMessage))
+		}
+	}
+
+	if cmd.Options.Annotation != "" {
+		switch s := spec.ImportSpec.(type) {
+		case *types.VirtualMachineImportSpec:
+			s.ConfigSpec.Annotation = cmd.Options.Annotation
+		case *types.VirtualAppImportSpec:
+			s.VAppConfigSpec.Annotation = cmd.Options.Annotation
+		}
+	}
+
+	folder, err := cmd.FolderOrDefault("vm")
+	if err != nil {
+		return nil, err
+	}
+
+	lease, err := cmd.ResourcePool.ImportVApp(ctx, spec.ImportSpec, folder, host)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := lease.Wait(ctx, spec.FileItem)
+	if err != nil {
+		return nil, err
+	}
+
+	u := lease.StartUpdater(ctx, info)
+	defer u.Done()
+
+	for _, i := range info.Items {
+		err = cmd.Upload(ctx, lease, i)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &info.Entity, lease.Complete(ctx)
+}
+
+func (cmd *ovfx) Upload(ctx context.Context, lease *nfc.Lease, item nfc.FileItem) error {
+	file := item.Path
+
+	f, size, err := cmd.Open(file)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("Uploading %s... ", path.Base(file)))
+	defer logger.Wait()
+
+	opts := soap.Upload{
+		ContentLength: size,
+		Progress:      logger,
+	}
+
+	return lease.Upload(ctx, item, f, opts)
+}

--- a/vendor/github.com/vmware/govmomi/govc/importx/spec.go
+++ b/vendor/github.com/vmware/govmomi/govc/importx/spec.go
@@ -1,0 +1,222 @@
+/*
+Copyright (c) 2015-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package importx
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/ovf"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+var (
+	allDiskProvisioningOptions = []string{
+		string(types.OvfCreateImportSpecParamsDiskProvisioningTypeFlat),
+		string(types.OvfCreateImportSpecParamsDiskProvisioningTypeMonolithicSparse),
+		string(types.OvfCreateImportSpecParamsDiskProvisioningTypeMonolithicFlat),
+		string(types.OvfCreateImportSpecParamsDiskProvisioningTypeTwoGbMaxExtentSparse),
+		string(types.OvfCreateImportSpecParamsDiskProvisioningTypeTwoGbMaxExtentFlat),
+		string(types.OvfCreateImportSpecParamsDiskProvisioningTypeThin),
+		string(types.OvfCreateImportSpecParamsDiskProvisioningTypeThick),
+		string(types.OvfCreateImportSpecParamsDiskProvisioningTypeSeSparse),
+		string(types.OvfCreateImportSpecParamsDiskProvisioningTypeEagerZeroedThick),
+		string(types.OvfCreateImportSpecParamsDiskProvisioningTypeSparse),
+	}
+	allIPAllocationPolicyOptions = []string{
+		string(types.VAppIPAssignmentInfoIpAllocationPolicyDhcpPolicy),
+		string(types.VAppIPAssignmentInfoIpAllocationPolicyTransientPolicy),
+		string(types.VAppIPAssignmentInfoIpAllocationPolicyFixedPolicy),
+		string(types.VAppIPAssignmentInfoIpAllocationPolicyFixedAllocatedPolicy),
+	}
+	allIPProtocolOptions = []string{
+		string(types.VAppIPAssignmentInfoProtocolsIPv4),
+		string(types.VAppIPAssignmentInfoProtocolsIPv6),
+	}
+)
+
+type spec struct {
+	*ArchiveFlag
+
+	verbose bool
+}
+
+func init() {
+	cli.Register("import.spec", &spec{})
+}
+
+func (cmd *spec) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ArchiveFlag, ctx = newArchiveFlag(ctx)
+	cmd.ArchiveFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.verbose, "verbose", false, "Verbose spec output")
+}
+
+func (cmd *spec) Process(ctx context.Context) error {
+	if err := cmd.ArchiveFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *spec) Usage() string {
+	return "PATH_TO_OVF_OR_OVA"
+}
+
+func (cmd *spec) Run(ctx context.Context, f *flag.FlagSet) error {
+	fpath := ""
+	args := f.Args()
+	if len(args) == 1 {
+		fpath = f.Arg(0)
+	}
+
+	if len(fpath) > 0 {
+		switch path.Ext(fpath) {
+		case ".ovf":
+			cmd.Archive = &FileArchive{Path: fpath}
+		case "", ".ova":
+			cmd.Archive = &TapeArchive{Path: fpath}
+			fpath = "*.ovf"
+		default:
+			return fmt.Errorf("invalid file extension %s", path.Ext(fpath))
+		}
+	}
+
+	return cmd.Spec(fpath)
+}
+
+func (cmd *spec) Map(e *ovf.Envelope) (res []Property) {
+	if e == nil || e.VirtualSystem == nil {
+		return nil
+	}
+
+	for _, p := range e.VirtualSystem.Product {
+		for i, v := range p.Property {
+			if v.UserConfigurable == nil || !*v.UserConfigurable {
+				continue
+			}
+
+			d := ""
+			if v.Default != nil {
+				d = *v.Default
+			}
+
+			// vSphere only accept True/False as boolean values for some reason
+			if v.Type == "boolean" {
+				d = strings.Title(d)
+			}
+
+			// From OVF spec, section 9.5.1:
+			// key-value-env = [class-value "."] key-value-prod ["." instance-value]
+			k := v.Key
+			if p.Class != nil {
+				k = fmt.Sprintf("%s.%s", *p.Class, k)
+			}
+			if p.Instance != nil {
+				k = fmt.Sprintf("%s.%s", k, *p.Instance)
+			}
+
+			np := Property{KeyValue: types.KeyValue{Key: k, Value: d}}
+			if cmd.verbose {
+				np.Spec = &p.Property[i]
+			}
+
+			res = append(res, np)
+		}
+	}
+
+	return
+}
+
+func (cmd *spec) Spec(fpath string) error {
+	e := &ovf.Envelope{}
+	if fpath != "" {
+		d, err := cmd.ReadOvf(fpath)
+		if err != nil {
+			return err
+		}
+
+		if e, err = cmd.ReadEnvelope(d); err != nil {
+			return err
+		}
+	}
+
+	var deploymentOptions []string
+	if e.DeploymentOption != nil && e.DeploymentOption.Configuration != nil {
+		// add default first
+		for _, c := range e.DeploymentOption.Configuration {
+			if c.Default != nil && *c.Default {
+				deploymentOptions = append(deploymentOptions, c.ID)
+			}
+		}
+
+		for _, c := range e.DeploymentOption.Configuration {
+			if c.Default == nil || !*c.Default {
+				deploymentOptions = append(deploymentOptions, c.ID)
+			}
+		}
+	}
+
+	o := Options{
+		DiskProvisioning:   allDiskProvisioningOptions[0],
+		IPAllocationPolicy: allIPAllocationPolicyOptions[0],
+		IPProtocol:         allIPProtocolOptions[0],
+		MarkAsTemplate:     false,
+		PowerOn:            false,
+		WaitForIP:          false,
+		InjectOvfEnv:       false,
+		PropertyMapping:    cmd.Map(e),
+	}
+
+	if deploymentOptions != nil {
+		o.Deployment = deploymentOptions[0]
+	}
+
+	if e.VirtualSystem != nil && e.VirtualSystem.Annotation != nil {
+		for _, a := range e.VirtualSystem.Annotation {
+			o.Annotation += a.Annotation
+		}
+	}
+
+	if e.Network != nil {
+		for _, net := range e.Network.Networks {
+			o.NetworkMapping = append(o.NetworkMapping, Network{net.Name, ""})
+		}
+	}
+
+	if cmd.verbose {
+		if deploymentOptions != nil {
+			o.AllDeploymentOptions = deploymentOptions
+		}
+		o.AllDiskProvisioningOptions = allDiskProvisioningOptions
+		o.AllIPAllocationPolicyOptions = allIPAllocationPolicyOptions
+		o.AllIPProtocolOptions = allIPProtocolOptions
+	}
+
+	j, err := json.Marshal(&o)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(j))
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/importx/vmdk.go
+++ b/vendor/github.com/vmware/govmomi/govc/importx/vmdk.go
@@ -1,0 +1,132 @@
+/*
+Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package importx
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"path"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vmdk"
+)
+
+type disk struct {
+	*flags.DatastoreFlag
+	*flags.ResourcePoolFlag
+	*flags.FolderFlag
+	*flags.OutputFlag
+
+	force bool
+}
+
+func init() {
+	cli.Register("import.vmdk", &disk{})
+}
+
+func (cmd *disk) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+	cmd.ResourcePoolFlag, ctx = flags.NewResourcePoolFlag(ctx)
+	cmd.ResourcePoolFlag.Register(ctx, f)
+	cmd.FolderFlag, ctx = flags.NewFolderFlag(ctx)
+	cmd.FolderFlag.Register(ctx, f)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.force, "force", false, "Overwrite existing disk")
+}
+
+func (cmd *disk) Process(ctx context.Context) error {
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.ResourcePoolFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.FolderFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *disk) Usage() string {
+	return "PATH_TO_VMDK [REMOTE_DIRECTORY]"
+}
+
+func (cmd *disk) Run(ctx context.Context, f *flag.FlagSet) error {
+	args := f.Args()
+	if len(args) < 1 {
+		return errors.New("no file to import")
+	}
+
+	src := f.Arg(0)
+
+	c, err := cmd.DatastoreFlag.Client()
+	if err != nil {
+		return err
+	}
+
+	dc, err := cmd.DatastoreFlag.Datacenter()
+	if err != nil {
+		return err
+	}
+
+	ds, err := cmd.DatastoreFlag.Datastore()
+	if err != nil {
+		return err
+	}
+
+	pool, err := cmd.ResourcePoolFlag.ResourcePool()
+	if err != nil {
+		return err
+	}
+
+	folder, err := cmd.FolderOrDefault("vm")
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("Uploading %s... ", path.Base(src)))
+	defer logger.Wait()
+
+	p := vmdk.ImportParams{
+		Path:       f.Arg(1),
+		Logger:     logger,
+		Type:       "", // TODO: flag
+		Force:      cmd.force,
+		Datacenter: dc,
+		Pool:       pool,
+		Folder:     folder,
+	}
+
+	err = vmdk.Import(ctx, c, src, ds, p)
+	if err != nil && err == vmdk.ErrInvalidFormat {
+		return fmt.Errorf(`%s
+The vmdk can be converted using one of:
+  vmware-vdiskmanager -t 5 -r '%s' new.vmdk
+  qemu-img convert -O vmdk -o subformat=streamOptimized '%s' new.vmdk`, err, src, src)
+	}
+
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/library/checkin.go
+++ b/vendor/github.com/vmware/govmomi/govc/library/checkin.go
@@ -1,0 +1,92 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/library/finder"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/vcenter"
+)
+
+type checkin struct {
+	*flags.VirtualMachineFlag
+	vcenter.CheckIn
+}
+
+func init() {
+	cli.Register("library.checkin", &checkin{}, true)
+}
+
+func (cmd *checkin) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.Message, "m", "", "Check in message")
+}
+
+func (cmd *checkin) Usage() string {
+	return "PATH"
+}
+
+func (cmd *checkin) Description() string {
+	return `Check in VM to Content Library item PATH.
+
+Examples:
+  govc library.checkin -vm my-vm my-content/template-vm-item`
+}
+
+func (cmd *checkin) Run(ctx context.Context, f *flag.FlagSet) error {
+	path := f.Arg(0)
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		m := library.NewManager(c)
+		res, err := finder.NewFinder(m).Find(ctx, path)
+		if err != nil {
+			return err
+		}
+		if len(res) != 1 {
+			return ErrMultiMatch{Type: "library", Key: "name", Val: path, Count: len(res)}
+		}
+		l, ok := res[0].GetResult().(library.Item)
+		if !ok {
+			return fmt.Errorf("%q is a %T", path, res[0].GetResult())
+		}
+
+		version, err := vcenter.NewManager(c).CheckIn(ctx, l.ID, vm, &cmd.CheckIn)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("%s (%s) checked in as content version %s", l.Name, l.ID, version)
+
+		return nil
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/library/checkout.go
+++ b/vendor/github.com/vmware/govmomi/govc/library/checkout.go
@@ -1,0 +1,141 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/library/finder"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/vcenter"
+)
+
+type checkout struct {
+	*flags.ClusterFlag
+	*flags.FolderFlag
+	*flags.ResourcePoolFlag
+	*flags.HostSystemFlag
+}
+
+func init() {
+	cli.Register("library.checkout", &checkout{}, true)
+}
+
+func (cmd *checkout) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClusterFlag, ctx = flags.NewClusterFlag(ctx)
+	cmd.ClusterFlag.Register(ctx, f)
+
+	cmd.ResourcePoolFlag, ctx = flags.NewResourcePoolFlag(ctx)
+	cmd.ResourcePoolFlag.Register(ctx, f)
+
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	cmd.FolderFlag, ctx = flags.NewFolderFlag(ctx)
+	cmd.FolderFlag.Register(ctx, f)
+}
+
+func (cmd *checkout) Process(ctx context.Context) error {
+	if err := cmd.ClusterFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.ResourcePoolFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.FolderFlag.Process(ctx)
+}
+
+func (cmd *checkout) Usage() string {
+	return "PATH NAME"
+}
+
+func (cmd *checkout) Description() string {
+	return `Check out Content Library item PATH to vm NAME.
+
+Examples:
+  govc library.checkout -cluster my-cluster my-content/template-vm-item my-vm`
+}
+
+func (cmd *checkout) Run(ctx context.Context, f *flag.FlagSet) error {
+	path := f.Arg(0)
+	name := f.Arg(1)
+
+	folder, err := cmd.FolderOrDefault("vm")
+	if err != nil {
+		return err
+	}
+	host, err := cmd.HostSystemIfSpecified()
+	if err != nil {
+		return err
+	}
+	cluster, err := cmd.ClusterIfSpecified()
+	if err != nil {
+		return err
+	}
+	pool, err := cmd.ResourcePoolIfSpecified()
+	if err != nil {
+		return err
+	}
+
+	return cmd.FolderFlag.WithRestClient(ctx, func(c *rest.Client) error {
+		m := library.NewManager(c)
+		res, err := finder.NewFinder(m).Find(ctx, path)
+		if err != nil {
+			return err
+		}
+		if len(res) != 1 {
+			return ErrMultiMatch{Type: "library", Key: "name", Val: path, Count: len(res)}
+		}
+		l, ok := res[0].GetResult().(library.Item)
+		if !ok {
+			return fmt.Errorf("%q is a %T", path, res[0].GetResult())
+		}
+
+		spec := vcenter.CheckOut{
+			Name: name,
+			Placement: &vcenter.Placement{
+				Folder: folder.Reference().Value,
+			},
+		}
+		if pool != nil {
+			spec.Placement.ResourcePool = pool.Reference().Value
+		}
+		if host != nil {
+			spec.Placement.Host = host.Reference().Value
+		}
+		if cluster != nil {
+			spec.Placement.Cluster = cluster.Reference().Value
+		}
+
+		id, err := vcenter.NewManager(c).CheckOut(ctx, l.ID, &spec)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(id)
+
+		return nil
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/library/clone.go
+++ b/vendor/github.com/vmware/govmomi/govc/library/clone.go
@@ -1,0 +1,192 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/library/finder"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/vcenter"
+)
+
+type clone struct {
+	*flags.ClusterFlag
+	*flags.DatastoreFlag
+	*flags.FolderFlag
+	*flags.ResourcePoolFlag
+	*flags.HostSystemFlag
+	*flags.VirtualMachineFlag
+
+	profile string
+}
+
+func init() {
+	cli.Register("library.clone", &clone{})
+}
+
+func (cmd *clone) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClusterFlag, ctx = flags.NewClusterFlag(ctx)
+	cmd.ClusterFlag.Register(ctx, f)
+
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	cmd.ResourcePoolFlag, ctx = flags.NewResourcePoolFlag(ctx)
+	cmd.ResourcePoolFlag.Register(ctx, f)
+
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	cmd.FolderFlag, ctx = flags.NewFolderFlag(ctx)
+	cmd.FolderFlag.Register(ctx, f)
+
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.profile, "profile", "", "Storage profile")
+}
+
+func (cmd *clone) Process(ctx context.Context) error {
+	if err := cmd.ClusterFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.ResourcePoolFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.FolderFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.VirtualMachineFlag.Process(ctx)
+}
+
+func (cmd *clone) Usage() string {
+	return "PATH NAME"
+}
+
+func (cmd *clone) Description() string {
+	return `Clone VM to Content Library PATH.
+
+The API used by this command requires vCenter version 6.7U1 or higher.
+
+Examples:
+  govc library.clone -vm template-vm my-content template-vm-item`
+}
+
+func (cmd *clone) Run(ctx context.Context, f *flag.FlagSet) error {
+	path := f.Arg(0)
+	name := f.Arg(1)
+
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+	if vm == nil {
+		return flag.ErrHelp
+	}
+	ds, err := cmd.DatastoreIfSpecified()
+	if err != nil {
+		return err
+	}
+	folder, err := cmd.FolderOrDefault("vm")
+	if err != nil {
+		return err
+	}
+	host, err := cmd.HostSystemIfSpecified()
+	if err != nil {
+		return err
+	}
+	cluster, err := cmd.ClusterIfSpecified()
+	if err != nil {
+		return err
+	}
+	pool, err := cmd.ResourcePoolIfSpecified()
+	if err != nil {
+		return err
+	}
+
+	dsID := ""
+	if ds != nil {
+		dsID = ds.Reference().Value
+	}
+
+	return cmd.VirtualMachineFlag.WithRestClient(ctx, func(c *rest.Client) error {
+		m := library.NewManager(c)
+		res, err := finder.NewFinder(m).Find(ctx, path)
+		if err != nil {
+			return err
+		}
+		if len(res) != 1 {
+			return ErrMultiMatch{Type: "library", Key: "name", Val: path, Count: len(res)}
+		}
+		l, ok := res[0].GetResult().(library.Library)
+		if !ok {
+			return fmt.Errorf("%q is a %T", path, res[0].GetResult())
+		}
+
+		storage := &vcenter.DiskStorage{
+			Datastore: dsID,
+			StoragePolicy: &vcenter.StoragePolicy{
+				Policy: cmd.profile,
+				Type:   "USE_SOURCE_POLICY",
+			},
+		}
+		if cmd.profile != "" {
+			storage.StoragePolicy.Type = "USE_SPECIFIED_POLICY"
+		}
+
+		spec := vcenter.Template{
+			Name:          name,
+			Library:       l.ID,
+			DiskStorage:   storage,
+			VMHomeStorage: storage,
+			SourceVM:      vm.Reference().Value,
+			Placement: &vcenter.Placement{
+				Folder: folder.Reference().Value,
+			},
+		}
+		if pool != nil {
+			spec.Placement.ResourcePool = pool.Reference().Value
+		}
+		if host != nil {
+			spec.Placement.Host = host.Reference().Value
+		}
+		if cluster != nil {
+			spec.Placement.Cluster = cluster.Reference().Value
+		}
+
+		id, err := vcenter.NewManager(c).CreateTemplate(ctx, spec)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(id)
+
+		return nil
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/library/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/library/create.go
@@ -1,0 +1,117 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/rest"
+)
+
+type create struct {
+	*flags.DatastoreFlag
+	library library.Library
+	sub     library.Subscription
+}
+
+func init() {
+	cli.Register("library.create", &create{})
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	cmd.sub.AutomaticSyncEnabled = new(bool)
+	cmd.sub.OnDemand = new(bool)
+
+	f.StringVar(&cmd.library.Description, "d", "", "Description of library")
+	f.StringVar(&cmd.sub.SubscriptionURL, "sub", "", "Subscribe to library URL")
+	f.StringVar(&cmd.sub.UserName, "sub-username", "", "Subscription username")
+	f.StringVar(&cmd.sub.Password, "sub-password", "", "Subscription password")
+	f.StringVar(&cmd.sub.SslThumbprint, "thumbprint", "", "SHA-1 thumbprint of the host's SSL certificate")
+	f.BoolVar(cmd.sub.AutomaticSyncEnabled, "sub-autosync", true, "Automatic synchronization")
+	f.BoolVar(cmd.sub.OnDemand, "sub-ondemand", false, "Download content on demand")
+}
+
+func (cmd *create) Usage() string {
+	return "NAME"
+}
+
+func (cmd *create) Description() string {
+	return `Create library.
+
+Examples:
+  govc library.create library_name
+  govc library.create -sub http://server/path/lib.json library_name
+  govc library.create -json | jq .
+  govc library.create library_name -json | jq .`
+}
+
+type createResult []library.Library
+
+func (r createResult) Write(w io.Writer) error {
+	for i := range r {
+		fmt.Fprintln(w, r[i].Name)
+	}
+	return nil
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	cmd.library.Name = f.Arg(0)
+	cmd.library.Type = "LOCAL"
+	cmd.library.Storage = []library.StorageBackings{
+		{
+			DatastoreID: ds.Reference().Value,
+			Type:        "DATASTORE",
+		},
+	}
+
+	if cmd.sub.SubscriptionURL != "" {
+		cmd.library.Subscription = &cmd.sub
+		cmd.library.Type = "SUBSCRIBED"
+		cmd.sub.AuthenticationMethod = "NONE"
+		if cmd.sub.Password != "" {
+			cmd.sub.AuthenticationMethod = "BASIC"
+		}
+	}
+
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		id, err := library.NewManager(c).CreateLibrary(ctx, cmd.library)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(id)
+		return nil
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/library/deploy.go
+++ b/vendor/github.com/vmware/govmomi/govc/library/deploy.go
@@ -1,0 +1,259 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/govc/importx"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/library/finder"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/vcenter"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type deploy struct {
+	*flags.DatastoreFlag
+	*flags.ResourcePoolFlag
+	*flags.HostSystemFlag
+	*flags.FolderFlag
+	*importx.OptionsFlag
+
+	profile string
+}
+
+func init() {
+	cli.Register("library.deploy", &deploy{})
+}
+
+func (cmd *deploy) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	cmd.ResourcePoolFlag, ctx = flags.NewResourcePoolFlag(ctx)
+	cmd.ResourcePoolFlag.Register(ctx, f)
+
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	cmd.FolderFlag, ctx = flags.NewFolderFlag(ctx)
+	cmd.FolderFlag.Register(ctx, f)
+
+	cmd.OptionsFlag = new(importx.OptionsFlag)
+	cmd.OptionsFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.profile, "profile", "", "Storage profile")
+}
+
+func (cmd *deploy) Process(ctx context.Context) error {
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.ResourcePoolFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.FolderFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.OptionsFlag.Process(ctx)
+}
+
+func (cmd *deploy) Usage() string {
+	return "TEMPLATE [NAME]"
+}
+
+func (cmd *deploy) Description() string {
+	return `Deploy library OVF template.
+
+Examples:
+  govc library.deploy /library_name/ovf_template vm_name
+  govc library.deploy /library_name/ovf_template -options deploy.json`
+}
+
+func (cmd *deploy) Run(ctx context.Context, f *flag.FlagSet) error {
+	path := f.Arg(0)
+	name := f.Arg(1)
+
+	if name == "" && cmd.Options.Name != nil {
+		name = *cmd.Options.Name
+	}
+
+	return cmd.DatastoreFlag.WithRestClient(ctx, func(c *rest.Client) error {
+		m := vcenter.NewManager(c)
+
+		res, err := finder.NewFinder(library.NewManager(c)).Find(ctx, path)
+		if err != nil {
+			return err
+		}
+		if len(res) != 1 {
+			return ErrMultiMatch{Type: "library", Key: "name", Val: f.Arg(0), Count: len(res)}
+		}
+		item, ok := res[0].GetResult().(library.Item)
+		if !ok {
+			return fmt.Errorf("%q is a %T", path, item)
+		}
+
+		ds, err := cmd.DatastoreIfSpecified()
+		if err != nil {
+			return err
+		}
+		rp, err := cmd.ResourcePoolIfSpecified()
+		if err != nil {
+			return err
+		}
+		host, err := cmd.HostSystemIfSpecified()
+		if err != nil {
+			return err
+		}
+		hostID := ""
+		if rp == nil {
+			if host == nil {
+				rp, err = cmd.ResourcePoolFlag.ResourcePool()
+			} else {
+				rp, err = host.ResourcePool(ctx)
+				hostID = host.Reference().Value
+			}
+			if err != nil {
+				return err
+			}
+		}
+		folder, err := cmd.Folder()
+		if err != nil {
+			return err
+		}
+		finder, err := cmd.FolderFlag.Finder(false)
+		if err != nil {
+			return err
+		}
+
+		var networks []vcenter.NetworkMapping
+		for _, net := range cmd.Options.NetworkMapping {
+			if net.Network == "" {
+				continue
+			}
+			obj, err := finder.Network(ctx, net.Network)
+			if err != nil {
+				return err
+			}
+			networks = append(networks, vcenter.NetworkMapping{
+				Key:   net.Name,
+				Value: obj.Reference().Value,
+			})
+		}
+
+		var properties []vcenter.Property
+		for _, prop := range cmd.Options.PropertyMapping {
+			properties = append(properties, vcenter.Property{
+				ID:    prop.Key,
+				Value: prop.Value,
+			})
+		}
+
+		dsID := ""
+		if ds != nil {
+			dsID = ds.Reference().Value
+		}
+
+		cmd.FolderFlag.Log("Deploying library item...\n")
+
+		var ref *types.ManagedObjectReference
+
+		switch item.Type {
+		case library.ItemTypeOVF:
+			deploy := vcenter.Deploy{
+				DeploymentSpec: vcenter.DeploymentSpec{
+					Name:               name,
+					DefaultDatastoreID: dsID,
+					AcceptAllEULA:      true,
+					Annotation:         cmd.Options.Annotation,
+					AdditionalParams: []vcenter.AdditionalParams{
+						{
+							Class:       vcenter.ClassOvfParams,
+							Type:        vcenter.TypeDeploymentOptionParams,
+							SelectedKey: cmd.Options.Deployment,
+						},
+						{
+							Class:       vcenter.ClassPropertyParams,
+							Type:        vcenter.TypePropertyParams,
+							SelectedKey: cmd.Options.Deployment,
+							Properties:  properties,
+						},
+					},
+					NetworkMappings:     networks,
+					StorageProvisioning: cmd.Options.DiskProvisioning,
+					StorageProfileID:    cmd.profile,
+				},
+				Target: vcenter.Target{
+					ResourcePoolID: rp.Reference().Value,
+					HostID:         hostID,
+					FolderID:       folder.Reference().Value,
+				},
+			}
+			ref, err = m.DeployLibraryItem(ctx, item.ID, deploy)
+			if err != nil {
+				return err
+			}
+		case library.ItemTypeVMTX:
+			storage := &vcenter.DiskStorage{
+				Datastore: dsID,
+				StoragePolicy: &vcenter.StoragePolicy{
+					Policy: cmd.profile,
+					Type:   "USE_SOURCE_POLICY",
+				},
+			}
+			if cmd.profile != "" {
+				storage.StoragePolicy.Type = "USE_SPECIFIED_POLICY"
+			}
+
+			deploy := vcenter.DeployTemplate{
+				Name:          name,
+				Description:   cmd.Options.Annotation,
+				DiskStorage:   storage,
+				VMHomeStorage: storage,
+				Placement: &vcenter.Placement{
+					ResourcePool: rp.Reference().Value,
+					Host:         hostID,
+					Folder:       folder.Reference().Value,
+				},
+			}
+			ref, err = m.DeployTemplateLibraryItem(ctx, item.ID, deploy)
+			if err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported library item type: %s", item.Type)
+		}
+
+		obj, err := finder.ObjectReference(ctx, *ref)
+		if err != nil {
+			return err
+		}
+
+		vm := obj.(*object.VirtualMachine)
+
+		return cmd.Deploy(vm, cmd.FolderFlag.OutputFlag)
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/library/errors.go
+++ b/vendor/github.com/vmware/govmomi/govc/library/errors.go
@@ -1,0 +1,44 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import "fmt"
+
+// ErrMultiMatch is an error returned when a query returns more than one result.
+type ErrMultiMatch struct {
+	// Type is the type of object being queried.
+	Type string
+
+	// Key is the key used to perform the query.
+	Key string
+
+	// Val is the value used to perform the query.
+	Val string
+
+	// Count is the number of objects returned.
+	Count int
+}
+
+// Error returns the error string.
+func (e ErrMultiMatch) Error() string {
+	return e.String()
+}
+
+// String returns the same value as Error().
+func (e ErrMultiMatch) String() string {
+	return fmt.Sprintf("%q=%q matches %d items, %q id must be specified", e.Key, e.Val, e.Count, e.Type)
+}

--- a/vendor/github.com/vmware/govmomi/govc/library/export.go
+++ b/vendor/github.com/vmware/govmomi/govc/library/export.go
@@ -1,0 +1,195 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/library/finder"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+type export struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+	library.Item
+}
+
+func init() {
+	cli.Register("library.export", &export{})
+}
+
+func (cmd *export) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *export) Usage() string {
+	return "PATH [DEST]"
+}
+
+func (cmd *export) Description() string {
+	return `Export library items.
+
+If the given PATH is a library item, all files will be downloaded.
+
+If the given PATH is a library item file, only that file will be downloaded.
+
+By default, files are saved using the library item's file names to the current directory.
+If DEST is given for a library item, files are saved there instead of the current directory.
+If DEST is given for a library item file, the file will be saved with that name.
+If DEST is '-', the file contents are written to stdout instead of saving to a file.
+
+Examples:
+  govc library.export library_name/item_name
+  govc library.export library_name/item_name/file_name
+  govc library.export library_name/item_name/*.ovf -`
+}
+
+func (cmd *export) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.OutputFlag.Process(ctx)
+}
+
+func (cmd *export) Run(ctx context.Context, f *flag.FlagSet) error {
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		var names []string
+		m := library.NewManager(c)
+		res, err := finder.NewFinder(m).Find(ctx, f.Arg(0))
+		if err != nil {
+			return err
+		}
+
+		if len(res) != 1 {
+			return ErrMultiMatch{Type: "library", Key: "name", Val: f.Arg(0), Count: len(res)}
+		}
+
+		switch t := res[0].GetResult().(type) {
+		case library.Item:
+			cmd.Item = t
+		case library.File:
+			names = []string{t.Name}
+			cmd.Item = res[0].GetParent().GetResult().(library.Item)
+		default:
+			return fmt.Errorf("%q is a %T", f.Arg(0), t)
+		}
+
+		dst := f.Arg(1)
+		one := len(names) == 1
+		var log io.Writer = os.Stdout
+		isStdout := one && dst == "-"
+		if isStdout {
+			log = ioutil.Discard
+		}
+
+		session, err := m.CreateLibraryItemDownloadSession(ctx, library.Session{
+			LibraryItemID: cmd.ID,
+		})
+		if err != nil {
+			return err
+		}
+
+		if len(names) == 0 {
+			files, err := m.ListLibraryItemDownloadSessionFile(ctx, session)
+			if err != nil {
+				return err
+			}
+
+			for _, file := range files {
+				names = append(names, file.Name)
+			}
+		}
+
+		for _, name := range names {
+			_, err = m.PrepareLibraryItemDownloadSessionFile(ctx, session, name)
+			if err != nil {
+				return err
+			}
+		}
+
+		download := func(src *url.URL, name string) error {
+			p := soap.DefaultDownload
+
+			if isStdout {
+				s, _, err := c.Download(ctx, src, &p)
+				if err != nil {
+					return err
+				}
+				_, err = io.Copy(os.Stdout, s)
+				_ = s.Close()
+				return err
+			}
+
+			if cmd.OutputFlag.TTY {
+				logger := cmd.ProgressLogger(fmt.Sprintf("Downloading %s... ", src.String()))
+				defer logger.Wait()
+				p.Progress = logger
+			}
+
+			if one && dst != "" {
+				name = dst
+			} else {
+				name = filepath.Join(dst, name)
+			}
+			return c.DownloadFile(ctx, name, src, &p)
+		}
+
+		for _, name := range names {
+			var info *library.DownloadFile
+			_, _ = fmt.Fprintf(log, "Checking %s... ", name)
+			for {
+				info, err = m.GetLibraryItemDownloadSessionFile(ctx, session, name)
+				if err != nil {
+					return err
+				}
+				if info.Status == "PREPARED" {
+					_, _ = fmt.Fprintln(log, info.Status)
+					break // with this status we have a DownloadEndpoint.URI
+				}
+				time.Sleep(time.Second)
+			}
+
+			src, err := url.Parse(info.DownloadEndpoint.URI)
+			if err != nil {
+				return err
+			}
+			err = download(src, name)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/library/import.go
+++ b/vendor/github.com/vmware/govmomi/govc/library/import.go
@@ -1,0 +1,246 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/govc/importx"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/library/finder"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+type item struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+	library.Item
+
+	manifest bool
+	pull     bool
+}
+
+func init() {
+	cli.Register("library.import", &item{})
+}
+
+func (cmd *item) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.Name, "n", "", "Library item name")
+	f.StringVar(&cmd.Type, "t", "", "Library item type")
+	f.BoolVar(&cmd.manifest, "m", false, "Require ova manifest")
+	f.BoolVar(&cmd.pull, "pull", false, "Pull library item from http endpoint")
+}
+
+func (cmd *item) Usage() string {
+	return "LIBRARY ITEM"
+}
+
+func (cmd *item) Description() string {
+	return `Import library items.
+
+Examples:
+  govc library.import library_name file.ova
+  govc library.import library_name file.ovf
+  govc library.import library_name file.iso
+  govc library.import library_id file.iso # Use library id if multiple libraries have the same name
+  govc library.import library_name/item_name file.ova # update existing item
+  govc library.import library_name http://example.com/file.ovf # download and push to vCenter
+  govc library.import -pull library_name http://example.com/file.ova # direct pull from vCenter`
+}
+
+func (cmd *item) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.OutputFlag.Process(ctx)
+}
+
+func (cmd *item) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 2 {
+		return flag.ErrHelp
+	}
+
+	file := f.Arg(1)
+	base := filepath.Base(file)
+	ext := filepath.Ext(base)
+	mf := strings.Replace(base, ext, ".mf", 1)
+	kind := ""
+	client, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+	opener := importx.Opener{Client: client}
+	archive := &importx.ArchiveFlag{Archive: &importx.FileArchive{Path: file, Opener: opener}}
+
+	manifest := make(map[string]*library.Checksum)
+	if cmd.Name == "" {
+		cmd.Name = strings.TrimSuffix(base, ext)
+	}
+
+	switch ext {
+	case ".ova":
+		archive.Archive = &importx.TapeArchive{Path: file, Opener: opener}
+		base = "*.ovf"
+		mf = "*.mf"
+		kind = library.ItemTypeOVF
+	case ".ovf":
+		kind = library.ItemTypeOVF
+	case ".iso":
+		kind = library.ItemTypeISO
+	}
+
+	if cmd.Type == "" {
+		cmd.Type = kind
+	}
+
+	if !cmd.pull && cmd.Type == library.ItemTypeOVF {
+		f, _, err := archive.Open(mf)
+		if err == nil {
+			sums, err := library.ReadManifest(f)
+			_ = f.Close()
+			if err != nil {
+				return err
+			}
+			manifest = sums
+		} else {
+			msg := fmt.Sprintf("manifest %q: %s", mf, err)
+			if cmd.manifest {
+				return errors.New(msg)
+			}
+			fmt.Fprintln(os.Stderr, msg)
+		}
+	}
+
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		m := library.NewManager(c)
+		res, err := finder.NewFinder(m).Find(ctx, f.Arg(0))
+		if err != nil {
+			return err
+		}
+
+		if len(res) != 1 {
+			return ErrMultiMatch{Type: "library", Key: "name", Val: f.Arg(0), Count: len(res)}
+		}
+
+		switch t := res[0].GetResult().(type) {
+		case library.Library:
+			cmd.LibraryID = t.ID
+			cmd.ID, err = m.CreateLibraryItem(ctx, cmd.Item)
+			if err != nil {
+				return err
+			}
+		case library.Item:
+			cmd.Item = t
+		default:
+			return fmt.Errorf("%q is a %T", f.Arg(0), t)
+		}
+
+		session, err := m.CreateLibraryItemUpdateSession(ctx, library.Session{
+			LibraryItemID: cmd.ID,
+		})
+
+		if cmd.pull {
+			_, err = m.AddLibraryItemFileFromURI(ctx, session, filepath.Base(file), file)
+			if err != nil {
+				return err
+			}
+
+			return m.WaitOnLibraryItemUpdateSession(ctx, session, 3*time.Second, nil)
+		}
+
+		upload := func(name string) error {
+			f, size, err := archive.Open(name)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+
+			if e, ok := f.(*importx.TapeArchiveEntry); ok {
+				name = e.Name // expand path.Match's (e.g. "*.ovf" -> "name.ovf")
+			}
+
+			info := library.UpdateFile{
+				Name:       name,
+				SourceType: "PUSH",
+				Checksum:   manifest[name],
+				Size:       size,
+			}
+
+			update, err := m.AddLibraryItemFile(ctx, session, info)
+			if err != nil {
+				return err
+			}
+
+			p := soap.DefaultUpload
+			p.Headers = map[string]string{
+				"vmware-api-session-id": session,
+			}
+			p.ContentLength = size
+			u, err := url.Parse(update.UploadEndpoint.URI)
+			if err != nil {
+				return err
+			}
+			if cmd.OutputFlag.TTY {
+				logger := cmd.ProgressLogger(fmt.Sprintf("Uploading %s... ", name))
+				p.Progress = logger
+				defer logger.Wait()
+			}
+			return c.Upload(ctx, f, u, &p)
+		}
+
+		if err = upload(base); err != nil {
+			return err
+		}
+
+		if cmd.Type == library.ItemTypeOVF {
+			o, err := archive.ReadOvf(base)
+			if err != nil {
+				return err
+			}
+
+			e, err := archive.ReadEnvelope(o)
+			if err != nil {
+				return fmt.Errorf("failed to parse ovf: %s", err)
+			}
+
+			for i := range e.References {
+				if err = upload(e.References[i].Href); err != nil {
+					return err
+				}
+			}
+		}
+
+		return m.CompleteLibraryItemUpdateSession(ctx, session)
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/library/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/library/info.go
@@ -1,0 +1,346 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/units"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/library/finder"
+	"github.com/vmware/govmomi/vapi/rest"
+
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+	*flags.DatacenterFlag
+
+	long bool
+	link bool
+
+	names map[string]string
+}
+
+func init() {
+	cli.Register("library.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+	cmd.OutputFlag.Register(ctx, f)
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.long, "l", false, "Long listing format")
+	f.BoolVar(&cmd.link, "L", false, "List Datastore path only")
+
+	cmd.names = make(map[string]string)
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *info) Description() string {
+	return `Display library information.
+
+Examples:
+  govc library.info
+  govc library.info /lib1
+  govc library.info -l /lib1 | grep Size:
+  govc library.info /lib1/item1
+  govc library.info /lib1/item1/
+  govc library.info */
+  govc device.cdrom.insert -vm $vm -device cdrom-3000 $(govc library.info -L /lib1/item1/file1)
+  govc library.info -json | jq .
+  govc library.info /lib1/item1 -json | jq .`
+}
+
+type infoResultsWriter struct {
+	Result []finder.FindResult
+	m      *library.Manager
+	cmd    *info
+}
+
+func (r infoResultsWriter) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.Result)
+}
+
+func (r infoResultsWriter) Write(w io.Writer) error {
+	if r.cmd.link {
+		for _, j := range r.Result {
+			p, err := r.cmd.getDatastoreFilePath(j)
+			if err != nil {
+				return err
+			}
+			if !r.cmd.long {
+				var path object.DatastorePath
+				path.FromString(p)
+				p = path.Path
+			}
+			fmt.Fprintln(w, p)
+		}
+		return nil
+	}
+
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+	defer tw.Flush()
+	for _, j := range r.Result {
+		switch t := j.GetResult().(type) {
+		case library.Library:
+			if err := r.writeLibrary(tw, t, j); err != nil {
+				return err
+			}
+		case library.Item:
+			if err := r.writeItem(tw, t, j); err != nil {
+				return err
+			}
+		case library.File:
+			if err := r.writeFile(tw, t, j); err != nil {
+				return err
+			}
+		}
+		tw.Flush()
+	}
+	return nil
+}
+
+func (r infoResultsWriter) writeLibrary(
+	w io.Writer, v library.Library, res finder.FindResult) error {
+
+	fmt.Fprintf(w, "Name:\t%s\n", v.Name)
+	fmt.Fprintf(w, "  ID:\t%s\n", v.ID)
+	fmt.Fprintf(w, "  Path:\t%s\n", res.GetPath())
+	fmt.Fprintf(w, "  Description:\t%s\n", v.Description)
+	fmt.Fprintf(w, "  Version:\t%s\n", v.Version)
+	fmt.Fprintf(w, "  Created:\t%s\n", v.CreationTime.Format(time.ANSIC))
+	fmt.Fprintf(w, "  StorageBackings:\t\n")
+	for _, d := range v.Storage {
+		fmt.Fprintf(w, "    DatastoreID:\t%s\n", d.DatastoreID)
+		fmt.Fprintf(w, "    Type:\t%s\n", d.Type)
+	}
+	if r.cmd.long {
+		fmt.Fprintf(w, "  Datastore Path:\t%s\n", r.cmd.getDatastorePath(res))
+		items, err := r.m.GetLibraryItems(context.Background(), v.ID)
+		if err != nil {
+			return err
+		}
+		var size int64
+		for i := range items {
+			size += items[i].Size
+		}
+		fmt.Fprintf(w, "  Size:\t%s\n", units.ByteSize(size))
+		fmt.Fprintf(w, "  Items:\t%d\n", len(items))
+	}
+	if v.Subscription != nil {
+		dl := "All"
+		if v.Subscription.OnDemand != nil && *v.Subscription.OnDemand {
+			dl = "On Demand"
+		}
+
+		fmt.Fprintf(w, "  Subscription:\t\n")
+		fmt.Fprintf(w, "    AutoSync:\t%t\n", *v.Subscription.AutomaticSyncEnabled)
+		fmt.Fprintf(w, "    URL:\t%s\n", v.Subscription.SubscriptionURL)
+		fmt.Fprintf(w, "    Auth:\t%s\n", v.Subscription.AuthenticationMethod)
+		fmt.Fprintf(w, "    Download:\t%s\n", dl)
+	}
+	return nil
+}
+
+func (r infoResultsWriter) writeItem(
+	w io.Writer, v library.Item, res finder.FindResult) error {
+
+	fmt.Fprintf(w, "Name:\t%s\n", v.Name)
+	fmt.Fprintf(w, "  ID:\t%s\n", v.ID)
+	fmt.Fprintf(w, "  Path:\t%s\n", res.GetPath())
+	fmt.Fprintf(w, "  Description:\t%s\n", v.Description)
+	fmt.Fprintf(w, "  Type:\t%s\n", v.Type)
+	fmt.Fprintf(w, "  Size:\t%s\n", units.ByteSize(v.Size))
+	fmt.Fprintf(w, "  Created:\t%s\n", v.CreationTime.Format(time.ANSIC))
+	fmt.Fprintf(w, "  Modified:\t%s\n", v.LastModifiedTime.Format(time.ANSIC))
+	fmt.Fprintf(w, "  Version:\t%s\n", v.Version)
+
+	if r.cmd.long {
+		fmt.Fprintf(w, "  Datastore Path:\t%s\n", r.cmd.getDatastorePath(res))
+	}
+
+	return nil
+}
+
+func (r infoResultsWriter) writeFile(
+	w io.Writer, v library.File, res finder.FindResult) error {
+
+	size := "-"
+	if v.Size != nil {
+		size = units.ByteSize(*v.Size).String()
+	}
+	fmt.Fprintf(w, "Name:\t%s\n", v.Name)
+	fmt.Fprintf(w, "  Path:\t%s\n", res.GetPath())
+	fmt.Fprintf(w, "  Size:\t%s\n", size)
+	fmt.Fprintf(w, "  Version:\t%s\n", v.Version)
+
+	if r.cmd.long {
+		fmt.Fprintf(w, "  Datastore Path:\t%s\n", r.cmd.getDatastorePath(res))
+	}
+
+	return nil
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		m := library.NewManager(c)
+		finder := finder.NewFinder(m)
+		findResults, err := finder.Find(ctx, f.Args()...)
+		if err != nil {
+			return err
+		}
+		// Lookup the names(s) of the library's datastore(s).
+		for i := range findResults {
+			if t, ok := findResults[i].GetResult().(library.Library); ok {
+				for j := range t.Storage {
+					if t.Storage[j].Type == "DATASTORE" {
+						t.Storage[j].DatastoreID = cmd.getDatastoreName(t.Storage[j].DatastoreID)
+					}
+				}
+			}
+		}
+		return cmd.WriteResult(&infoResultsWriter{findResults, m, cmd})
+	})
+}
+
+func (cmd *info) getDatastoreName(id string) string {
+	if name, ok := cmd.names[id]; ok {
+		return name
+	}
+
+	c, err := cmd.Client()
+	if err != nil {
+		return id
+	}
+
+	obj := types.ManagedObjectReference{
+		Type:  "Datastore",
+		Value: id,
+	}
+	pc := property.DefaultCollector(c)
+	var me mo.ManagedEntity
+
+	err = pc.RetrieveOne(context.Background(), obj, []string{"name"}, &me)
+	if err != nil {
+		return id
+	}
+
+	cmd.names[id] = me.Name
+	return me.Name
+}
+
+func (cmd *info) getDatastorePath(r finder.FindResult) string {
+	p, _ := cmd.getDatastoreFilePath(r)
+	return p
+}
+
+func (cmd *info) getDatastoreFilePath(r finder.FindResult) (string, error) {
+	switch x := r.GetResult().(type) {
+	case library.Library:
+		id := ""
+		if len(x.Storage) != 0 {
+			id = cmd.getDatastoreName(x.Storage[0].DatastoreID)
+		}
+		return fmt.Sprintf("[%s] contentlib-%s", id, x.ID), nil
+	case library.Item:
+		return fmt.Sprintf("%s/%s", cmd.getDatastorePath(r.GetParent()), x.ID), nil
+	case library.File:
+		return cmd.getDatastoreFileItemPath(r)
+	default:
+		return "", fmt.Errorf("unsupported type=%T", x)
+	}
+}
+
+// getDatastoreFileItemPath returns the absolute datastore path for a library.File
+func (cmd *info) getDatastoreFileItemPath(r finder.FindResult) (string, error) {
+	name := r.GetName()
+	dir := cmd.getDatastorePath(r.GetParent())
+	p := path.Join(dir, name)
+
+	lib := r.GetParent().GetParent().GetResult().(library.Library)
+	if len(lib.Storage) == 0 {
+		return p, nil
+	}
+
+	ctx := context.Background()
+	c, err := cmd.Client()
+	if err != nil {
+		return p, err
+	}
+
+	ref := types.ManagedObjectReference{Type: "Datastore", Value: lib.Storage[0].DatastoreID}
+	ds := object.NewDatastore(c, ref)
+
+	b, err := ds.Browser(ctx)
+	if err != nil {
+		return p, err
+	}
+
+	// The file ID isn't available via the API, so we use DatastoreBrowser to search
+	ext := path.Ext(name)
+	pat := strings.Replace(name, ext, "*"+ext, 1)
+	spec := types.HostDatastoreBrowserSearchSpec{
+		MatchPattern: []string{pat},
+	}
+
+	task, err := b.SearchDatastore(ctx, dir, &spec)
+	if err != nil {
+		return p, err
+	}
+
+	info, err := task.WaitForResult(ctx, nil)
+	if err != nil {
+		return p, err
+	}
+
+	res, ok := info.Result.(types.HostDatastoreBrowserSearchResults)
+	if !ok {
+		return p, fmt.Errorf("search(%s) result type=%T", pat, info.Result)
+	}
+
+	if len(res.File) != 1 {
+		return p, fmt.Errorf("search(%s) result files=%d", pat, len(res.File))
+	}
+
+	return path.Join(dir, res.File[0].GetFileInfo().Path), nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/library/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/library/ls.go
@@ -1,0 +1,87 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/library/finder"
+	"github.com/vmware/govmomi/vapi/rest"
+)
+
+type ls struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("library.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ls) Description() string {
+	return `List libraries, items, and files.
+
+Examples:
+  govc library.ls
+  govc library.ls /lib1
+  govc library.ls /lib1/item1
+  govc library.ls /lib1/item1/
+  govc library.ls */
+  govc library.ls -json | jq .
+  govc library.ls /lib1/item1 -json | jq .`
+}
+
+type lsResultsWriter []finder.FindResult
+
+func (r lsResultsWriter) Write(w io.Writer) error {
+	for _, i := range r {
+		fmt.Fprintln(w, i.GetPath())
+	}
+	return nil
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		m := library.NewManager(c)
+		finder := finder.NewFinder(m)
+		findResults, err := finder.Find(ctx, f.Args()...)
+		if err != nil {
+			return err
+		}
+		return cmd.WriteResult(lsResultsWriter(findResults))
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/library/rm.go
+++ b/vendor/github.com/vmware/govmomi/govc/library/rm.go
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/library/finder"
+	"github.com/vmware/govmomi/vapi/rest"
+)
+
+type rm struct {
+	*flags.ClientFlag
+	force bool
+}
+
+func init() {
+	cli.Register("library.rm", &rm{})
+}
+
+func (cmd *rm) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+}
+
+func (cmd *rm) Usage() string {
+	return "NAME"
+}
+
+func (cmd *rm) Description() string {
+	return `Delete library or item NAME.
+
+Examples:
+  govc library.rm /library_name
+  govc library.rm library_id # Use library id if multiple libraries have the same name
+  govc library.rm /library_name/item_name`
+}
+
+func (cmd *rm) Run(ctx context.Context, f *flag.FlagSet) error {
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		m := library.NewManager(c)
+
+		res, err := finder.NewFinder(m).Find(ctx, f.Arg(0))
+		if err != nil {
+			return err
+		}
+
+		if len(res) != 1 {
+			return ErrMultiMatch{Type: "library", Key: "name", Val: f.Arg(0), Count: len(res)}
+		}
+
+		switch t := res[0].GetResult().(type) {
+		case library.Library:
+			return m.DeleteLibrary(ctx, &t)
+		case library.Item:
+			return m.DeleteLibraryItem(ctx, &t)
+		default:
+			return fmt.Errorf("%q is a %T", f.Arg(0), t)
+		}
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/library/session/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/library/session/ls.go
@@ -1,0 +1,128 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package session
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/rest"
+)
+
+type ls struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("library.session.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.OutputFlag.Process(ctx)
+}
+
+func (cmd *ls) Description() string {
+	return `List library item update sessions.
+
+Examples:
+  govc library.session.ls
+  govc library.session.ls -json | jq .`
+}
+
+type info struct {
+	Sessions []*library.Session
+	kind     string
+}
+
+func (i *info) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "ID\tItem\tType\tVersion\tProgress\tState\tExpires")
+
+	for _, s := range i.Sessions {
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%s\t%s\n",
+			s.ID, s.LibraryItemID, i.kind, s.LibraryItemContentVersion, s.ClientProgress, s.State,
+			s.ExpirationTime.Format("2006-01-02 15:04"))
+	}
+
+	return tw.Flush()
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		m := library.NewManager(c)
+
+		kinds := []struct {
+			kind string
+			list func(context.Context) ([]string, error)
+			get  func(context.Context, string) (*library.Session, error)
+		}{
+			{"Update", m.ListLibraryItemUpdateSession, m.GetLibraryItemUpdateSession},
+			{"Download", m.ListLibraryItemDownloadSession, m.GetLibraryItemDownloadSession},
+		}
+
+		for _, k := range kinds {
+			ids, err := k.list(ctx)
+			if err != nil {
+				return err
+			}
+			if len(ids) == 0 {
+				continue
+			}
+			var sessions []*library.Session
+
+			for _, id := range ids {
+				session, err := k.get(ctx, id)
+				if err != nil {
+					return err
+				}
+				item, err := m.GetLibraryItem(ctx, session.LibraryItemID)
+				if err != nil {
+					return err
+				}
+				lib, err := m.GetLibraryByID(ctx, item.LibraryID)
+				if err != nil {
+					return err
+				}
+				session.LibraryItemID = fmt.Sprintf("/%s/%s", lib.Name, item.Name)
+				sessions = append(sessions, session)
+			}
+
+			err = cmd.WriteResult(&info{sessions, k.kind})
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/library/session/rm.go
+++ b/vendor/github.com/vmware/govmomi/govc/library/session/rm.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package session
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/rest"
+)
+
+type rm struct {
+	*flags.ClientFlag
+
+	cancel bool
+}
+
+func init() {
+	cli.Register("library.session.rm", &rm{})
+}
+
+func (cmd *rm) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.cancel, "f", false, "Cancel session if active")
+}
+
+func (cmd *rm) Description() string {
+	return `Remove a library item update session.
+
+Examples:
+  govc library.session.rm session_id`
+}
+
+func (cmd *rm) Run(ctx context.Context, f *flag.FlagSet) error {
+	id := f.Arg(0)
+
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		m := library.NewManager(c)
+		cancel := m.CancelLibraryItemUpdateSession
+		remove := m.DeleteLibraryItemUpdateSession
+
+		_, err := m.GetLibraryItemUpdateSession(ctx, id)
+		if err != nil {
+			cancel = m.CancelLibraryItemDownloadSession
+			remove = m.DeleteLibraryItemDownloadSession
+		}
+
+		if cmd.cancel {
+			err := cancel(ctx, id)
+			if err != nil {
+				return nil
+			}
+		}
+		return remove(ctx, id)
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/library/sync.go
+++ b/vendor/github.com/vmware/govmomi/govc/library/sync.go
@@ -1,0 +1,175 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/library/finder"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/vcenter"
+)
+
+type sync struct {
+	*flags.FolderFlag
+	*flags.ResourcePoolFlag
+
+	vmtx string
+}
+
+func init() {
+	cli.Register("library.sync", &sync{})
+}
+
+func (cmd *sync) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.FolderFlag, ctx = flags.NewFolderFlag(ctx)
+	cmd.FolderFlag.Register(ctx, f)
+
+	cmd.ResourcePoolFlag, ctx = flags.NewResourcePoolFlag(ctx)
+	cmd.ResourcePoolFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.vmtx, "vmtx", "", "Sync subscribed library to local library as VM Templates")
+}
+
+func (cmd *sync) Process(ctx context.Context) error {
+	if err := cmd.FolderFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.ResourcePoolFlag.Process(ctx)
+}
+
+func (cmd *sync) Description() string {
+	return `Sync library NAME or ITEM.
+
+Examples:
+  govc library.sync subscribed-library
+  govc library.sync subscribed-library/item
+  govc library.sync -vmtx local-library subscribed-library # convert subscribed OVFs to local VMTX`
+}
+
+func (cmd *sync) Usage() string {
+	return "NAME|ITEM"
+}
+
+func (cmd *sync) syncVMTX(ctx context.Context, m *library.Manager, src library.Library, dst library.Library, items ...library.Item) error {
+	if cmd.vmtx == "" {
+		return nil
+	}
+
+	pool, err := cmd.ResourcePool()
+	if err != nil {
+		return err
+	}
+
+	folder, err := cmd.Folder()
+	if err != nil {
+		return err
+	}
+
+	l := vcenter.TemplateLibrary{
+		Source:      src,
+		Destination: dst,
+		Placement: vcenter.Target{
+			FolderID:       folder.Reference().Value,
+			ResourcePoolID: pool.Reference().Value,
+		},
+		Include: func(item library.Item, current *library.Item) bool {
+			fmt.Printf("Syncing /%s/%s to /%s/%s...", src.Name, item.Name, dst.Name, item.Name)
+			if current == nil {
+				fmt.Println()
+				return true
+			}
+			fmt.Println("already exists.")
+			return false
+		},
+	}
+
+	return vcenter.NewManager(m.Client).SyncTemplateLibrary(ctx, l, items...)
+}
+
+func (cmd *sync) shouldSync(l library.Library) bool {
+	if cmd.vmtx == "" {
+		return true
+
+	}
+	// Allow library.sync -vmtx of LOCAL or SUBSCRIBED library
+	return l.Type == "SUBSCRIBED"
+}
+
+func (cmd *sync) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+	path := f.Arg(0)
+
+	return cmd.FolderFlag.WithRestClient(ctx, func(c *rest.Client) error {
+		m := library.NewManager(c)
+		finder := finder.NewFinder(m)
+
+		var local library.Library
+		if cmd.vmtx != "" {
+			res, err := finder.Find(ctx, cmd.vmtx)
+			if err != nil {
+				return err
+			}
+			if len(res) != 1 {
+				return ErrMultiMatch{Type: "library", Key: "name", Val: cmd.vmtx, Count: len(res)}
+			}
+			l, ok := res[0].GetResult().(library.Library)
+			if !ok {
+				return fmt.Errorf("%q is a %T", res[0].GetPath(), l)
+			}
+			local = l
+		}
+
+		res, err := finder.Find(ctx, path)
+		if err != nil {
+			return err
+		}
+
+		if len(res) != 1 {
+			return ErrMultiMatch{Type: "library", Key: "name", Val: path, Count: len(res)}
+		}
+
+		fmt.Printf("Syncing %s...\n", res[0].GetPath())
+
+		switch t := res[0].GetResult().(type) {
+		case library.Library:
+			if cmd.shouldSync(t) {
+				if err = m.SyncLibrary(ctx, &t); err != nil {
+					return err
+				}
+			}
+			return cmd.syncVMTX(ctx, m, t, local)
+		case library.Item:
+			lib := res[0].GetParent().GetResult().(library.Library)
+			if cmd.shouldSync(lib) {
+				if err = m.SyncLibraryItem(ctx, &t, false); err != nil {
+					return err
+				}
+			}
+			return cmd.syncVMTX(ctx, m, lib, local, t)
+		default:
+			return fmt.Errorf("%q is a %T", res[0].GetPath(), t)
+		}
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/license/add.go
+++ b/vendor/github.com/vmware/govmomi/govc/license/add.go
@@ -1,0 +1,96 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package license
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/license"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type add struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("license.add", &add{})
+}
+
+func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *add) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *add) Usage() string {
+	return "KEY..."
+}
+
+func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
+	client, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m := license.NewManager(client)
+
+	// From the vSphere 5.5 documentation:
+	//
+	//     To specify the edition type and any optional functions, use
+	//     updateLicense for ESX Server and addLicense follow by
+	//     LicenseAssingmentManager.updateAssignedLicense for VirtualCenter.
+	//
+	var addFunc func(ctx context.Context, key string, labels map[string]string) (types.LicenseManagerLicenseInfo, error)
+	switch t := client.ServiceContent.About.ApiType; t {
+	case "HostAgent":
+		addFunc = m.Update
+	case "VirtualCenter":
+		addFunc = m.Add
+	default:
+		return fmt.Errorf("unsupported ApiType: %s", t)
+	}
+
+	result := make(licenseOutput, 0)
+	for _, v := range f.Args() {
+		license, err := addFunc(ctx, v, nil)
+		if err != nil {
+			return err
+		}
+
+		result = append(result, license)
+	}
+
+	return cmd.WriteResult(licenseOutput(result))
+}

--- a/vendor/github.com/vmware/govmomi/govc/license/assign.go
+++ b/vendor/github.com/vmware/govmomi/govc/license/assign.go
@@ -1,0 +1,135 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package license
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/license"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type assign struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+	*flags.HostSystemFlag
+	*flags.ClusterFlag
+
+	name   string
+	remove bool
+}
+
+func init() {
+	cli.Register("license.assign", &assign{})
+}
+
+func (cmd *assign) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	cmd.ClusterFlag, ctx = flags.NewClusterFlag(ctx)
+	cmd.ClusterFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.name, "name", "", "Display name")
+	f.BoolVar(&cmd.remove, "remove", false, "Remove assignment")
+}
+
+func (cmd *assign) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.ClusterFlag.Process(ctx)
+}
+
+func (cmd *assign) Usage() string {
+	return "KEY"
+}
+
+func (cmd *assign) Description() string {
+	return `Assign licenses to HOST or CLUSTER.
+
+Examples:
+  govc license.assign $VCSA_LICENSE_KEY
+  govc license.assign -host a_host.example.com $ESX_LICENSE_KEY
+  govc license.assign -cluster a_cluster $VSAN_LICENSE_KEY`
+}
+
+func (cmd *assign) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	key := f.Arg(0)
+
+	client, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m, err := license.NewManager(client).AssignmentManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	host, err := cmd.HostSystemIfSpecified()
+	if err != nil {
+		return err
+	}
+
+	var id string
+
+	if host == nil {
+		cluster, cerr := cmd.ClusterIfSpecified()
+		if cerr != nil {
+			return cerr
+		}
+		if cluster == nil {
+			// Default to vCenter UUID
+			id = client.ServiceContent.About.InstanceUuid
+		} else {
+			id = cluster.Reference().Value
+		}
+	} else {
+		id = host.Reference().Value
+	}
+
+	if cmd.remove {
+		return m.Remove(ctx, id)
+	}
+
+	info, err := m.Update(ctx, id, key, cmd.name)
+	if err != nil {
+		return err
+	}
+
+	return cmd.WriteResult(licenseOutput([]types.LicenseManagerLicenseInfo{*info}))
+}

--- a/vendor/github.com/vmware/govmomi/govc/license/assigned.go
+++ b/vendor/github.com/vmware/govmomi/govc/license/assigned.go
@@ -1,0 +1,96 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package license
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/license"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type assigned struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+
+	id string
+}
+
+func init() {
+	cli.Register("license.assigned.ls", &assigned{})
+}
+
+func (cmd *assigned) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.id, "id", "", "Entity ID")
+}
+
+func (cmd *assigned) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *assigned) Run(ctx context.Context, f *flag.FlagSet) error {
+	client, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m, err := license.NewManager(client).AssignmentManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	assigned, err := m.QueryAssigned(ctx, cmd.id)
+	if err != nil {
+		return err
+	}
+
+	return cmd.WriteResult(assignedOutput(assigned))
+}
+
+type assignedOutput []types.LicenseAssignmentManagerLicenseAssignment
+
+func (res assignedOutput) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(os.Stdout, 4, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, "Id:\tScope:\tName:\tLicense:\n")
+	for _, v := range res {
+		fmt.Fprintf(tw, "%s\t", v.EntityId)
+		fmt.Fprintf(tw, "%s\t", v.Scope)
+		fmt.Fprintf(tw, "%s\t", v.EntityDisplayName)
+		fmt.Fprintf(tw, "%s\t", v.AssignedLicense.LicenseKey)
+		fmt.Fprintf(tw, "\n")
+	}
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/license/decode.go
+++ b/vendor/github.com/vmware/govmomi/govc/license/decode.go
@@ -1,0 +1,85 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package license
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/license"
+)
+
+type decode struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+
+	feature string
+}
+
+func init() {
+	cli.Register("license.decode", &decode{})
+}
+
+func (cmd *decode) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.feature, "feature", "", featureUsage)
+}
+
+func (cmd *decode) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *decode) Usage() string {
+	return "KEY..."
+}
+
+func (cmd *decode) Run(ctx context.Context, f *flag.FlagSet) error {
+	client, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	var result license.InfoList
+	m := license.NewManager(client)
+	for _, v := range f.Args() {
+		license, err := m.Decode(ctx, v)
+		if err != nil {
+			return err
+		}
+
+		result = append(result, license)
+	}
+
+	if cmd.feature != "" {
+		result = result.WithFeature(cmd.feature)
+	}
+
+	return cmd.WriteResult(licenseOutput(result))
+}

--- a/vendor/github.com/vmware/govmomi/govc/license/label.go
+++ b/vendor/github.com/vmware/govmomi/govc/license/label.go
@@ -1,0 +1,77 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package license
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/license"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type label struct {
+	*flags.ClientFlag
+}
+
+func init() {
+	cli.Register("license.label.set", &label{})
+}
+
+func (cmd *label) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+}
+
+func (cmd *label) Usage() string {
+	return "LICENSE KEY VAL"
+}
+
+func (cmd *label) Description() string {
+	return `Set license labels.
+
+Examples:
+  govc license.label.set 00000-00000-00000-00000-00000 team cnx # add/set label
+  govc license.label.set 00000-00000-00000-00000-00000 team ""  # remove label
+  govc license.ls -json | jq '.[] | select(.Labels[].Key == "team") | .LicenseKey'`
+}
+
+func (cmd *label) Run(ctx context.Context, f *flag.FlagSet) error {
+	client, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m := license.NewManager(client)
+
+	if f.NArg() != 3 {
+		return flag.ErrHelp
+	}
+
+	req := types.UpdateLicenseLabel{
+		This:       m.Reference(),
+		LicenseKey: f.Arg(0),
+		LabelKey:   f.Arg(1),
+		LabelValue: f.Arg(2),
+	}
+
+	_, err = methods.UpdateLicenseLabel(ctx, m.Client(), &req)
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/license/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/license/ls.go
@@ -1,0 +1,78 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package license
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/license"
+)
+
+var featureUsage = "List licenses with given feature"
+
+type ls struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+
+	feature string
+}
+
+func init() {
+	cli.Register("license.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.feature, "feature", "", featureUsage)
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	client, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m := license.NewManager(client)
+	result, err := m.List(ctx)
+	if err != nil {
+		return err
+	}
+
+	if cmd.feature != "" {
+		result = result.WithFeature(cmd.feature)
+	}
+
+	return cmd.WriteResult(licenseOutput(result))
+}

--- a/vendor/github.com/vmware/govmomi/govc/license/output.go
+++ b/vendor/github.com/vmware/govmomi/govc/license/output.go
@@ -1,0 +1,41 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package license
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type licenseOutput []types.LicenseManagerLicenseInfo
+
+func (res licenseOutput) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(os.Stdout, 4, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, "Key:\tEdition:\tUsed:\tTotal:\n")
+	for _, v := range res {
+		fmt.Fprintf(tw, "%s\t", v.LicenseKey)
+		fmt.Fprintf(tw, "%s\t", v.EditionKey)
+		fmt.Fprintf(tw, "%d\t", v.Used)
+		fmt.Fprintf(tw, "%d\t", v.Total)
+		fmt.Fprintf(tw, "\n")
+	}
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/license/remove.go
+++ b/vendor/github.com/vmware/govmomi/govc/license/remove.go
@@ -1,0 +1,74 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package license
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/license"
+)
+
+type remove struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("license.remove", &remove{})
+}
+
+func (cmd *remove) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *remove) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *remove) Usage() string {
+	return "KEY..."
+}
+
+func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
+	client, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m := license.NewManager(client)
+	for _, v := range f.Args() {
+		err = m.Remove(ctx, v)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/logs/command.go
+++ b/vendor/github.com/vmware/govmomi/govc/logs/command.go
@@ -1,0 +1,121 @@
+/*
+Copyright (c) 2015-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"context"
+	"flag"
+	"time"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type logs struct {
+	*flags.HostSystemFlag
+
+	Max int32
+	Key string
+
+	follow bool
+}
+
+func init() {
+	cli.Register("logs", &logs{})
+}
+
+func (cmd *logs) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	cmd.Max = 25 // default
+	f.Var(flags.NewInt32(&cmd.Max), "n", "Output the last N log lines")
+	f.StringVar(&cmd.Key, "log", "", "Log file key")
+	f.BoolVar(&cmd.follow, "f", false, "Follow log file changes")
+}
+
+func (cmd *logs) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *logs) Description() string {
+	return `View VPX and ESX logs.
+
+The '-log' option defaults to "hostd" when connected directly to a host or
+when connected to VirtualCenter and a '-host' option is given.  Otherwise,
+the '-log' option defaults to "vpxd:vpxd.log".  The '-host' option is ignored
+when connected directly to a host.  See 'govc logs.ls' for other '-log' options.
+
+Examples:
+  govc logs -n 1000 -f
+  govc logs -host esx1
+  govc logs -host esx1 -log vmkernel`
+}
+
+func (cmd *logs) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	defaultKey := "hostd"
+	var host *object.HostSystem
+
+	if c.IsVC() {
+		host, err = cmd.HostSystemIfSpecified()
+		if err != nil {
+			return err
+		}
+
+		if host == nil {
+			defaultKey = "vpxd:vpxd.log"
+		}
+	}
+
+	m := object.NewDiagnosticManager(c)
+
+	key := cmd.Key
+	if key == "" {
+		key = defaultKey
+	}
+
+	l := m.Log(ctx, host, key)
+
+	err = l.Seek(ctx, cmd.Max)
+	if err != nil {
+		return err
+	}
+
+	for {
+		_, err = l.Copy(ctx, cmd.Out)
+		if err != nil {
+			return nil
+		}
+
+		if !cmd.follow {
+			break
+		}
+
+		<-time.After(time.Second)
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/logs/download.go
+++ b/vendor/github.com/vmware/govmomi/govc/logs/download.go
@@ -1,0 +1,145 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"path"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type download struct {
+	*flags.DatacenterFlag
+
+	IncludeDefault bool
+}
+
+func init() {
+	cli.Register("logs.download", &download{})
+}
+
+func (cmd *download) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.IncludeDefault, "default", false, "Specifies if the bundle should include the default server")
+}
+
+func (cmd *download) Process(ctx context.Context) error {
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *download) Usage() string {
+	return "[PATH]..."
+}
+
+func (cmd *download) Description() string {
+	return `Generate diagnostic bundles.
+
+A diagnostic bundle includes log files and other configuration information.
+
+Use PATH to include a specific set of hosts to include.
+
+Examples:
+  govc logs.download
+  govc logs.download host-a host-b`
+}
+
+func (cmd *download) DownloadFile(c *vim25.Client, b string) error {
+	u, err := c.Client.ParseURL(b)
+	if err != nil {
+		return err
+	}
+
+	dst := path.Base(u.Path)
+	p := soap.DefaultDownload
+	if cmd.OutputFlag.TTY {
+		logger := cmd.ProgressLogger(fmt.Sprintf("Downloading %s... ", dst))
+		defer logger.Wait()
+		p.Progress = logger
+	}
+
+	return c.Client.DownloadFile(context.Background(), dst, u, &p)
+}
+
+func (cmd *download) GenerateLogBundles(m *object.DiagnosticManager, host []*object.HostSystem) ([]types.DiagnosticManagerBundleInfo, error) {
+	ctx := context.TODO()
+	logger := cmd.ProgressLogger("Generating log bundles... ")
+	defer logger.Wait()
+
+	task, err := m.GenerateLogBundles(ctx, cmd.IncludeDefault, host)
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := task.WaitForResult(ctx, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.Result.(types.ArrayOfDiagnosticManagerBundleInfo).DiagnosticManagerBundleInfo, nil
+}
+
+func (cmd *download) Run(ctx context.Context, f *flag.FlagSet) error {
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	var host []*object.HostSystem
+
+	for _, arg := range f.Args() {
+		hs, err := finder.HostSystemList(ctx, arg)
+		if err != nil {
+			return err
+		}
+
+		host = append(host, hs...)
+	}
+
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m := object.NewDiagnosticManager(c)
+
+	bundles, err := cmd.GenerateLogBundles(m, host)
+	if err != nil {
+		return err
+	}
+
+	for _, bundle := range bundles {
+		err := cmd.DownloadFile(c, bundle.Url)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/logs/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/logs/ls.go
@@ -1,0 +1,88 @@
+/*
+Copyright (c) 2015-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type ls struct {
+	*flags.HostSystemFlag
+}
+
+func init() {
+	cli.Register("logs.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ls) Description() string {
+	return `List diagnostic log keys.
+
+Examples:
+  govc logs.ls
+  govc logs.ls -host host-a`
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	var host *object.HostSystem
+
+	if c.IsVC() {
+		host, err = cmd.HostSystemIfSpecified()
+		if err != nil {
+			return err
+		}
+	}
+
+	m := object.NewDiagnosticManager(c)
+
+	desc, err := m.QueryDescriptions(ctx, host)
+	if err != nil {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
+
+	for _, d := range desc {
+		fmt.Fprintf(tw, "%s\t%s\n", d.Key, d.FileName)
+	}
+
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/ls/command.go
+++ b/vendor/github.com/vmware/govmomi/govc/ls/command.go
@@ -1,0 +1,175 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ls
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/list"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ls struct {
+	*flags.DatacenterFlag
+
+	Long  bool
+	Type  string
+	ToRef bool
+	DeRef bool
+}
+
+func init() {
+	cli.Register("ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.Long, "l", false, "Long listing format")
+	f.BoolVar(&cmd.ToRef, "i", false, "Print the managed object reference")
+	f.BoolVar(&cmd.DeRef, "L", false, "Follow managed object references")
+	f.StringVar(&cmd.Type, "t", "", "Object type")
+}
+
+func (cmd *ls) Description() string {
+	return `List inventory items.
+
+Examples:
+  govc ls -l '*'
+  govc ls -t ClusterComputeResource host
+  govc ls -t Datastore host/ClusterA/* | grep -v local | xargs -n1 basename | sort | uniq`
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ls) Usage() string {
+	return "[PATH]..."
+}
+
+func (cmd *ls) typeMatch(ref types.ManagedObjectReference) bool {
+	if cmd.Type == "" {
+		return true
+	}
+
+	return strings.EqualFold(cmd.Type, ref.Type)
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	finder, err := cmd.Finder(cmd.All())
+	if err != nil {
+		return err
+	}
+
+	lr := listResult{
+		ls:       cmd,
+		Elements: nil,
+	}
+
+	args := f.Args()
+	if len(args) == 0 {
+		args = []string{"."}
+	}
+
+	var ref = new(types.ManagedObjectReference)
+
+	var types []string
+	if cmd.Type != "" {
+		// TODO: support multiple -t flags
+		types = []string{cmd.Type}
+	}
+
+	for _, arg := range args {
+		if cmd.DeRef && ref.FromString(arg) {
+			e, err := finder.Element(ctx, *ref)
+			if err == nil {
+				if cmd.typeMatch(*ref) {
+					if e.Path == "/" && ref.Type != "Folder" {
+						// Special case: when given a moref with no ancestors,
+						// just echo the moref.
+						e.Path = ref.String()
+					}
+					lr.Elements = append(lr.Elements, *e)
+				}
+				continue
+			}
+		}
+
+		es, err := finder.ManagedObjectListChildren(ctx, arg, types...)
+		if err != nil {
+			return err
+		}
+
+		for _, e := range es {
+			if cmd.typeMatch(e.Object.Reference()) {
+				lr.Elements = append(lr.Elements, e)
+			}
+		}
+	}
+
+	return cmd.WriteResult(lr)
+}
+
+type listResult struct {
+	*ls      `json:"-"`
+	Elements []list.Element `json:"elements"`
+}
+
+func (l listResult) Write(w io.Writer) error {
+	var err error
+
+	for _, e := range l.Elements {
+		if l.ToRef {
+			fmt.Fprint(w, e.Object.Reference().String())
+			if l.Long {
+				fmt.Fprintf(w, " %s", e.Path)
+			}
+			fmt.Fprintln(w)
+			continue
+		}
+
+		if !l.Long {
+			fmt.Fprintf(w, "%s\n", e.Path)
+			continue
+		}
+
+		switch e.Object.(type) {
+		case mo.Folder:
+			if _, err = fmt.Fprintf(w, "%s/\n", e.Path); err != nil {
+				return err
+			}
+		default:
+			if _, err = fmt.Fprintf(w, "%s (%s)\n", e.Path, e.Object.Reference().Type); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/main.go
+++ b/vendor/github.com/vmware/govmomi/govc/main.go
@@ -1,0 +1,98 @@
+/*
+Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	_ "github.com/vmware/govmomi/govc/about"
+	"github.com/vmware/govmomi/govc/cli"
+	_ "github.com/vmware/govmomi/govc/cluster"
+	_ "github.com/vmware/govmomi/govc/cluster/group"
+	_ "github.com/vmware/govmomi/govc/cluster/override"
+	_ "github.com/vmware/govmomi/govc/cluster/rule"
+	_ "github.com/vmware/govmomi/govc/datacenter"
+	_ "github.com/vmware/govmomi/govc/datastore"
+	_ "github.com/vmware/govmomi/govc/datastore/cluster"
+	_ "github.com/vmware/govmomi/govc/datastore/disk"
+	_ "github.com/vmware/govmomi/govc/datastore/maintenance"
+	_ "github.com/vmware/govmomi/govc/datastore/vsan"
+	_ "github.com/vmware/govmomi/govc/device"
+	_ "github.com/vmware/govmomi/govc/device/cdrom"
+	_ "github.com/vmware/govmomi/govc/device/floppy"
+	_ "github.com/vmware/govmomi/govc/device/scsi"
+	_ "github.com/vmware/govmomi/govc/device/serial"
+	_ "github.com/vmware/govmomi/govc/device/usb"
+	_ "github.com/vmware/govmomi/govc/disk"
+	_ "github.com/vmware/govmomi/govc/disk/snapshot"
+	_ "github.com/vmware/govmomi/govc/dvs"
+	_ "github.com/vmware/govmomi/govc/dvs/portgroup"
+	_ "github.com/vmware/govmomi/govc/env"
+	_ "github.com/vmware/govmomi/govc/events"
+	_ "github.com/vmware/govmomi/govc/export"
+	_ "github.com/vmware/govmomi/govc/extension"
+	_ "github.com/vmware/govmomi/govc/fields"
+	_ "github.com/vmware/govmomi/govc/folder"
+	_ "github.com/vmware/govmomi/govc/host"
+	_ "github.com/vmware/govmomi/govc/host/account"
+	_ "github.com/vmware/govmomi/govc/host/autostart"
+	_ "github.com/vmware/govmomi/govc/host/cert"
+	_ "github.com/vmware/govmomi/govc/host/date"
+	_ "github.com/vmware/govmomi/govc/host/esxcli"
+	_ "github.com/vmware/govmomi/govc/host/firewall"
+	_ "github.com/vmware/govmomi/govc/host/maintenance"
+	_ "github.com/vmware/govmomi/govc/host/option"
+	_ "github.com/vmware/govmomi/govc/host/portgroup"
+	_ "github.com/vmware/govmomi/govc/host/service"
+	_ "github.com/vmware/govmomi/govc/host/storage"
+	_ "github.com/vmware/govmomi/govc/host/vnic"
+	_ "github.com/vmware/govmomi/govc/host/vswitch"
+	_ "github.com/vmware/govmomi/govc/importx"
+	_ "github.com/vmware/govmomi/govc/library"
+	_ "github.com/vmware/govmomi/govc/library/session"
+	_ "github.com/vmware/govmomi/govc/license"
+	_ "github.com/vmware/govmomi/govc/logs"
+	_ "github.com/vmware/govmomi/govc/ls"
+	_ "github.com/vmware/govmomi/govc/metric"
+	_ "github.com/vmware/govmomi/govc/metric/interval"
+	_ "github.com/vmware/govmomi/govc/object"
+	_ "github.com/vmware/govmomi/govc/option"
+	_ "github.com/vmware/govmomi/govc/permissions"
+	_ "github.com/vmware/govmomi/govc/pool"
+	_ "github.com/vmware/govmomi/govc/role"
+	_ "github.com/vmware/govmomi/govc/session"
+	_ "github.com/vmware/govmomi/govc/sso/group"
+	_ "github.com/vmware/govmomi/govc/sso/service"
+	_ "github.com/vmware/govmomi/govc/sso/user"
+	_ "github.com/vmware/govmomi/govc/tags"
+	_ "github.com/vmware/govmomi/govc/tags/association"
+	_ "github.com/vmware/govmomi/govc/tags/category"
+	_ "github.com/vmware/govmomi/govc/task"
+	_ "github.com/vmware/govmomi/govc/vapp"
+	_ "github.com/vmware/govmomi/govc/version"
+	_ "github.com/vmware/govmomi/govc/vm"
+	_ "github.com/vmware/govmomi/govc/vm/disk"
+	_ "github.com/vmware/govmomi/govc/vm/guest"
+	_ "github.com/vmware/govmomi/govc/vm/network"
+	_ "github.com/vmware/govmomi/govc/vm/option"
+	_ "github.com/vmware/govmomi/govc/vm/rdm"
+	_ "github.com/vmware/govmomi/govc/vm/snapshot"
+)
+
+func main() {
+	os.Exit(cli.Run(os.Args[1:]))
+}

--- a/vendor/github.com/vmware/govmomi/govc/metric/change.go
+++ b/vendor/github.com/vmware/govmomi/govc/metric/change.go
@@ -1,0 +1,101 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metric
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type change struct {
+	*PerformanceFlag
+
+	level  int
+	device int
+}
+
+func init() {
+	cli.Register("metric.change", &change{})
+}
+
+func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.PerformanceFlag, ctx = NewPerformanceFlag(ctx)
+	cmd.PerformanceFlag.Register(ctx, f)
+
+	f.IntVar(&cmd.level, "level", 0, "Level for the aggregate counter")
+	f.IntVar(&cmd.device, "device-level", 0, "Level for the per device counter")
+}
+
+func (cmd *change) Usage() string {
+	return "NAME..."
+}
+
+func (cmd *change) Description() string {
+	return `Change counter NAME levels.
+
+Examples:
+  govc metric.change -level 1 net.bytesRx.average net.bytesTx.average`
+}
+
+func (cmd *change) Process(ctx context.Context) error {
+	if err := cmd.PerformanceFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 || (cmd.level == 0 && cmd.device == 0) {
+		return flag.ErrHelp
+	}
+
+	m, err := cmd.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	counters, err := m.CounterInfoByName(ctx)
+	if err != nil {
+		return err
+	}
+
+	var mapping []types.PerformanceManagerCounterLevelMapping
+
+	for _, name := range f.Args() {
+		counter, ok := counters[name]
+		if !ok {
+			return cmd.ErrNotFound(name)
+		}
+
+		mapping = append(mapping, types.PerformanceManagerCounterLevelMapping{
+			CounterId:      counter.Key,
+			AggregateLevel: int32(cmd.level),
+			PerDeviceLevel: int32(cmd.device),
+		})
+	}
+
+	_, err = methods.UpdateCounterLevelMapping(ctx, m.Client(), &types.UpdateCounterLevelMapping{
+		This:            m.Reference(),
+		CounterLevelMap: mapping,
+	})
+
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/metric/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/metric/info.go
@@ -1,0 +1,230 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metric
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*PerformanceFlag
+}
+
+func init() {
+	cli.Register("metric.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.PerformanceFlag, ctx = NewPerformanceFlag(ctx)
+	cmd.PerformanceFlag.Register(ctx, f)
+}
+
+func (cmd *info) Usage() string {
+	return "PATH [NAME]..."
+}
+
+func (cmd *info) Description() string {
+	return `Metric info for NAME.
+
+If PATH is a value other than '-', provider summary and instance list are included
+for the given object type.
+
+If NAME is not specified, all available metrics for the given INTERVAL are listed.
+An object PATH must be provided in this case.
+
+Examples:
+  govc metric.info vm/my-vm
+  govc metric.info -i 300 vm/my-vm
+  govc metric.info - cpu.usage.average
+  govc metric.info /dc1/host/cluster cpu.usage.average`
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.PerformanceFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+type EntityDetail struct {
+	Realtime   bool
+	Historical bool
+	Instance   []string
+}
+
+type MetricInfo struct {
+	Counter          *types.PerfCounterInfo
+	Enabled          []string
+	PerDeviceEnabled []string
+	Detail           *EntityDetail
+}
+
+type infoResult struct {
+	Info []*MetricInfo
+	cmd  *info
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for _, info := range r.Info {
+		counter := info.Counter
+
+		fmt.Fprintf(tw, "Name:\t%s\n", counter.Name())
+		fmt.Fprintf(tw, "  Label:\t%s\n", counter.NameInfo.GetElementDescription().Label)
+		fmt.Fprintf(tw, "  Summary:\t%s\n", counter.NameInfo.GetElementDescription().Summary)
+		fmt.Fprintf(tw, "  Group:\t%s\n", counter.GroupInfo.GetElementDescription().Label)
+		fmt.Fprintf(tw, "  Unit:\t%s\n", counter.UnitInfo.GetElementDescription().Label)
+		fmt.Fprintf(tw, "  Rollup type:\t%s\n", counter.RollupType)
+		fmt.Fprintf(tw, "  Stats type:\t%s\n", counter.StatsType)
+		fmt.Fprintf(tw, "  Level:\t%d\n", counter.Level)
+		fmt.Fprintf(tw, "    Intervals:\t%s\n", strings.Join(info.Enabled, ","))
+		fmt.Fprintf(tw, "  Per-device level:\t%d\n", counter.PerDeviceLevel)
+		fmt.Fprintf(tw, "    Intervals:\t%s\n", strings.Join(info.PerDeviceEnabled, ","))
+
+		summary := info.Detail
+		if summary == nil {
+			continue
+		}
+
+		fmt.Fprintf(tw, "  Realtime:\t%t\n", summary.Realtime)
+		fmt.Fprintf(tw, "  Historical:\t%t\n", summary.Historical)
+		fmt.Fprintf(tw, "  Instances:\t%s\n", strings.Join(summary.Instance, ","))
+	}
+
+	return tw.Flush()
+}
+
+func (r *infoResult) MarshalJSON() ([]byte, error) {
+	m := make(map[string]*MetricInfo)
+
+	for _, info := range r.Info {
+		m[info.Counter.Name()] = info
+	}
+
+	return json.Marshal(m)
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
+	names := f.Args()[1:]
+
+	m, err := cmd.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	counters, err := m.CounterInfoByName(ctx)
+	if err != nil {
+		return err
+	}
+
+	intervals, err := m.HistoricalInterval(ctx)
+	if err != nil {
+		return err
+	}
+	enabled := intervals.Enabled()
+
+	var summary *types.PerfProviderSummary
+	var mids map[int32][]*types.PerfMetricId
+
+	if f.Arg(0) == "-" {
+		if len(names) == 0 {
+			return flag.ErrHelp
+		}
+	} else {
+		objs, err := cmd.ManagedObjects(ctx, f.Args()[:1])
+		if err != nil {
+			return err
+		}
+
+		summary, err = m.ProviderSummary(ctx, objs[0])
+		if err != nil {
+			return err
+		}
+
+		all, err := m.AvailableMetric(ctx, objs[0], cmd.Interval(summary.RefreshRate))
+		if err != nil {
+			return err
+		}
+
+		mids = all.ByKey()
+
+		if len(names) == 0 {
+			nc, _ := m.CounterInfoByKey(ctx)
+
+			for i := range all {
+				id := &all[i]
+				if id.Instance != "" {
+					continue
+				}
+
+				names = append(names, nc[id.CounterId].Name())
+			}
+		}
+	}
+
+	var metrics []*MetricInfo
+
+	for _, name := range names {
+		counter, ok := counters[name]
+		if !ok {
+			return cmd.ErrNotFound(name)
+		}
+
+		info := &MetricInfo{
+			Counter:          counter,
+			Enabled:          enabled[counter.Level],
+			PerDeviceEnabled: enabled[counter.PerDeviceLevel],
+		}
+
+		metrics = append(metrics, info)
+
+		if summary == nil {
+			continue
+		}
+
+		var instances []string
+
+		for _, id := range mids[counter.Key] {
+			if id.Instance != "" {
+				instances = append(instances, id.Instance)
+			}
+		}
+
+		info.Detail = &EntityDetail{
+			Realtime:   summary.CurrentSupported,
+			Historical: summary.SummarySupported,
+			Instance:   instances,
+		}
+
+	}
+
+	return cmd.WriteResult(&infoResult{metrics, cmd})
+}

--- a/vendor/github.com/vmware/govmomi/govc/metric/interval/change.go
+++ b/vendor/github.com/vmware/govmomi/govc/metric/interval/change.go
@@ -1,0 +1,111 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interval
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/govc/metric"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type change struct {
+	*metric.PerformanceFlag
+
+	enabled *bool
+	level   int
+}
+
+func init() {
+	cli.Register("metric.interval.change", &change{})
+}
+
+func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.PerformanceFlag, ctx = metric.NewPerformanceFlag(ctx)
+	cmd.PerformanceFlag.Register(ctx, f)
+
+	f.Var(flags.NewOptionalBool(&cmd.enabled), "enabled", "Enable or disable")
+	f.IntVar(&cmd.level, "level", 0, "Level")
+}
+
+func (cmd *change) Description() string {
+	return `Change historical metric intervals.
+
+Examples:
+  govc metric.interval.change -i 300 -level 2
+  govc metric.interval.change -i 86400 -enabled=false`
+}
+
+func (cmd *change) Process(ctx context.Context) error {
+	if err := cmd.PerformanceFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
+	m, err := cmd.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	intervals, err := m.HistoricalInterval(ctx)
+	if err != nil {
+		return err
+	}
+
+	interval := cmd.Interval(0)
+	if interval == 0 {
+		return flag.ErrHelp
+	}
+
+	var current *types.PerfInterval
+
+	for _, i := range intervals {
+		if i.SamplingPeriod == interval {
+			current = &i
+			break
+		}
+	}
+
+	if current == nil {
+		return fmt.Errorf("%d interval ID not found", interval)
+	}
+
+	if cmd.level != 0 {
+		if cmd.level > 4 {
+			return flag.ErrHelp
+		}
+		current.Level = int32(cmd.level)
+	}
+
+	if cmd.enabled != nil {
+		current.Enabled = *cmd.enabled
+	}
+
+	_, err = methods.UpdatePerfInterval(ctx, m.Client(), &types.UpdatePerfInterval{
+		This:     m.Reference(),
+		Interval: *current,
+	})
+
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/metric/interval/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/metric/interval/info.go
@@ -1,0 +1,87 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interval
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"text/tabwriter"
+	"time"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/metric"
+)
+
+type info struct {
+	*metric.PerformanceFlag
+}
+
+func init() {
+	cli.Register("metric.interval.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.PerformanceFlag, ctx = metric.NewPerformanceFlag(ctx)
+	cmd.PerformanceFlag.Register(ctx, f)
+}
+
+func (cmd *info) Description() string {
+	return `List historical metric intervals.
+
+Examples:
+  govc metric.interval.info
+  govc metric.interval.info -i 300`
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.PerformanceFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	m, err := cmd.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	intervals, err := m.HistoricalInterval(ctx)
+	if err != nil {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(cmd.Out, 2, 0, 2, ' ', 0)
+	cmd.Out = tw
+
+	interval := cmd.Interval(0)
+
+	for _, i := range intervals {
+		if interval != 0 && i.SamplingPeriod != interval {
+			continue
+		}
+
+		fmt.Fprintf(cmd.Out, "ID:\t%d\n", i.SamplingPeriod)
+		fmt.Fprintf(cmd.Out, "  Enabled:\t%t\n", i.Enabled)
+		fmt.Fprintf(cmd.Out, "  Interval:\t%s\n", time.Duration(i.SamplingPeriod)*time.Second)
+		fmt.Fprintf(cmd.Out, "  Name:\t%s\n", i.Name)
+		fmt.Fprintf(cmd.Out, "  Level:\t%d\n", i.Level)
+	}
+
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/metric/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/metric/ls.go
@@ -1,0 +1,140 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metric
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/performance"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ls struct {
+	*PerformanceFlag
+
+	long bool
+}
+
+func init() {
+	cli.Register("metric.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.PerformanceFlag, ctx = NewPerformanceFlag(ctx)
+	cmd.PerformanceFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.long, "l", false, "Long listing format")
+}
+
+func (cmd *ls) Usage() string {
+	return "PATH"
+}
+
+func (cmd *ls) Description() string {
+	return `List available metrics for PATH.
+
+Examples:
+  govc metric.ls /dc1/host/cluster1
+  govc metric.ls datastore/*
+  govc metric.ls vm/* | grep mem. | xargs govc metric.sample vm/*`
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.PerformanceFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+type lsResult struct {
+	cmd      *ls
+	counters map[int32]*types.PerfCounterInfo
+	performance.MetricList
+}
+
+func (r *lsResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for _, id := range r.MetricList {
+		if id.Instance != "" {
+			continue
+		}
+
+		info := r.counters[id.CounterId]
+
+		if r.cmd.long {
+			fmt.Fprintf(w, "%s\t%s\n", info.Name(),
+				info.NameInfo.GetElementDescription().Label)
+			continue
+		}
+
+		fmt.Fprintln(w, info.Name())
+	}
+
+	return tw.Flush()
+}
+
+func (r *lsResult) MarshalJSON() ([]byte, error) {
+	m := make(map[string]*types.PerfCounterInfo)
+
+	for _, id := range r.MetricList {
+		info := r.counters[id.CounterId]
+
+		m[info.Name()] = info
+	}
+
+	return json.Marshal(m)
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	objs, err := cmd.ManagedObjects(ctx, f.Args())
+	if err != nil {
+		return err
+	}
+
+	m, err := cmd.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	s, err := m.ProviderSummary(ctx, objs[0])
+	if err != nil {
+		return err
+	}
+
+	mids, err := m.AvailableMetric(ctx, objs[0], cmd.Interval(s.RefreshRate))
+	if err != nil {
+		return err
+	}
+
+	counters, err := m.CounterInfoByKey(ctx)
+	if err != nil {
+		return err
+	}
+
+	return cmd.WriteResult(&lsResult{cmd, counters, mids})
+}

--- a/vendor/github.com/vmware/govmomi/govc/metric/performance.go
+++ b/vendor/github.com/vmware/govmomi/govc/metric/performance.go
@@ -1,0 +1,96 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metric
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/performance"
+)
+
+type PerformanceFlag struct {
+	*flags.DatacenterFlag
+	*flags.OutputFlag
+
+	m *performance.Manager
+
+	interval int
+}
+
+func NewPerformanceFlag(ctx context.Context) (*PerformanceFlag, context.Context) {
+	f := &PerformanceFlag{}
+	f.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	f.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	return f, ctx
+}
+
+func (f *PerformanceFlag) Register(ctx context.Context, fs *flag.FlagSet) {
+	f.DatacenterFlag.Register(ctx, fs)
+	f.OutputFlag.Register(ctx, fs)
+
+	fs.IntVar(&f.interval, "i", 0, "Interval ID")
+}
+
+func (f *PerformanceFlag) Process(ctx context.Context) error {
+	if err := f.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := f.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (f *PerformanceFlag) Manager(ctx context.Context) (*performance.Manager, error) {
+	if f.m != nil {
+		return f.m, nil
+	}
+
+	c, err := f.Client()
+	if err != nil {
+		return nil, err
+	}
+
+	f.m = performance.NewManager(c)
+
+	f.m.Sort = true
+
+	return f.m, err
+}
+
+func (f *PerformanceFlag) Interval(val int32) int32 {
+	interval := int32(f.interval)
+
+	if interval == 0 {
+		if val == -1 {
+			// realtime not supported
+			return 300
+		}
+
+		return val
+	}
+
+	return interval
+}
+
+func (f *PerformanceFlag) ErrNotFound(name string) error {
+	return fmt.Errorf("counter %q not found", name)
+}

--- a/vendor/github.com/vmware/govmomi/govc/metric/reset.go
+++ b/vendor/github.com/vmware/govmomi/govc/metric/reset.go
@@ -1,0 +1,91 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metric
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type reset struct {
+	*PerformanceFlag
+}
+
+func init() {
+	cli.Register("metric.reset", &reset{})
+}
+
+func (cmd *reset) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.PerformanceFlag, ctx = NewPerformanceFlag(ctx)
+	cmd.PerformanceFlag.Register(ctx, f)
+}
+
+func (cmd *reset) Usage() string {
+	return "NAME..."
+}
+
+func (cmd *reset) Description() string {
+	return `Reset counter NAME to the default level of data collection.
+
+Examples:
+  govc metric.reset net.bytesRx.average net.bytesTx.average`
+}
+
+func (cmd *reset) Process(ctx context.Context) error {
+	if err := cmd.PerformanceFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *reset) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
+	m, err := cmd.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	counters, err := m.CounterInfoByName(ctx)
+	if err != nil {
+		return err
+	}
+
+	var ids []int32
+
+	for _, name := range f.Args() {
+		counter, ok := counters[name]
+		if !ok {
+			return cmd.ErrNotFound(name)
+		}
+
+		ids = append(ids, counter.Key)
+	}
+
+	_, err = methods.ResetCounterLevelMapping(ctx, m.Client(), &types.ResetCounterLevelMapping{
+		This:     m.Reference(),
+		Counters: ids,
+	})
+
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/metric/sample.go
+++ b/vendor/github.com/vmware/govmomi/govc/metric/sample.go
@@ -1,0 +1,330 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metric
+
+import (
+	"context"
+	"crypto/md5"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/performance"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type sample struct {
+	*PerformanceFlag
+
+	d        int
+	n        int
+	t        bool
+	plot     string
+	instance string
+}
+
+func init() {
+	cli.Register("metric.sample", &sample{})
+}
+
+func (cmd *sample) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.PerformanceFlag, ctx = NewPerformanceFlag(ctx)
+	cmd.PerformanceFlag.Register(ctx, f)
+
+	f.IntVar(&cmd.d, "d", 30, "Limit object display name to D chars")
+	f.IntVar(&cmd.n, "n", 6, "Max number of samples")
+	f.StringVar(&cmd.plot, "plot", "", "Plot data using gnuplot")
+	f.BoolVar(&cmd.t, "t", false, "Include sample times")
+	f.StringVar(&cmd.instance, "instance", "*", "Instance")
+}
+
+func (cmd *sample) Usage() string {
+	return "PATH... NAME..."
+}
+
+func (cmd *sample) Description() string {
+	return `Sample for object PATH of metric NAME.
+
+Interval ID defaults to 20 (realtime) if supported, otherwise 300 (5m interval).
+
+By default, INSTANCE '*' samples all instances and the aggregate counter.
+An INSTANCE value of '-' will only sample the aggregate counter.
+An INSTANCE value other than '*' or '-' will only sample the given instance counter.
+
+If PLOT value is set to '-', output a gnuplot script.  If non-empty with another
+value, PLOT will pipe the script to gnuplot for you.  The value is also used to set
+the gnuplot 'terminal' variable, unless the value is that of the DISPLAY env var.
+Only 1 metric NAME can be specified when the PLOT flag is set.
+
+Examples:
+  govc metric.sample host/cluster1/* cpu.usage.average
+  govc metric.sample -plot .png host/cluster1/* cpu.usage.average | xargs open
+  govc metric.sample vm/* net.bytesTx.average net.bytesTx.average
+  govc metric.sample -instance vmnic0 vm/* net.bytesTx.average
+  govc metric.sample -instance - vm/* net.bytesTx.average`
+}
+
+func (cmd *sample) Process(ctx context.Context) error {
+	if err := cmd.PerformanceFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+type sampleResult struct {
+	cmd      *sample
+	m        *performance.Manager
+	counters map[string]*types.PerfCounterInfo
+	Sample   []performance.EntityMetric
+}
+
+func (r *sampleResult) name(e types.ManagedObjectReference) string {
+	var me mo.ManagedEntity
+	_ = r.m.Properties(context.Background(), e, []string{"name"}, &me)
+
+	name := me.Name
+
+	if r.cmd.d > 0 && len(name) > r.cmd.d {
+		return name[:r.cmd.d] + "*"
+	}
+
+	return name
+}
+
+func sampleInfoTimes(m *performance.EntityMetric) []string {
+	vals := make([]string, len(m.SampleInfo))
+
+	for i := range m.SampleInfo {
+		vals[i] = m.SampleInfo[i].Timestamp.Format(time.RFC3339)
+	}
+
+	return vals
+}
+
+func (r *sampleResult) Plot(w io.Writer) error {
+	if len(r.Sample) == 0 {
+		return nil
+	}
+
+	if r.cmd.plot != "-" {
+		cmd := exec.Command("gnuplot", "-persist")
+		cmd.Stdout = w
+		cmd.Stderr = os.Stderr
+		stdin, err := cmd.StdinPipe()
+		if err != nil {
+			return err
+		}
+
+		if err = cmd.Start(); err != nil {
+			return err
+		}
+
+		w = stdin
+		defer func() {
+			_ = stdin.Close()
+			_ = cmd.Wait()
+		}()
+	}
+
+	counter := r.counters[r.Sample[0].Value[0].Name]
+	unit := counter.UnitInfo.GetElementDescription()
+
+	fmt.Fprintf(w, "set title %q\n", counter.Name())
+	fmt.Fprintf(w, "set ylabel %q\n", unit.Label)
+	fmt.Fprintf(w, "set xlabel %q\n", "Time")
+	fmt.Fprintf(w, "set xdata %s\n", "time")
+	fmt.Fprintf(w, "set format x %q\n", "%H:%M")
+	fmt.Fprintf(w, "set timefmt %q\n", "%Y-%m-%dT%H:%M:%SZ")
+
+	ext := path.Ext(r.cmd.plot)
+	if ext != "" {
+		// If a file name is given, use the extension as terminal type.
+		// If just an ext is given, use the entities and counter as the file name.
+		file := r.cmd.plot
+		name := r.cmd.plot[:len(r.cmd.plot)-len(ext)]
+		r.cmd.plot = ext[1:]
+
+		if name == "" {
+			h := md5.New()
+
+			for i := range r.Sample {
+				_, _ = io.WriteString(h, r.Sample[i].Entity.String())
+			}
+			_, _ = io.WriteString(h, counter.Name())
+
+			file = fmt.Sprintf("govc-plot-%x%s", h.Sum(nil), ext)
+		}
+
+		fmt.Fprintf(w, "set output %q\n", file)
+
+		defer func() {
+			fmt.Fprintln(r.cmd.Out, file)
+		}()
+	}
+
+	switch r.cmd.plot {
+	case "-", os.Getenv("DISPLAY"):
+	default:
+		fmt.Fprintf(w, "set terminal %s\n", r.cmd.plot)
+	}
+
+	if unit.Key == string(types.PerformanceManagerUnitPercent) {
+		fmt.Fprintln(w, "set yrange [0:100]")
+	}
+
+	fmt.Fprintln(w)
+
+	var set []string
+
+	for i := range r.Sample {
+		name := r.name(r.Sample[i].Entity)
+		name = strings.Replace(name, "_", "*", -1) // underscore is some gnuplot markup?
+		set = append(set, fmt.Sprintf("'-' using 1:2 title '%s' with lines", name))
+	}
+
+	fmt.Fprintf(w, "plot %s\n", strings.Join(set, ", "))
+
+	for i := range r.Sample {
+		times := sampleInfoTimes(&r.Sample[i])
+
+		for _, value := range r.Sample[i].Value {
+			for j := range value.Value {
+				fmt.Fprintf(w, "%s %s\n", times[j], value.Format(value.Value[j]))
+			}
+		}
+
+		fmt.Fprintln(w, "e")
+	}
+
+	return nil
+}
+
+func (r *sampleResult) Write(w io.Writer) error {
+	if r.cmd.plot != "" {
+		return r.Plot(w)
+	}
+
+	cmd := r.cmd
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for i := range r.Sample {
+		metric := r.Sample[i]
+		name := r.name(metric.Entity)
+		t := ""
+		if cmd.t {
+			t = metric.SampleInfoCSV()
+		}
+
+		for _, v := range metric.Value {
+			counter := r.counters[v.Name]
+			units := counter.UnitInfo.GetElementDescription().Label
+
+			instance := v.Instance
+			if instance == "" {
+				instance = "-"
+			}
+
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%v\t%s\t%s\n",
+				name, instance, v.Name, t, v.ValueCSV(), units)
+		}
+	}
+
+	return tw.Flush()
+}
+
+func (cmd *sample) Run(ctx context.Context, f *flag.FlagSet) error {
+	m, err := cmd.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	var paths []string
+	var names []string
+
+	byName, err := m.CounterInfoByName(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, arg := range f.Args() {
+		if _, ok := byName[arg]; ok {
+			names = append(names, arg)
+		} else {
+			paths = append(paths, arg)
+		}
+	}
+
+	if len(paths) == 0 || len(names) == 0 {
+		return flag.ErrHelp
+	}
+
+	if cmd.plot != "" {
+		if len(names) > 1 {
+			return flag.ErrHelp
+		}
+
+		if cmd.instance == "*" {
+			cmd.instance = ""
+		}
+	}
+
+	objs, err := cmd.ManagedObjects(ctx, paths)
+	if err != nil {
+		return err
+	}
+
+	s, err := m.ProviderSummary(ctx, objs[0])
+	if err != nil {
+		return err
+	}
+
+	if cmd.instance == "-" {
+		cmd.instance = ""
+	}
+
+	spec := types.PerfQuerySpec{
+		Format:     string(types.PerfFormatNormal),
+		MaxSample:  int32(cmd.n),
+		MetricId:   []types.PerfMetricId{{Instance: cmd.instance}},
+		IntervalId: cmd.Interval(s.RefreshRate),
+	}
+
+	sample, err := m.SampleByName(ctx, spec, names, objs)
+	if err != nil {
+		return err
+	}
+
+	result, err := m.ToMetricSeries(ctx, sample)
+	if err != nil {
+		return err
+	}
+
+	counters, err := m.CounterInfoByName(ctx)
+	if err != nil {
+		return err
+	}
+
+	return cmd.WriteResult(&sampleResult{cmd, m, counters, result})
+}

--- a/vendor/github.com/vmware/govmomi/govc/object/collect.go
+++ b/vendor/github.com/vmware/govmomi/govc/object/collect.go
@@ -1,0 +1,430 @@
+/*
+Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/view"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vim25/xml"
+)
+
+type collect struct {
+	*flags.DatacenterFlag
+
+	single bool
+	simple bool
+	raw    string
+	delim  string
+	dump   bool
+	n      int
+	kind   kinds
+	wait   time.Duration
+
+	filter property.Filter
+	obj    string
+}
+
+func init() {
+	cli.Register("object.collect", &collect{})
+}
+
+func (cmd *collect) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.simple, "s", false, "Output property value only")
+	f.StringVar(&cmd.delim, "d", ",", "Delimiter for array values")
+	f.BoolVar(&cmd.dump, "O", false, "Output the CreateFilter request itself")
+	f.StringVar(&cmd.raw, "R", "", "Raw XML encoded CreateFilter request")
+	f.IntVar(&cmd.n, "n", 0, "Wait for N property updates")
+	f.Var(&cmd.kind, "type", "Resource type.  If specified, MOID is used for a container view root")
+	f.DurationVar(&cmd.wait, "wait", 0, "Max wait time for updates")
+}
+
+func (cmd *collect) Usage() string {
+	return "[MOID] [PROPERTY]..."
+}
+
+func (cmd *collect) Description() string {
+	return `Collect managed object properties.
+
+MOID can be an inventory path or ManagedObjectReference.
+MOID defaults to '-', an alias for 'ServiceInstance:ServiceInstance' or the root folder if a '-type' flag is given.
+
+If a '-type' flag is given, properties are collected using a ContainerView object where MOID is the root of the view.
+
+By default only the current property value(s) are collected.  To wait for updates, use the '-n' flag or
+specify a property filter.  A property filter can be specified by prefixing the property name with a '-',
+followed by the value to match.
+
+The '-R' flag sets the Filter using the given XML encoded request, which can be captured by 'vcsim -trace' for example.
+It can be useful for replaying property filters created by other clients and converting filters to Go code via '-O -dump'.
+
+Examples:
+  govc object.collect - content
+  govc object.collect -s HostSystem:ha-host hardware.systemInfo.uuid
+  govc object.collect -s /ha-datacenter/vm/foo overallStatus
+  govc object.collect -s /ha-datacenter/vm/foo -guest.guestOperationsReady true # property filter
+  govc object.collect -type m / name runtime.powerState # collect properties for multiple objects
+  govc object.collect -json -n=-1 EventManager:ha-eventmgr latestEvent | jq .
+  govc object.collect -json -s $(govc object.collect -s - content.perfManager) description.counterType | jq .
+  govc object.collect -R create-filter-request.xml # replay filter
+  govc object.collect -R create-filter-request.xml -O # convert filter to Go code
+  govc object.collect -s vm/my-vm summary.runtime.host | xargs govc ls -L # inventory path of VM's host
+  govc object.collect -json $vm config | \ # use -json + jq to search array elements
+    jq -r '.[] | select(.Val.Hardware.Device[].MacAddress == "00:0c:29:0c:73:c0") | .Val.Name'`
+}
+
+var stringer = reflect.TypeOf((*fmt.Stringer)(nil)).Elem()
+
+type change struct {
+	cmd    *collect
+	Update types.ObjectUpdate
+}
+
+func (pc *change) MarshalJSON() ([]byte, error) {
+	if len(pc.cmd.kind) == 0 {
+		return json.Marshal(pc.Update.ChangeSet)
+	}
+
+	return json.Marshal(pc.Update)
+}
+
+func (pc *change) output(name string, rval reflect.Value, rtype reflect.Type) {
+	s := "..."
+
+	kind := rval.Kind()
+
+	if kind == reflect.Ptr || kind == reflect.Interface {
+		if rval.IsNil() {
+			s = ""
+		} else {
+			rval = rval.Elem()
+			kind = rval.Kind()
+		}
+	}
+
+	switch kind {
+	case reflect.Ptr, reflect.Interface:
+	case reflect.Slice:
+		if rval.Len() == 0 {
+			s = ""
+			break
+		}
+
+		etype := rtype.Elem()
+
+		if etype.Kind() != reflect.Interface && etype.Kind() != reflect.Struct || etype.Implements(stringer) {
+			var val []string
+
+			for i := 0; i < rval.Len(); i++ {
+				v := rval.Index(i).Interface()
+
+				if fstr, ok := v.(fmt.Stringer); ok {
+					s = fstr.String()
+				} else {
+					s = fmt.Sprintf("%v", v)
+				}
+
+				val = append(val, s)
+			}
+
+			s = strings.Join(val, pc.cmd.delim)
+		}
+	case reflect.Struct:
+		if rtype.Implements(stringer) {
+			s = rval.Interface().(fmt.Stringer).String()
+		}
+	default:
+		s = fmt.Sprintf("%v", rval.Interface())
+	}
+
+	if pc.cmd.simple {
+		fmt.Fprintln(pc.cmd.Out, s)
+		return
+	}
+
+	if pc.cmd.obj != "" {
+		fmt.Fprintf(pc.cmd.Out, "%s\t", pc.cmd.obj)
+	}
+
+	fmt.Fprintf(pc.cmd.Out, "%s\t%s\t%s\n", name, rtype, s)
+}
+
+func (pc *change) writeStruct(name string, rval reflect.Value, rtype reflect.Type) {
+	for i := 0; i < rval.NumField(); i++ {
+		fval := rval.Field(i)
+		field := rtype.Field(i)
+
+		if field.Anonymous {
+			pc.writeStruct(name, fval, fval.Type())
+			continue
+		}
+
+		fname := fmt.Sprintf("%s.%s%s", name, strings.ToLower(field.Name[:1]), field.Name[1:])
+		pc.output(fname, fval, field.Type)
+	}
+}
+
+func (pc *change) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(pc.cmd.Out, 4, 0, 2, ' ', 0)
+	pc.cmd.Out = tw
+
+	for _, c := range pc.Update.ChangeSet {
+		if c.Val == nil {
+			// type is unknown in this case, as xsi:type was not provided - just skip for now
+			continue
+		}
+
+		rval := reflect.ValueOf(c.Val)
+		rtype := rval.Type()
+
+		if strings.HasPrefix(rtype.Name(), "ArrayOf") {
+			rval = rval.Field(0)
+			rtype = rval.Type()
+		}
+
+		if len(pc.cmd.kind) != 0 {
+			pc.cmd.obj = pc.Update.Obj.String()
+		}
+
+		if pc.cmd.single && rtype.Kind() == reflect.Struct && !rtype.Implements(stringer) {
+			pc.writeStruct(c.Name, rval, rtype)
+			continue
+		}
+
+		pc.output(c.Name, rval, rtype)
+	}
+
+	return tw.Flush()
+}
+
+func (pc *change) Dump() interface{} {
+	if pc.cmd.simple && len(pc.Update.ChangeSet) == 1 {
+		val := pc.Update.ChangeSet[0].Val
+		if val != nil {
+			rval := reflect.ValueOf(val)
+			rtype := rval.Type()
+
+			if strings.HasPrefix(rtype.Name(), "ArrayOf") {
+				return rval.Field(0).Interface()
+			}
+		}
+
+		return val
+	}
+
+	return pc.Update
+}
+
+func (cmd *collect) match(update types.ObjectUpdate) bool {
+	if len(cmd.filter) == 0 {
+		return false
+	}
+
+	for _, c := range update.ChangeSet {
+		if cmd.filter.MatchProperty(types.DynamicProperty{Name: c.Name, Val: c.Val}) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (cmd *collect) toFilter(f *flag.FlagSet, props []string) ([]string, error) {
+	// TODO: Only supporting 1 filter prop for now.  More than one would require some
+	// accounting / accumulating of multiple updates.  And need to consider objects
+	// then enter/leave a container view.
+	if len(props) != 2 || !strings.HasPrefix(props[0], "-") {
+		return props, nil
+	}
+
+	cmd.filter = property.Filter{props[0][1:]: props[1]}
+
+	return cmd.filter.Keys(), nil
+}
+
+type dumpFilter struct {
+	types.CreateFilter
+}
+
+func (f *dumpFilter) Dump() interface{} {
+	return f.CreateFilter
+}
+
+// Write satisfies the flags.OutputWriter interface, but is not used with dumpFilter.
+func (f *dumpFilter) Write(w io.Writer) error {
+	return nil
+}
+
+func (cmd *collect) decodeFilter(filter *property.WaitFilter) error {
+	var r io.Reader
+
+	if cmd.raw == "-" {
+		r = os.Stdin
+	} else {
+		f, err := os.Open(cmd.raw)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		r = f
+	}
+
+	env := soap.Envelope{
+		Body: &methods.CreateFilterBody{Req: &filter.CreateFilter},
+	}
+
+	dec := xml.NewDecoder(r)
+	dec.TypeFunc = types.TypeFunc()
+	return dec.Decode(&env)
+}
+
+func (cmd *collect) Run(ctx context.Context, f *flag.FlagSet) error {
+	client, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	p := property.DefaultCollector(client)
+	filter := new(property.WaitFilter)
+
+	if cmd.raw == "" {
+		ref := vim25.ServiceInstance
+		arg := f.Arg(0)
+
+		if len(cmd.kind) != 0 {
+			ref = client.ServiceContent.RootFolder
+		}
+
+		switch arg {
+		case "", "-":
+		default:
+			ref, err = cmd.ManagedObject(ctx, arg)
+			if err != nil {
+				if !ref.FromString(arg) {
+					return err
+				}
+			}
+		}
+
+		var props []string
+		if f.NArg() > 1 {
+			props = f.Args()[1:]
+			cmd.single = len(props) == 1
+		}
+
+		props, err = cmd.toFilter(f, props)
+		if err != nil {
+			return err
+		}
+
+		if len(cmd.kind) == 0 {
+			filter.Add(ref, ref.Type, props)
+		} else {
+			m := view.NewManager(client)
+
+			v, cerr := m.CreateContainerView(ctx, ref, cmd.kind, true)
+			if cerr != nil {
+				return cerr
+			}
+
+			defer func() {
+				_ = v.Destroy(ctx)
+			}()
+
+			for _, kind := range cmd.kind {
+				filter.Add(v.Reference(), kind, props, v.TraversalSpec())
+			}
+		}
+	} else {
+		if err = cmd.decodeFilter(filter); err != nil {
+			return err
+		}
+	}
+
+	if cmd.dump {
+		if !cmd.JSON {
+			cmd.Dump = true
+		}
+		return cmd.WriteResult(&dumpFilter{filter.CreateFilter})
+	}
+
+	entered := false
+	hasFilter := len(cmd.filter) != 0
+
+	if cmd.wait != 0 {
+		filter.Options = &types.WaitOptions{
+			MaxWaitSeconds: types.NewInt32(int32(cmd.wait.Seconds())),
+		}
+	}
+
+	return cmd.WithCancel(ctx, func(wctx context.Context) error {
+		return property.WaitForUpdates(wctx, p, filter, func(updates []types.ObjectUpdate) bool {
+			matches := 0
+			for _, update := range updates {
+				if entered && update.Kind == types.ObjectUpdateKindEnter {
+					// on the first update we only get kind "enter"
+					// if a new object is added, the next update with have both "enter" and "modify".
+					continue
+				}
+
+				c := &change{cmd, update}
+
+				if hasFilter {
+					if cmd.match(update) {
+						matches++
+					} else {
+						continue
+					}
+				}
+
+				_ = cmd.WriteResult(c)
+			}
+
+			entered = true
+
+			if hasFilter {
+				if matches > 0 {
+					return true
+				}
+				return false
+			}
+
+			cmd.n--
+
+			return cmd.n == -1 && cmd.wait == 0
+		})
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/object/destroy.go
+++ b/vendor/github.com/vmware/govmomi/govc/object/destroy.go
@@ -1,0 +1,90 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type destroy struct {
+	*flags.DatacenterFlag
+}
+
+func init() {
+	cli.Register("object.destroy", &destroy{})
+}
+
+func (cmd *destroy) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+}
+
+func (cmd *destroy) Usage() string {
+	return "PATH..."
+}
+
+func (cmd *destroy) Description() string {
+	return `Destroy managed objects.
+
+Examples:
+  govc object.destroy /dc1/network/dvs /dc1/host/cluster`
+}
+
+func (cmd *destroy) Process(ctx context.Context) error {
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *destroy) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	objs, err := cmd.ManagedObjects(ctx, f.Args())
+	if err != nil {
+		return err
+	}
+
+	for _, obj := range objs {
+		task, err := object.NewCommon(c, obj).Destroy(ctx)
+		if err != nil {
+			return err
+		}
+
+		logger := cmd.ProgressLogger(fmt.Sprintf("destroying %s... ", obj))
+		_, err = task.WaitForResult(ctx, logger)
+		logger.Wait()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/object/find.go
+++ b/vendor/github.com/vmware/govmomi/govc/object/find.go
@@ -1,0 +1,349 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/view"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type find struct {
+	*flags.DatacenterFlag
+
+	ref      bool
+	kind     kinds
+	name     string
+	maxdepth int
+}
+
+var alias = []struct {
+	name string
+	kind string
+}{
+	{"a", "VirtualApp"},
+	{"c", "ClusterComputeResource"},
+	{"d", "Datacenter"},
+	{"f", "Folder"},
+	{"g", "DistributedVirtualPortgroup"},
+	{"h", "HostSystem"},
+	{"m", "VirtualMachine"},
+	{"n", "Network"},
+	{"o", "OpaqueNetwork"},
+	{"p", "ResourcePool"},
+	{"r", "ComputeResource"},
+	{"s", "Datastore"},
+	{"w", "DistributedVirtualSwitch"},
+}
+
+func aliasHelp() string {
+	var help bytes.Buffer
+
+	for _, a := range alias {
+		fmt.Fprintf(&help, "  %s    %s\n", a.name, a.kind)
+	}
+
+	return help.String()
+}
+
+type kinds []string
+
+func (e *kinds) String() string {
+	return fmt.Sprint(*e)
+}
+
+func (e *kinds) Set(value string) error {
+	*e = append(*e, e.alias(value))
+	return nil
+}
+
+func (e *kinds) alias(value string) string {
+	if len(value) != 1 {
+		return value
+	}
+
+	for _, a := range alias {
+		if a.name == value {
+			return a.kind
+		}
+	}
+
+	return value
+}
+
+func (e *kinds) wanted(kind string) bool {
+	if len(*e) == 0 {
+		return true
+	}
+
+	for _, k := range *e {
+		if kind == k {
+			return true
+		}
+	}
+
+	return false
+}
+
+func init() {
+	cli.Register("find", &find{})
+}
+
+func (cmd *find) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	f.Var(&cmd.kind, "type", "Resource type")
+	f.StringVar(&cmd.name, "name", "*", "Resource name")
+	f.IntVar(&cmd.maxdepth, "maxdepth", -1, "Max depth")
+	f.BoolVar(&cmd.ref, "i", false, "Print the managed object reference")
+}
+
+func (cmd *find) Usage() string {
+	return "[ROOT] [KEY VAL]..."
+}
+
+func (cmd *find) Description() string {
+	atable := aliasHelp()
+
+	return fmt.Sprintf(`Find managed objects.
+
+ROOT can be an inventory path or ManagedObjectReference.
+ROOT defaults to '.', an alias for the root folder or DC if set.
+
+Optional KEY VAL pairs can be used to filter results against object instance properties.
+Use the govc 'object.collect' command to view possible object property keys.
+
+The '-type' flag value can be a managed entity type or one of the following aliases:
+
+%s
+Examples:
+  govc find
+  govc find /dc1 -type c
+  govc find vm -name my-vm-*
+  govc find . -type n
+  govc find . -type m -runtime.powerState poweredOn
+  govc find . -type m -datastore $(govc find -i datastore -name vsanDatastore)
+  govc find . -type s -summary.type vsan
+  govc find . -type h -hardware.cpuInfo.numCpuCores 16`, atable)
+}
+
+// rootMatch returns true if the root object path should be printed
+func (cmd *find) rootMatch(ctx context.Context, root object.Reference, client *vim25.Client, filter property.Filter) bool {
+	ref := root.Reference()
+
+	if !cmd.kind.wanted(ref.Type) {
+		return false
+	}
+
+	if len(filter) == 1 && filter["name"] == "*" {
+		return true
+	}
+
+	var content []types.ObjectContent
+
+	pc := property.DefaultCollector(client)
+	_ = pc.RetrieveWithFilter(ctx, []types.ManagedObjectReference{ref}, filter.Keys(), &content, filter)
+
+	return content != nil
+}
+
+type findResult []string
+
+func (r findResult) Write(w io.Writer) error {
+	for i := range r {
+		fmt.Fprintln(w, r[i])
+	}
+	return nil
+}
+
+func (r findResult) Dump() interface{} {
+	return []string(r)
+}
+
+func (cmd *find) Run(ctx context.Context, f *flag.FlagSet) error {
+	client, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	root := client.ServiceContent.RootFolder
+	rootPath := "/"
+
+	arg := f.Arg(0)
+	props := f.Args()
+
+	if len(props) > 0 {
+		if strings.HasPrefix(arg, "-") {
+			arg = "."
+		} else {
+			props = props[1:]
+		}
+	}
+
+	if len(props)%2 != 0 {
+		return flag.ErrHelp
+	}
+
+	dc, err := cmd.DatacenterIfSpecified()
+	if err != nil {
+		return err
+	}
+
+	switch arg {
+	case rootPath:
+	case "", ".":
+		if dc == nil {
+			arg = rootPath
+		} else {
+			arg = "."
+			root = dc.Reference()
+			rootPath = dc.InventoryPath
+		}
+	default:
+		path := arg
+		if !strings.Contains(arg, "/") {
+			// Force list mode
+			p := "."
+			if dc != nil {
+				p = dc.InventoryPath
+			}
+			path = strings.Join([]string{p, arg}, "/")
+		}
+
+		l, ferr := finder.ManagedObjectList(ctx, path)
+		if ferr != nil {
+			return err
+		}
+
+		switch len(l) {
+		case 0:
+			return fmt.Errorf("%s not found", arg)
+		case 1:
+			root = l[0].Object.Reference()
+			rootPath = l[0].Path
+		default:
+			return fmt.Errorf("%q matches %d objects", arg, len(l))
+		}
+	}
+
+	filter := property.Filter{}
+
+	if len(props)%2 != 0 {
+		return flag.ErrHelp
+	}
+
+	for i := 0; i < len(props); i++ {
+		key := props[i]
+		if !strings.HasPrefix(key, "-") {
+			return flag.ErrHelp
+		}
+
+		key = key[1:]
+		i++
+		val := props[i]
+
+		if xf := f.Lookup(key); xf != nil {
+			// Support use of -flag following the ROOT arg (flag package does not do this)
+			if err = xf.Value.Set(val); err != nil {
+				return err
+			}
+		} else {
+			filter[key] = val
+		}
+	}
+
+	filter["name"] = cmd.name
+	var paths findResult
+
+	printPath := func(o types.ManagedObjectReference, p string) {
+		if cmd.ref {
+			paths = append(paths, o.String())
+			return
+		}
+
+		path := strings.Replace(p, rootPath, arg, 1)
+		paths = append(paths, path)
+	}
+
+	recurse := false
+
+	switch cmd.maxdepth {
+	case -1:
+		recurse = true
+	case 0:
+	case 1:
+	default:
+		return flag.ErrHelp // TODO: ?
+	}
+
+	if cmd.rootMatch(ctx, root, client, filter) {
+		printPath(root, arg)
+	}
+
+	if cmd.maxdepth == 0 {
+		return cmd.WriteResult(paths)
+	}
+
+	m := view.NewManager(client)
+
+	v, err := m.CreateContainerView(ctx, root, cmd.kind, recurse)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = v.Destroy(ctx)
+	}()
+
+	objs, err := v.Find(ctx, cmd.kind, filter)
+	if err != nil {
+		return err
+	}
+
+	for _, o := range objs {
+		var path string
+
+		if !cmd.ref {
+			e, err := finder.Element(ctx, o)
+			if err != nil {
+				return err
+			}
+			path = e.Path
+		}
+
+		printPath(o, path)
+	}
+
+	return cmd.WriteResult(paths)
+}

--- a/vendor/github.com/vmware/govmomi/govc/object/method.go
+++ b/vendor/github.com/vmware/govmomi/govc/object/method.go
@@ -1,0 +1,104 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type method struct {
+	*flags.DatacenterFlag
+
+	name   string
+	reason string
+	source string
+	enable bool
+}
+
+func init() {
+	cli.Register("object.method", &method{})
+}
+
+func (cmd *method) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.name, "name", "", "Method name")
+	f.StringVar(&cmd.reason, "reason", "", "Reason for disabling method")
+	f.StringVar(&cmd.source, "source", "govc", "Source ID")
+	f.BoolVar(&cmd.enable, "enable", true, "Enable method")
+}
+
+func (cmd *method) Usage() string {
+	return "PATH..."
+}
+
+func (cmd *method) Description() string {
+	return `Enable or disable methods for managed objects.
+
+Examples:
+  govc object.method -name Destroy_Task -enable=false /dc1/vm/foo
+  govc object.collect /dc1/vm/foo disabledMethod | grep --color Destroy_Task
+  govc object.method -name Destroy_Task -enable /dc1/vm/foo`
+}
+
+func (cmd *method) Process(ctx context.Context) error {
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *method) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
+	if cmd.name == "" {
+		return flag.ErrHelp
+	}
+
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	objs, err := cmd.ManagedObjects(ctx, f.Args())
+	if err != nil {
+		return err
+	}
+
+	m := object.NewAuthorizationManager(c)
+
+	if cmd.enable {
+		return m.EnableMethods(ctx, objs, []string{cmd.name}, cmd.source)
+	}
+
+	method := []object.DisabledMethodRequest{
+		{
+			Method: cmd.name,
+			Reason: cmd.reason,
+		},
+	}
+
+	return m.DisableMethods(ctx, objs, method, cmd.source)
+}

--- a/vendor/github.com/vmware/govmomi/govc/object/mv.go
+++ b/vendor/github.com/vmware/govmomi/govc/object/mv.go
@@ -1,0 +1,92 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type mv struct {
+	*flags.DatacenterFlag
+}
+
+func init() {
+	cli.Register("object.mv", &mv{})
+}
+
+func (cmd *mv) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+}
+
+func (cmd *mv) Usage() string {
+	return "PATH... FOLDER"
+}
+
+func (cmd *mv) Description() string {
+	return `Move managed entities to FOLDER.
+
+Examples:
+  govc folder.create /dc1/host/example
+  govc object.mv /dc2/host/*.example.com /dc1/host/example`
+}
+
+func (cmd *mv) Process(ctx context.Context) error {
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *mv) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() < 2 {
+		return flag.ErrHelp
+	}
+
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	n := f.NArg() - 1
+
+	folder, err := finder.Folder(ctx, f.Arg(n))
+	if err != nil {
+		return err
+	}
+
+	objs, err := cmd.ManagedObjects(ctx, f.Args()[:n])
+	if err != nil {
+		return err
+	}
+
+	task, err := folder.MoveInto(ctx, objs)
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("moving %d objects to %s... ", len(objs), folder.InventoryPath))
+	_, err = task.WaitForResult(ctx, logger)
+	logger.Wait()
+
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/object/reload.go
+++ b/vendor/github.com/vmware/govmomi/govc/object/reload.go
@@ -1,0 +1,88 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type reload struct {
+	*flags.DatacenterFlag
+}
+
+func init() {
+	cli.Register("object.reload", &reload{})
+}
+
+func (cmd *reload) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+}
+
+func (cmd *reload) Usage() string {
+	return "PATH..."
+}
+
+func (cmd *reload) Description() string {
+	return `Reload managed object state.
+
+Examples:
+  govc datastore.upload $vm.vmx $vm/$vm.vmx
+  govc object.reload /dc1/vm/$vm`
+}
+
+func (cmd *reload) Process(ctx context.Context) error {
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *reload) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	objs, err := cmd.ManagedObjects(ctx, f.Args())
+	if err != nil {
+		return err
+	}
+
+	for _, obj := range objs {
+		req := types.Reload{
+			This: obj,
+		}
+
+		_, err = methods.Reload(ctx, c, &req)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/object/rename.go
+++ b/vendor/github.com/vmware/govmomi/govc/object/rename.go
@@ -1,0 +1,85 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type rename struct {
+	*flags.DatacenterFlag
+}
+
+func init() {
+	cli.Register("object.rename", &rename{})
+}
+
+func (cmd *rename) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+}
+
+func (cmd *rename) Usage() string {
+	return "PATH NAME"
+}
+
+func (cmd *rename) Description() string {
+	return `Rename managed objects.
+
+Examples:
+  govc object.rename /dc1/network/dvs1 Switch1`
+}
+
+func (cmd *rename) Process(ctx context.Context) error {
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *rename) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 2 {
+		return flag.ErrHelp
+	}
+
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	objs, err := cmd.ManagedObjects(ctx, f.Args()[:1])
+	if err != nil {
+		return err
+	}
+
+	task, err := object.NewCommon(c, objs[0]).Rename(ctx, f.Arg(1))
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("renaming %s... ", objs[0]))
+	_, err = task.WaitForResult(ctx, logger)
+	logger.Wait()
+
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/object/save.go
+++ b/vendor/github.com/vmware/govmomi/govc/object/save.go
@@ -1,0 +1,304 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/view"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vim25/xml"
+)
+
+type save struct {
+	*flags.FolderFlag
+
+	n       int
+	dir     string
+	force   bool
+	verbose bool
+	recurse bool
+	one     bool
+	kind    kinds
+	summary map[string]int
+}
+
+func init() {
+	cli.Register("object.save", &save{})
+}
+
+func (cmd *save) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.FolderFlag, ctx = flags.NewFolderFlag(ctx)
+	cmd.FolderFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.one, "1", false, "Save ROOT only, without its children")
+	f.StringVar(&cmd.dir, "d", "", "Save objects in directory")
+	f.BoolVar(&cmd.force, "f", false, "Remove existing object directory")
+	f.BoolVar(&cmd.recurse, "r", true, "Include children of the container view root")
+	f.Var(&cmd.kind, "type", "Resource types to save.  Defaults to all types")
+	f.BoolVar(&cmd.verbose, "v", false, "Verbose output")
+}
+
+func (cmd *save) Usage() string {
+	return "[PATH]"
+}
+
+func (cmd *save) Description() string {
+	return `Save managed objects.
+
+By default, the object tree and all properties are saved, starting at PATH.
+PATH defaults to ServiceContent, but can be specified to save a subset of objects.
+The primary use case for this command is to save inventory from a live vCenter and
+load it into a vcsim instance.
+
+Examples:
+  govc object.save -d my-vcenter
+  vcsim -load my-vcenter`
+}
+
+func (cmd *save) save(content []types.ObjectContent) error {
+	for _, x := range content {
+		cmd.summary[x.Obj.Type]++
+		if cmd.verbose {
+			fmt.Printf("Saving %s...", x.Obj)
+		}
+		name := fmt.Sprintf("%04d-%s-%s", cmd.n, x.Obj.Type, url.QueryEscape(x.Obj.Value))
+		cmd.n++
+		f, err := os.Create(filepath.Join(cmd.dir, name) + ".xml")
+		if err != nil {
+			return err
+		}
+		e := xml.NewEncoder(f)
+		e.Indent("", "  ")
+		if err = e.Encode(x); err != nil {
+			_ = f.Close()
+			return err
+		}
+		if err = f.Close(); err != nil {
+			return err
+		}
+		if cmd.verbose {
+			fmt.Println("ok")
+		}
+	}
+	return nil
+}
+
+func (cmd *save) Run(ctx context.Context, f *flag.FlagSet) error {
+	cmd.summary = make(map[string]int)
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+	if cmd.dir == "" {
+		u := c.URL()
+		name := u.Fragment
+		if name == "" {
+			name = u.Hostname()
+		}
+		cmd.dir = "vcsim-" + name
+	}
+	mkdir := os.Mkdir
+	if cmd.force {
+		mkdir = os.MkdirAll
+	}
+	if err := mkdir(cmd.dir, 0755); err != nil {
+		return err
+	}
+
+	var content []types.ObjectContent
+	pc := property.DefaultCollector(c)
+	root := vim25.ServiceInstance
+	if f.NArg() == 1 {
+		root, err = cmd.ManagedObject(ctx, f.Arg(0))
+		if err != nil {
+			if !root.FromString(f.Arg(0)) {
+				return err
+			}
+		}
+		if cmd.one {
+			err = pc.RetrieveOne(ctx, root, nil, &content)
+			if err != nil {
+				return nil
+			}
+			if err = cmd.save(content); err != nil {
+				return err
+			}
+			return nil
+		}
+	}
+
+	req := types.RetrievePropertiesEx{
+		This:    pc.Reference(),
+		Options: types.RetrieveOptions{MaxObjects: 10},
+	}
+
+	if root == vim25.ServiceInstance {
+		err := pc.RetrieveOne(ctx, root, []string{"content"}, &content)
+		if err != nil {
+			return nil
+		}
+		if err = cmd.save(content); err != nil {
+			return err
+		}
+		if cmd.one {
+			return nil
+		}
+
+		root = c.ServiceContent.RootFolder
+
+		for _, p := range content[0].PropSet {
+			if c, ok := p.Val.(types.ServiceContent); ok {
+				for _, ref := range mo.References(c) {
+					all := types.NewBool(true)
+					switch ref.Type {
+					case "LicenseManager", "ServiceManager":
+						all = nil
+					}
+					req.SpecSet = append(req.SpecSet, types.PropertyFilterSpec{
+						ObjectSet: []types.ObjectSpec{{
+							Obj: ref,
+						}},
+						PropSet: []types.PropertySpec{{
+							Type:    ref.Type,
+							All:     all,
+							PathSet: nil,
+						}},
+					})
+				}
+				break
+			}
+		}
+	}
+
+	m := view.NewManager(c)
+	v, err := m.CreateContainerView(ctx, root, cmd.kind, cmd.recurse)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = v.Destroy(ctx)
+	}()
+
+	all := types.NewBool(true)
+	req.SpecSet = append(req.SpecSet, types.PropertyFilterSpec{
+		ObjectSet: []types.ObjectSpec{{
+			Obj:  v.Reference(),
+			Skip: types.NewBool(false),
+			SelectSet: []types.BaseSelectionSpec{
+				&types.TraversalSpec{
+					Type: v.Reference().Type,
+					Path: "view",
+					SelectSet: []types.BaseSelectionSpec{
+						&types.SelectionSpec{
+							Name: "computeTraversalSpec",
+						},
+						&types.SelectionSpec{
+							Name: "datastoreTraversalSpec",
+						},
+						&types.SelectionSpec{
+							Name: "entityTraversalSpec",
+						},
+					},
+				},
+				&types.TraversalSpec{
+					SelectionSpec: types.SelectionSpec{
+						Name: "computeTraversalSpec",
+					},
+					Type: "ComputeResource",
+					Path: "environmentBrowser",
+				},
+				&types.TraversalSpec{
+					SelectionSpec: types.SelectionSpec{
+						Name: "datastoreTraversalSpec",
+					},
+					Type: "Datastore",
+					Path: "browser",
+				},
+				&types.TraversalSpec{
+					SelectionSpec: types.SelectionSpec{
+						Name: "entityTraversalSpec",
+					},
+					Type: "ManagedEntity",
+					Path: "recentTask",
+				},
+			},
+		}},
+		PropSet: []types.PropertySpec{
+			{Type: "EnvironmentBrowser", All: all},
+			{Type: "HostDatastoreBrowser", All: all},
+			{Type: "ManagedEntity", All: all},
+			{Type: "Task", All: all},
+		},
+	})
+
+	res, err := methods.RetrievePropertiesEx(ctx, c, &req)
+	if err != nil {
+		return err
+	}
+	if err = cmd.save(res.Returnval.Objects); err != nil {
+		return err
+	}
+
+	token := res.Returnval.Token
+	for token != "" {
+		cres, err := methods.ContinueRetrievePropertiesEx(ctx, c, &types.ContinueRetrievePropertiesEx{
+			This:  req.This,
+			Token: token,
+		})
+		if err != nil {
+			return err
+		}
+		token = cres.Returnval.Token
+		if err = cmd.save(cres.Returnval.Objects); err != nil {
+			return err
+		}
+	}
+
+	var summary []string
+	for k, v := range cmd.summary {
+		if v == 1 && !cmd.verbose {
+			continue
+		}
+		summary = append(summary, fmt.Sprintf("%s: %d", k, v))
+	}
+	sort.Strings(summary)
+
+	s := ", including"
+	if cmd.verbose {
+		s = ""
+	}
+	fmt.Printf("Saved %d total objects to %q%s:\n", cmd.n, cmd.dir, s)
+	for i := range summary {
+		fmt.Println(summary[i])
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/option/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/option/ls.go
@@ -1,0 +1,121 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package option
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type List struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("option.ls", &List{})
+}
+
+func (cmd *List) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *List) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *List) Usage() string {
+	return "[NAME]"
+}
+
+var ListDescription = `List option with the given NAME.
+
+If NAME ends with a dot, all options for that subtree are listed.`
+
+func (cmd *List) Description() string {
+	return ListDescription + `
+
+Examples:
+  govc option.ls
+  govc option.ls config.vpxd.sso.
+  govc option.ls config.vpxd.sso.sts.uri`
+}
+
+func (cmd *List) Query(ctx context.Context, f *flag.FlagSet, m *object.OptionManager) error {
+	var err error
+	var opts []types.BaseOptionValue
+
+	if f.NArg() > 1 {
+		return flag.ErrHelp
+	}
+
+	if f.NArg() == 1 {
+		opts, err = m.Query(ctx, f.Arg(0))
+	} else {
+		var om mo.OptionManager
+		err = m.Properties(ctx, m.Reference(), []string{"setting"}, &om)
+		opts = om.Setting
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return cmd.WriteResult(optionResult(opts))
+}
+
+func (cmd *List) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m := object.NewOptionManager(c, *c.ServiceContent.Setting)
+
+	return cmd.Query(ctx, f, m)
+}
+
+type optionResult []types.BaseOptionValue
+
+func (r optionResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
+	for _, opt := range r {
+		o := opt.GetOptionValue()
+		fmt.Fprintf(tw, "%s:\t%v\n", o.Key, o.Value)
+	}
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/option/set.go
+++ b/vendor/github.com/vmware/govmomi/govc/option/set.go
@@ -1,0 +1,141 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package option
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strconv"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type Set struct {
+	*flags.ClientFlag
+}
+
+func init() {
+	cli.Register("option.set", &Set{})
+}
+
+func (cmd *Set) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+}
+
+func (cmd *Set) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *Set) Usage() string {
+	return "NAME VALUE"
+}
+
+var SetDescription = `Set option NAME to VALUE.`
+
+func (cmd *Set) Description() string {
+	return SetDescription + `
+
+Examples:
+  govc option.set log.level info
+  govc option.set logger.Vsan verbose`
+}
+
+func isInvalidName(err error) bool {
+	if soap.IsSoapFault(err) {
+		soapFault := soap.ToSoapFault(err)
+		if _, ok := soapFault.VimFault().(types.InvalidName); ok {
+			return ok
+		}
+	}
+
+	return false
+}
+
+func (cmd *Set) Update(ctx context.Context, f *flag.FlagSet, m *object.OptionManager) error {
+	if f.NArg() != 2 {
+		return flag.ErrHelp
+	}
+
+	name := f.Arg(0)
+	val := f.Arg(1)
+
+	opts, err := m.Query(ctx, name)
+	if err != nil {
+		if isInvalidName(err) {
+			// If the option doesn't exist, creating one can only have a string Value.
+			// The Key prefix is limited in this case too, it seems to the config.* namespace.
+			return m.Update(ctx, []types.BaseOptionValue{&types.OptionValue{
+				Key:   name,
+				Value: val,
+			}})
+		}
+		return err
+	}
+
+	if len(opts) != 1 {
+		return flag.ErrHelp
+	}
+
+	var set types.AnyType
+
+	switch x := opts[0].GetOptionValue().Value.(type) {
+	case string:
+		set = val
+	case bool:
+		set, err = strconv.ParseBool(val)
+		if err != nil {
+			return err
+		}
+	case int32:
+		s, err := strconv.ParseInt(val, 10, 32)
+		if err != nil {
+			return err
+		}
+		set = int32(s)
+	case int64:
+		set, err = strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("type %T conversion not supported", x)
+	}
+
+	opts[0].GetOptionValue().Value = set
+
+	return m.Update(ctx, opts)
+}
+
+func (cmd *Set) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m := object.NewOptionManager(c, *c.ServiceContent.Setting)
+
+	return cmd.Update(ctx, f, m)
+}

--- a/vendor/github.com/vmware/govmomi/govc/permissions/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/permissions/ls.go
@@ -1,0 +1,83 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package permissions
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+)
+
+type ls struct {
+	*PermissionFlag
+
+	inherited bool
+}
+
+func init() {
+	cli.Register("permissions.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.PermissionFlag, ctx = NewPermissionFlag(ctx)
+	cmd.PermissionFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.inherited, "a", true, "Include inherited permissions defined by parent entities")
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.PermissionFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ls) Usage() string {
+	return "[PATH]..."
+}
+
+func (cmd *ls) Description() string {
+	return `List the permissions defined on or effective on managed entities.
+
+Examples:
+  govc permissions.ls
+  govc permissions.ls /dc1/host/cluster1`
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	refs, err := cmd.ManagedObjects(ctx, f.Args())
+	if err != nil {
+		return err
+	}
+
+	m, err := cmd.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, ref := range refs {
+		perms, err := m.RetrieveEntityPermissions(ctx, ref, cmd.inherited)
+		if err != nil {
+			return err
+		}
+
+		cmd.List.Add(perms)
+	}
+
+	return cmd.WriteResult(&cmd.List)
+}

--- a/vendor/github.com/vmware/govmomi/govc/permissions/permissions.go
+++ b/vendor/github.com/vmware/govmomi/govc/permissions/permissions.go
@@ -1,0 +1,165 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package permissions
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type List struct {
+	Roles object.AuthorizationRoleList `json:",omitempty"`
+
+	Permissions []types.Permission `json:",omitempty"`
+
+	f *PermissionFlag
+}
+
+type PermissionFlag struct {
+	*flags.DatacenterFlag
+	*flags.OutputFlag
+
+	asRef bool
+
+	m *object.AuthorizationManager
+
+	List
+}
+
+func NewPermissionFlag(ctx context.Context) (*PermissionFlag, context.Context) {
+	f := &PermissionFlag{}
+	f.List.f = f
+	f.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	f.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	return f, ctx
+}
+
+func (f *PermissionFlag) Register(ctx context.Context, fs *flag.FlagSet) {
+	f.DatacenterFlag.Register(ctx, fs)
+	f.OutputFlag.Register(ctx, fs)
+
+	fs.BoolVar(&f.asRef, "i", false, "Use moref instead of inventory path")
+}
+
+func (f *PermissionFlag) Process(ctx context.Context) error {
+	if err := f.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := f.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (f *PermissionFlag) Manager(ctx context.Context) (*object.AuthorizationManager, error) {
+	if f.m != nil {
+		return f.m, nil
+	}
+
+	c, err := f.Client()
+	if err != nil {
+		return nil, err
+	}
+
+	f.m = object.NewAuthorizationManager(c)
+	f.Roles, err = f.m.RoleList(ctx)
+
+	return f.m, err
+}
+
+func (f *PermissionFlag) Role(name string) (*types.AuthorizationRole, error) {
+	role := f.Roles.ByName(name)
+	if role == nil {
+		return nil, fmt.Errorf("role %q not found", name)
+	}
+	return role, nil
+}
+
+func (f *PermissionFlag) ManagedObjects(ctx context.Context, args []string) ([]types.ManagedObjectReference, error) {
+	if !f.asRef {
+		return f.DatacenterFlag.ManagedObjects(ctx, args)
+	}
+
+	var refs []types.ManagedObjectReference
+
+	for _, arg := range args {
+		var ref types.ManagedObjectReference
+		if ref.FromString(arg) {
+			refs = append(refs, ref)
+		} else {
+			return nil, fmt.Errorf("invalid moref: %s", arg)
+		}
+	}
+
+	return refs, nil
+}
+
+func (l *List) Write(w io.Writer) error {
+	ctx := context.Background()
+	finder, err := l.f.Finder()
+	if err != nil {
+		return err
+	}
+
+	refs := make(map[types.ManagedObjectReference]string)
+
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", "Role", "Entity", "Principal", "Propagate")
+
+	for _, perm := range l.Permissions {
+		propagate := "No"
+		if perm.Propagate {
+			propagate = "Yes"
+		}
+
+		name := l.Roles.ById(perm.RoleId).Name
+
+		p := "-"
+		if perm.Entity != nil {
+			if l.f.asRef {
+				p = perm.Entity.String()
+			} else {
+				// convert moref to inventory path
+				if p = refs[*perm.Entity]; p == "" {
+					e, err := finder.Element(ctx, *perm.Entity)
+					if err == nil {
+						p = e.Path
+					}
+
+					refs[*perm.Entity] = p
+				}
+			}
+		}
+
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", name, p, perm.Principal, propagate)
+	}
+
+	return tw.Flush()
+}
+
+func (l *List) Add(perms []types.Permission) {
+	l.Permissions = append(l.Permissions, perms...)
+}

--- a/vendor/github.com/vmware/govmomi/govc/permissions/remove.go
+++ b/vendor/github.com/vmware/govmomi/govc/permissions/remove.go
@@ -1,0 +1,92 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package permissions
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type remove struct {
+	*PermissionFlag
+
+	types.Permission
+	force bool
+}
+
+func init() {
+	cli.Register("permissions.remove", &remove{})
+}
+
+func (cmd *remove) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.PermissionFlag, ctx = NewPermissionFlag(ctx)
+	cmd.PermissionFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.Principal, "principal", "", "User or group for which the permission is defined")
+	f.BoolVar(&cmd.Group, "group", false, "True, if principal refers to a group name; false, for a user name")
+	f.BoolVar(&cmd.force, "f", false, "Ignore NotFound fault if permission for this entity and user or group does not exist")
+}
+
+func (cmd *remove) Process(ctx context.Context) error {
+	if err := cmd.PermissionFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *remove) Usage() string {
+	return "[PATH]..."
+}
+
+func (cmd *remove) Description() string {
+	return `Removes a permission rule from managed entities.
+
+Examples:
+  govc permissions.remove -principal root
+  govc permissions.remove -principal $USER@vsphere.local /dc1/host/cluster1`
+}
+
+func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
+	refs, err := cmd.ManagedObjects(ctx, f.Args())
+	if err != nil {
+		return err
+	}
+
+	m, err := cmd.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, ref := range refs {
+		err = m.RemoveEntityPermission(ctx, ref, cmd.Principal, cmd.Group)
+		if err != nil {
+			if cmd.force && soap.IsSoapFault(err) {
+				_, ok := soap.ToSoapFault(err).VimFault().(types.NotFound)
+				if ok {
+					continue
+				}
+			}
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/permissions/set.go
+++ b/vendor/github.com/vmware/govmomi/govc/permissions/set.go
@@ -1,0 +1,96 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package permissions
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type set struct {
+	*PermissionFlag
+
+	types.Permission
+
+	role string
+}
+
+func init() {
+	cli.Register("permissions.set", &set{})
+}
+
+func (cmd *set) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.PermissionFlag, ctx = NewPermissionFlag(ctx)
+	cmd.PermissionFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.Principal, "principal", "", "User or group for which the permission is defined")
+	f.BoolVar(&cmd.Group, "group", false, "True, if principal refers to a group name; false, for a user name")
+	f.BoolVar(&cmd.Propagate, "propagate", true, "Whether or not this permission propagates down the hierarchy to sub-entities")
+	f.StringVar(&cmd.role, "role", "Admin", "Permission role name")
+}
+
+func (cmd *set) Process(ctx context.Context) error {
+	if err := cmd.PermissionFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *set) Usage() string {
+	return "[PATH]..."
+}
+
+func (cmd *set) Description() string {
+	return `Set the permissions managed entities.
+
+Examples:
+  govc permissions.set -principal root -role Admin
+  govc permissions.set -principal $USER@vsphere.local -role Admin /dc1/host/cluster1`
+}
+
+func (cmd *set) Run(ctx context.Context, f *flag.FlagSet) error {
+	refs, err := cmd.ManagedObjects(ctx, f.Args())
+	if err != nil {
+		return err
+	}
+
+	m, err := cmd.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	role, err := cmd.Role(cmd.role)
+	if err != nil {
+		return err
+	}
+
+	cmd.Permission.RoleId = role.RoleId
+
+	perms := []types.Permission{cmd.Permission}
+
+	for _, ref := range refs {
+		err = m.SetEntityPermissions(ctx, ref, perms)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/pool/change.go
+++ b/vendor/github.com/vmware/govmomi/govc/pool/change.go
@@ -1,0 +1,106 @@
+/*
+Copyright (c) 2015-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pool
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type change struct {
+	*flags.DatacenterFlag
+	*ResourceConfigSpecFlag
+
+	name string
+}
+
+func init() {
+	cli.Register("pool.change", &change{})
+}
+
+func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+	cmd.ResourceConfigSpecFlag = &ResourceConfigSpecFlag{
+		ResourceConfigSpec: types.ResourceConfigSpec{
+			CpuAllocation: types.ResourceAllocationInfo{
+				Shares: new(types.SharesInfo),
+			},
+			MemoryAllocation: types.ResourceAllocationInfo{
+				Shares: new(types.SharesInfo),
+			},
+		},
+	}
+	cmd.ResourceConfigSpecFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.name, "name", "", "Resource pool name")
+}
+
+func (cmd *change) Process(ctx context.Context) error {
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.ResourceConfigSpecFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *change) Usage() string {
+	return "POOL..."
+}
+
+func (cmd *change) Description() string {
+	return "Change the configuration of one or more resource POOLs.\n" + poolNameHelp
+}
+
+func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	for _, ra := range []*types.ResourceAllocationInfo{&cmd.CpuAllocation, &cmd.MemoryAllocation} {
+		if ra.Shares.Level == "" {
+			ra.Shares = nil
+		}
+	}
+
+	for _, arg := range f.Args() {
+		pools, err := finder.ResourcePoolListAll(ctx, arg)
+		if err != nil {
+			return err
+		}
+
+		for _, pool := range pools {
+			err := pool.UpdateConfig(ctx, cmd.name, &cmd.ResourceConfigSpec)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/pool/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/pool/create.go
@@ -1,0 +1,95 @@
+/*
+Copyright (c) 2015-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pool
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"path"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type create struct {
+	*flags.DatacenterFlag
+	*ResourceConfigSpecFlag
+}
+
+func init() {
+	cli.Register("pool.create", &create{})
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	cmd.ResourceConfigSpecFlag = NewResourceConfigSpecFlag()
+	cmd.ResourceConfigSpecFlag.Register(ctx, f)
+}
+
+func (cmd *create) Process(ctx context.Context) error {
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.ResourceConfigSpecFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *create) Usage() string {
+	return "POOL..."
+}
+
+func (cmd *create) Description() string {
+	return "Create one or more resource POOLs.\n" + poolCreateHelp
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	for _, arg := range f.Args() {
+		dir := path.Dir(arg)
+		base := path.Base(arg)
+		parents, err := finder.ResourcePoolList(ctx, dir)
+		if err != nil {
+			if _, ok := err.(*find.NotFoundError); ok {
+				return fmt.Errorf("cannot create resource pool '%s': parent not found", base)
+			}
+			return err
+		}
+
+		for _, parent := range parents {
+			_, err = parent.Create(ctx, base, cmd.ResourceConfigSpec)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/pool/destroy.go
+++ b/vendor/github.com/vmware/govmomi/govc/pool/destroy.go
@@ -1,0 +1,101 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pool
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type destroy struct {
+	*flags.DatacenterFlag
+
+	children bool
+}
+
+func init() {
+	cli.Register("pool.destroy", &destroy{})
+}
+
+func (cmd *destroy) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.children, "children", false, "Remove all children pools")
+}
+
+func (cmd *destroy) Process(ctx context.Context) error {
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *destroy) Usage() string {
+	return "POOL..."
+}
+
+func (cmd *destroy) Description() string {
+	return "Destroy one or more resource POOLs.\n" + poolNameHelp
+}
+
+func (cmd *destroy) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	for _, arg := range f.Args() {
+		pools, err := finder.ResourcePoolList(ctx, arg)
+		if err != nil {
+			if _, ok := err.(*find.NotFoundError); ok {
+				// Ignore if pool cannot be found
+				continue
+			}
+
+			return err
+		}
+
+		for _, pool := range pools {
+			if cmd.children {
+				err = pool.DestroyChildren(ctx)
+				if err != nil {
+					return err
+				}
+			} else {
+				task, err := pool.Destroy(ctx)
+				if err != nil {
+					return err
+				}
+				err = task.Wait(ctx)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/pool/help.go
+++ b/vendor/github.com/vmware/govmomi/govc/pool/help.go
@@ -1,0 +1,50 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pool
+
+var poolNameHelp = `
+POOL may be an absolute or relative path to a resource pool or a (clustered)
+compute host. If it resolves to a compute host, the associated root resource
+pool is returned. If a relative path is specified, it is resolved with respect
+to the current datacenter's "host" folder (i.e. /ha-datacenter/host).
+
+Paths to nested resource pools must traverse through the root resource pool of
+the selected compute host, i.e. "compute-host/Resources/nested-pool".
+
+The same globbing rules that apply to the "ls" command apply here. For example,
+POOL may be specified as "*/Resources/*" to expand to all resource pools that
+are nested one level under the root resource pool, on all (clustered) compute
+hosts in the current datacenter.`
+
+var poolCreateHelp = `
+POOL may be an absolute or relative path to a resource pool. The parent of the
+specified POOL must be an existing resource pool. If a relative path is
+specified, it is resolved with respect to the current datacenter's "host"
+folder (i.e. /ha-datacenter/host). The basename of the specified POOL is used
+as the name for the new resource pool.
+
+The same globbing rules that apply to the "ls" command apply here. For example,
+the path to the parent resource pool in POOL may be specified as "*/Resources"
+to expand to the root resource pools on all (clustered) compute hosts in the
+current datacenter.
+
+For example:
+  */Resources/test             Create resource pool "test" on all (clustered)
+                               compute hosts in the current datacenter.
+  somehost/Resources/*/nested  Create resource pool "nested" in every
+                               resource pool that is a direct descendant of
+                               the root resource pool on "somehost".`

--- a/vendor/github.com/vmware/govmomi/govc/pool/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/pool/info.go
@@ -1,0 +1,211 @@
+/*
+Copyright (c) 2015-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pool
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*flags.DatacenterFlag
+	*flags.OutputFlag
+
+	pools bool
+	apps  bool
+}
+
+func init() {
+	cli.Register("pool.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.pools, "p", true, "List resource pools")
+	f.BoolVar(&cmd.apps, "a", false, "List virtual app resource pools")
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *info) Usage() string {
+	return "POOL..."
+}
+
+func (cmd *info) Description() string {
+	return "Retrieve information about one or more resource POOLs.\n" + poolNameHelp
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	var res infoResult
+	var props []string
+
+	if cmd.OutputFlag.All() {
+		props = nil
+	} else {
+		props = []string{
+			"name",
+			"config.cpuAllocation",
+			"config.memoryAllocation",
+			"runtime.cpu",
+			"runtime.memory",
+		}
+	}
+
+	var vapps []*object.VirtualApp
+
+	for _, arg := range f.Args() {
+		if cmd.pools {
+			objects, err := finder.ResourcePoolList(ctx, arg)
+			if err != nil {
+				if _, ok := err.(*find.NotFoundError); !ok {
+					return err
+				}
+			}
+			res.objects = append(res.objects, objects...)
+		}
+
+		if cmd.apps {
+			apps, err := finder.VirtualAppList(ctx, arg)
+			if err != nil {
+				if _, ok := err.(*find.NotFoundError); !ok {
+					return err
+				}
+			}
+			vapps = append(vapps, apps...)
+		}
+	}
+
+	if len(res.objects) != 0 {
+		refs := make([]types.ManagedObjectReference, 0, len(res.objects))
+		for _, o := range res.objects {
+			refs = append(refs, o.Reference())
+		}
+
+		pc := property.DefaultCollector(c)
+		err = pc.Retrieve(ctx, refs, props, &res.ResourcePools)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(vapps) != 0 {
+		var apps []mo.VirtualApp
+		refs := make([]types.ManagedObjectReference, 0, len(vapps))
+		for _, o := range vapps {
+			refs = append(refs, o.Reference())
+			p := object.NewResourcePool(c, o.Reference())
+			p.InventoryPath = o.InventoryPath
+			res.objects = append(res.objects, p)
+		}
+
+		pc := property.DefaultCollector(c)
+		err = pc.Retrieve(ctx, refs, props, &apps)
+		if err != nil {
+			return err
+		}
+
+		for _, app := range apps {
+			res.ResourcePools = append(res.ResourcePools, app.ResourcePool)
+		}
+	}
+
+	return cmd.WriteResult(&res)
+}
+
+type infoResult struct {
+	ResourcePools []mo.ResourcePool
+	objects       []*object.ResourcePool
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	// Maintain order via r.objects as Property collector does not always return results in order.
+	objects := make(map[types.ManagedObjectReference]mo.ResourcePool, len(r.ResourcePools))
+	for _, o := range r.ResourcePools {
+		objects[o.Reference()] = o
+	}
+
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for _, o := range r.objects {
+		pool := objects[o.Reference()]
+		fmt.Fprintf(tw, "Name:\t%s\n", pool.Name)
+		fmt.Fprintf(tw, "  Path:\t%s\n", o.InventoryPath)
+
+		writeInfo(tw, "CPU", "MHz", &pool.Runtime.Cpu, pool.Config.CpuAllocation)
+		pool.Runtime.Memory.MaxUsage >>= 20
+		pool.Runtime.Memory.OverallUsage >>= 20
+		writeInfo(tw, "Mem", "MB", &pool.Runtime.Memory, pool.Config.MemoryAllocation)
+	}
+
+	return tw.Flush()
+}
+
+func writeInfo(w io.Writer, name string, units string, ru *types.ResourcePoolResourceUsage, ra types.ResourceAllocationInfo) {
+	usage := 100.0 * float64(ru.OverallUsage) / float64(ru.MaxUsage)
+	shares := ""
+	limit := "unlimited"
+
+	if ra.Shares.Level == types.SharesLevelCustom {
+		shares = fmt.Sprintf(" (%d)", ra.Shares.Shares)
+	}
+
+	if ra.Limit != nil {
+		limit = fmt.Sprintf("%d%s", *ra.Limit, units)
+	}
+
+	fmt.Fprintf(w, "  %s Usage:\t%d%s (%0.1f%%)\n", name, ru.OverallUsage, units, usage)
+	fmt.Fprintf(w, "  %s Shares:\t%s%s\n", name, ra.Shares.Level, shares)
+	fmt.Fprintf(w, "  %s Reservation:\t%d%s (expandable=%v)\n", name, *ra.Reservation, units, *ra.ExpandableReservation)
+	fmt.Fprintf(w, "  %s Limit:\t%s\n", name, limit)
+}

--- a/vendor/github.com/vmware/govmomi/govc/pool/resource_config_spec.go
+++ b/vendor/github.com/vmware/govmomi/govc/pool/resource_config_spec.go
@@ -1,0 +1,43 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pool
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func NewResourceConfigSpecFlag() *ResourceConfigSpecFlag {
+	return &ResourceConfigSpecFlag{types.DefaultResourceConfigSpec(), nil}
+}
+
+type ResourceConfigSpecFlag struct {
+	types.ResourceConfigSpec
+	*flags.ResourceAllocationFlag
+}
+
+func (s *ResourceConfigSpecFlag) Register(ctx context.Context, f *flag.FlagSet) {
+	s.ResourceAllocationFlag = flags.NewResourceAllocationFlag(&s.CpuAllocation, &s.MemoryAllocation)
+	s.ResourceAllocationFlag.Register(ctx, f)
+}
+
+func (s *ResourceConfigSpecFlag) Process(ctx context.Context) error {
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/role/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/role/create.go
@@ -1,0 +1,73 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package role
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/permissions"
+)
+
+type create struct {
+	*permissions.PermissionFlag
+}
+
+func init() {
+	cli.Register("role.create", &create{})
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.PermissionFlag, ctx = permissions.NewPermissionFlag(ctx)
+	cmd.PermissionFlag.Register(ctx, f)
+}
+
+func (cmd *create) Process(ctx context.Context) error {
+	if err := cmd.PermissionFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *create) Usage() string {
+	return "NAME [PRIVILEGE]..."
+}
+
+func (cmd *create) Description() string {
+	return `Create authorization role.
+
+Optionally populate the role with the given PRIVILEGE(s).
+
+Examples:
+  govc role.create MyRole
+  govc role.create NoDC $(govc role.ls Admin | grep -v Datacenter.)`
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
+	m, err := cmd.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	_, err = m.AddRole(ctx, f.Arg(0), f.Args()[1:])
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/role/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/role/ls.go
@@ -1,0 +1,107 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package role
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/permissions"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ls struct {
+	*permissions.PermissionFlag
+}
+
+func init() {
+	cli.Register("role.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.PermissionFlag, ctx = permissions.NewPermissionFlag(ctx)
+	cmd.PermissionFlag.Register(ctx, f)
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.PermissionFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ls) Usage() string {
+	return "[NAME]"
+}
+
+func (cmd *ls) Description() string {
+	return `List authorization roles.
+
+If NAME is provided, list privileges for the role.
+
+Examples:
+  govc role.ls
+  govc role.ls Admin`
+}
+
+type lsRoleList object.AuthorizationRoleList
+
+func (rl lsRoleList) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for _, role := range rl {
+		fmt.Fprintf(tw, "%s\t%s\n", role.Name, role.Info.GetDescription().Summary)
+	}
+
+	return tw.Flush()
+}
+
+type lsRole types.AuthorizationRole
+
+func (r lsRole) Write(w io.Writer) error {
+	for _, p := range r.Privilege {
+		fmt.Println(p)
+	}
+	return nil
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() > 1 {
+		return flag.ErrHelp
+	}
+
+	_, err := cmd.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	if f.NArg() == 1 {
+		role, err := cmd.Role(f.Arg(0))
+		if err != nil {
+			return err
+		}
+
+		return cmd.WriteResult(lsRole(*role))
+	}
+
+	return cmd.WriteResult(lsRoleList(cmd.Roles))
+}

--- a/vendor/github.com/vmware/govmomi/govc/role/remove.go
+++ b/vendor/github.com/vmware/govmomi/govc/role/remove.go
@@ -1,0 +1,79 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package role
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/permissions"
+)
+
+type remove struct {
+	*permissions.PermissionFlag
+
+	force bool
+}
+
+func init() {
+	cli.Register("role.remove", &remove{})
+}
+
+func (cmd *remove) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.PermissionFlag, ctx = permissions.NewPermissionFlag(ctx)
+	cmd.PermissionFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.force, "force", false, "Force removal if role is in use")
+}
+
+func (cmd *remove) Process(ctx context.Context) error {
+	if err := cmd.PermissionFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *remove) Usage() string {
+	return "NAME"
+}
+
+func (cmd *remove) Description() string {
+	return `Remove authorization role.
+
+Examples:
+  govc role.remove MyRole
+  govc role.remove MyRole -force`
+}
+
+func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	m, err := cmd.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	role, err := cmd.Role(f.Arg(0))
+	if err != nil {
+		return err
+	}
+
+	return m.RemoveRole(ctx, role.RoleId, !cmd.force)
+}

--- a/vendor/github.com/vmware/govmomi/govc/role/update.go
+++ b/vendor/github.com/vmware/govmomi/govc/role/update.go
@@ -1,0 +1,112 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package role
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/permissions"
+)
+
+type update struct {
+	*permissions.PermissionFlag
+
+	name   string
+	remove bool
+	add    bool
+}
+
+func init() {
+	cli.Register("role.update", &update{})
+}
+
+func (cmd *update) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.PermissionFlag, ctx = permissions.NewPermissionFlag(ctx)
+	cmd.PermissionFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.name, "name", "", "Change role name")
+	f.BoolVar(&cmd.remove, "r", false, "Remove given PRIVILEGE(s)")
+	f.BoolVar(&cmd.add, "a", false, "Add given PRIVILEGE(s)")
+}
+
+func (cmd *update) Process(ctx context.Context) error {
+	if err := cmd.PermissionFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *update) Usage() string {
+	return "NAME [PRIVILEGE]..."
+}
+
+func (cmd *update) Description() string {
+	return `Update authorization role.
+
+Set, Add or Remove role PRIVILEGE(s).
+
+Examples:
+  govc role.update MyRole $(govc role.ls Admin | grep VirtualMachine.)
+  govc role.update -r MyRole $(govc role.ls Admin | grep VirtualMachine.GuestOperations.)
+  govc role.update -a MyRole $(govc role.ls Admin | grep Datastore.)
+  govc role.update -name RockNRole MyRole`
+}
+
+func (cmd *update) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
+	m, err := cmd.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	role, err := cmd.Role(f.Arg(0))
+	if err != nil {
+		return err
+	}
+
+	ids := role.Privilege
+	args := f.Args()[1:]
+
+	if cmd.add {
+		ids = append(ids, args...)
+	} else if cmd.remove {
+		ids = nil
+		rm := make(map[string]bool, len(args))
+		for _, arg := range args {
+			rm[arg] = true
+		}
+
+		for _, id := range role.Privilege {
+			if !rm[id] {
+				ids = append(ids, id)
+			}
+		}
+	} else if len(args) != 0 {
+		ids = args
+	}
+
+	if cmd.name == "" {
+		cmd.name = role.Name
+	}
+
+	return m.UpdateRole(ctx, role.RoleId, cmd.name, ids)
+}

--- a/vendor/github.com/vmware/govmomi/govc/role/usage.go
+++ b/vendor/github.com/vmware/govmomi/govc/role/usage.go
@@ -1,0 +1,87 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package role
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/permissions"
+)
+
+type usage struct {
+	*permissions.PermissionFlag
+}
+
+func init() {
+	cli.Register("role.usage", &usage{})
+}
+
+func (cmd *usage) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.PermissionFlag, ctx = permissions.NewPermissionFlag(ctx)
+	cmd.PermissionFlag.Register(ctx, f)
+}
+
+func (cmd *usage) Process(ctx context.Context) error {
+	if err := cmd.PermissionFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *usage) Usage() string {
+	return "NAME..."
+}
+
+func (cmd *usage) Description() string {
+	return `List usage for role NAME.
+
+Examples:
+  govc role.usage
+  govc role.usage Admin`
+}
+
+func (cmd *usage) Run(ctx context.Context, f *flag.FlagSet) error {
+	m, err := cmd.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	if f.NArg() == 0 {
+		cmd.List.Permissions, err = m.RetrieveAllPermissions(ctx)
+		if err != nil {
+			return err
+		}
+	} else {
+		for _, name := range f.Args() {
+			role, err := cmd.Role(name)
+			if err != nil {
+				return err
+			}
+
+			perms, err := m.RetrieveRolePermissions(ctx, role.RoleId)
+			if err != nil {
+				return err
+			}
+
+			cmd.List.Add(perms)
+		}
+	}
+
+	return cmd.WriteResult(&cmd.List)
+}

--- a/vendor/github.com/vmware/govmomi/govc/session/login.go
+++ b/vendor/github.com/vmware/govmomi/govc/session/login.go
@@ -1,0 +1,293 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package session
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/sts"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+type login struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+
+	clone  bool
+	issue  bool
+	renew  bool
+	long   bool
+	ticket string
+	life   time.Duration
+	cookie string
+	token  string
+	ext    string
+}
+
+func init() {
+	cli.Register("session.login", &login{})
+}
+
+func (cmd *login) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.clone, "clone", false, "Acquire clone ticket")
+	f.BoolVar(&cmd.issue, "issue", false, "Issue SAML token")
+	f.BoolVar(&cmd.renew, "renew", false, "Renew SAML token")
+	f.DurationVar(&cmd.life, "lifetime", time.Minute*10, "SAML token lifetime")
+	f.BoolVar(&cmd.long, "l", false, "Output session cookie")
+	f.StringVar(&cmd.ticket, "ticket", "", "Use clone ticket for login")
+	f.StringVar(&cmd.cookie, "cookie", "", "Set HTTP cookie for an existing session")
+	f.StringVar(&cmd.token, "token", "", "Use SAML token for login or as issue identity")
+	f.StringVar(&cmd.ext, "extension", "", "Extension name")
+}
+
+func (cmd *login) Process(ctx context.Context) error {
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.ClientFlag.Process(ctx)
+}
+
+func (cmd *login) Description() string {
+	return `Session login.
+
+The session.login command is optional, all other govc commands will auto login when given credentials.
+The session.login command can be used to:
+- Persist a session without writing to disk via the '-cookie' flag
+- Acquire a clone ticket
+- Login using a clone ticket
+- Login using a vCenter Extension certificate
+- Issue a SAML token
+- Renew a SAML token
+- Login using a SAML token
+- Avoid passing credentials to other govc commands
+
+Examples:
+  govc session.login -u root:password@host
+  ticket=$(govc session.login -u root@host -clone)
+  govc session.login -u root@host -ticket $ticket
+  govc session.login -u host -extension com.vmware.vsan.health -cert rui.crt -key rui.key
+  token=$(govc session.login -u host -cert user.crt -key user.key -issue) # HoK token
+  bearer=$(govc session.login -u user:pass@host -issue) # Bearer token
+  token=$(govc session.login -u host -cert user.crt -key user.key -issue -token "$bearer")
+  govc session.login -u host -cert user.crt -key user.key -token "$token"
+  token=$(govc session.login -u host -cert user.crt -key user.key -renew -lifetime 24h -token "$token")`
+}
+
+type ticketResult struct {
+	cmd    *login
+	Ticket string `json:",omitempty"`
+	Token  string `json:",omitempty"`
+	Cookie string `json:",omitempty"`
+}
+
+func (r *ticketResult) Write(w io.Writer) error {
+	var output []string
+
+	for _, val := range []string{r.Ticket, r.Token, r.Cookie} {
+		if val != "" {
+			output = append(output, val)
+		}
+	}
+
+	if len(output) == 0 {
+		return nil
+	}
+
+	fmt.Fprintln(w, strings.Join(output, " "))
+
+	return nil
+}
+
+// Logout is called by cli.Run()
+// We override ClientFlag's Logout impl to avoid ending a session when -persist-session=false,
+// otherwise Logout would invalidate the cookie and/or ticket.
+func (cmd *login) Logout(ctx context.Context) error {
+	if cmd.long || cmd.clone || cmd.issue {
+		return nil
+	}
+	return cmd.ClientFlag.Logout(ctx)
+}
+
+func (cmd *login) cloneSession(ctx context.Context, c *vim25.Client) error {
+	return session.NewManager(c).CloneSession(ctx, cmd.ticket)
+}
+
+func (cmd *login) issueToken(ctx context.Context, vc *vim25.Client) (string, error) {
+	c, err := sts.NewClient(ctx, vc)
+	if err != nil {
+		return "", err
+	}
+
+	req := sts.TokenRequest{
+		Certificate: c.Certificate(),
+		Userinfo:    cmd.Userinfo(),
+		Renewable:   true,
+		Delegatable: true,
+		ActAs:       cmd.token != "",
+		Token:       cmd.token,
+		Lifetime:    cmd.life,
+	}
+
+	issue := c.Issue
+	if cmd.renew {
+		issue = c.Renew
+	}
+
+	s, err := issue(ctx, req)
+	if err != nil {
+		return "", err
+	}
+
+	if req.Token != "" {
+		duration := s.Lifetime.Expires.Sub(s.Lifetime.Created)
+		if duration < req.Lifetime {
+			// The granted lifetime is that of the bearer token, which is 5min max.
+			// Extend the lifetime via Renew.
+			req.Token = s.Token
+			if s, err = c.Renew(ctx, req); err != nil {
+				return "", err
+			}
+		}
+	}
+
+	return s.Token, nil
+}
+
+func (cmd *login) loginByToken(ctx context.Context, c *vim25.Client) error {
+	header := soap.Header{
+		Security: &sts.Signer{
+			Certificate: c.Certificate(),
+			Token:       cmd.token,
+		},
+	}
+
+	return session.NewManager(c).LoginByToken(c.WithHeader(ctx, header))
+}
+
+func (cmd *login) loginByExtension(ctx context.Context, c *vim25.Client) error {
+	return session.NewManager(c).LoginExtensionByCertificate(ctx, cmd.ext)
+}
+
+func (cmd *login) setCookie(ctx context.Context, c *vim25.Client) error {
+	url := c.URL()
+	jar := c.Client.Jar
+	cookies := jar.Cookies(url)
+	add := true
+
+	cookie := &http.Cookie{
+		Name: soap.SessionCookieName,
+	}
+
+	for _, e := range cookies {
+		if e.Name == cookie.Name {
+			add = false
+			cookie = e
+			break
+		}
+	}
+
+	if cmd.cookie == "" {
+		// This is the cookie from Set-Cookie after a Login or CloneSession
+		cmd.cookie = cookie.Value
+	} else {
+		// The cookie flag is set, set the HTTP header and skip Login()
+		cookie.Value = cmd.cookie
+		if add {
+			cookies = append(cookies, cookie)
+		}
+		jar.SetCookies(url, cookies)
+
+		// Check the session is still valid
+		_, err := methods.GetCurrentTime(ctx, c)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (cmd *login) Run(ctx context.Context, f *flag.FlagSet) error {
+	if cmd.renew {
+		cmd.issue = true
+	}
+	switch {
+	case cmd.ticket != "":
+		cmd.Login = cmd.cloneSession
+	case cmd.cookie != "":
+		cmd.Login = cmd.setCookie
+	case cmd.token != "":
+		cmd.Login = cmd.loginByToken
+	case cmd.ext != "":
+		cmd.Login = cmd.loginByExtension
+	case cmd.issue:
+		cmd.Login = func(_ context.Context, _ *vim25.Client) error {
+			return nil
+		}
+	}
+
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m := session.NewManager(c)
+	r := &ticketResult{cmd: cmd}
+
+	switch {
+	case cmd.clone:
+		r.Ticket, err = m.AcquireCloneTicket(ctx)
+		if err != nil {
+			return err
+		}
+	case cmd.issue:
+		r.Token, err = cmd.issueToken(ctx, c)
+		if err != nil {
+			return err
+		}
+		return cmd.WriteResult(r)
+	}
+
+	if cmd.cookie == "" {
+		_ = cmd.setCookie(ctx, c)
+		if cmd.cookie == "" {
+			return flag.ErrHelp
+		}
+	}
+
+	if cmd.long {
+		r.Cookie = cmd.cookie
+	}
+
+	return cmd.WriteResult(r)
+}

--- a/vendor/github.com/vmware/govmomi/govc/session/logout.go
+++ b/vendor/github.com/vmware/govmomi/govc/session/logout.go
@@ -1,0 +1,63 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package session
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/session"
+)
+
+type logout struct {
+	*flags.ClientFlag
+}
+
+func init() {
+	cli.Register("session.logout", &logout{})
+}
+
+func (cmd *logout) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+}
+
+func (cmd *logout) Process(ctx context.Context) error {
+	return cmd.ClientFlag.Process(ctx)
+}
+
+func (cmd *logout) Description() string {
+	return `Logout the current session.
+
+By default, govc commands persist sessions and do not logout unless '-persist-session=false' is set.
+The session.logout command can be used to end the current persisted session.
+The session.rm command can be used to remove sessions other than the current session.
+
+Examples:
+  govc session.logout`
+}
+
+func (cmd *logout) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	return session.NewManager(c).Logout(ctx)
+}

--- a/vendor/github.com/vmware/govmomi/govc/session/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/session/ls.go
@@ -1,0 +1,128 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package session
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+type ls struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("session.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *ls) Description() string {
+	return `List active sessions.
+
+Examples:
+  govc session.ls
+  govc session.ls -json | jq -r .CurrentSession.Key`
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+type sessionInfo struct {
+	cmd *ls
+	now *time.Time
+	mo.SessionManager
+}
+
+func (s *sessionInfo) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 4, 0, 2, ' ', 0)
+
+	fmt.Fprintf(tw, "Key\t")
+	fmt.Fprintf(tw, "Name\t")
+	fmt.Fprintf(tw, "Time\t")
+	fmt.Fprintf(tw, "Idle\t")
+	fmt.Fprintf(tw, "Host\t")
+	fmt.Fprintf(tw, "Agent\t")
+	fmt.Fprintf(tw, "\t")
+	fmt.Fprint(tw, "\n")
+
+	for _, v := range s.SessionList {
+		idle := "  ."
+		if v.Key != s.CurrentSession.Key {
+			since := s.now.Sub(v.LastActiveTime)
+			if since > time.Hour {
+				idle = "old"
+			} else {
+				idle = (time.Duration(since.Seconds()) * time.Second).String()
+			}
+		}
+		fmt.Fprintf(tw, "%s\t", v.Key)
+		fmt.Fprintf(tw, "%s\t", v.UserName)
+		fmt.Fprintf(tw, "%s\t", v.LoginTime.Format("2006-01-02 15:04"))
+		fmt.Fprintf(tw, "%s\t", idle)
+		fmt.Fprintf(tw, "%s\t", v.IpAddress)
+		fmt.Fprintf(tw, "%s\t", v.UserAgent)
+		fmt.Fprint(tw, "\n")
+	}
+
+	return tw.Flush()
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	var m mo.SessionManager
+	pc := property.DefaultCollector(c)
+	err = pc.RetrieveOne(ctx, *c.ServiceContent.SessionManager, nil, &m)
+	if err != nil {
+		return nil
+	}
+
+	now, err := methods.GetCurrentTime(ctx, c)
+	if err != nil {
+		return err
+	}
+
+	return cmd.WriteResult(&sessionInfo{cmd, now, m})
+}

--- a/vendor/github.com/vmware/govmomi/govc/session/rm.go
+++ b/vendor/github.com/vmware/govmomi/govc/session/rm.go
@@ -1,0 +1,67 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package session
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/session"
+)
+
+type rm struct {
+	*flags.ClientFlag
+}
+
+func init() {
+	cli.Register("session.rm", &rm{})
+}
+
+func (cmd *rm) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+}
+
+func (cmd *rm) Usage() string {
+	return "KEY..."
+}
+
+func (cmd *rm) Description() string {
+	return `Remove active sessions.
+
+Examples:
+  govc session.ls | grep root
+  govc session.rm 5279e245-e6f1-4533-4455-eb94353b213a`
+}
+
+func (cmd *rm) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *rm) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	return session.NewManager(c).TerminateSession(ctx, f.Args())
+}

--- a/vendor/github.com/vmware/govmomi/govc/sso/client.go
+++ b/vendor/github.com/vmware/govmomi/govc/sso/client.go
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sso
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/ssoadmin"
+	"github.com/vmware/govmomi/sts"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+func WithClient(ctx context.Context, cmd *flags.ClientFlag, f func(*ssoadmin.Client) error) error {
+	vc, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	c, err := ssoadmin.NewClient(ctx, vc)
+	if err != nil {
+		return err
+	}
+
+	// SSO admin server has its own session manager, so the govc persisted session cookies cannot
+	// be used to authenticate.  There is no SSO token persistence in govc yet, so just use an env
+	// var for now.  If no GOVC_LOGIN_TOKEN is set, issue a new token.
+	token := os.Getenv("GOVC_LOGIN_TOKEN")
+	header := soap.Header{
+		Security: &sts.Signer{
+			Certificate: vc.Certificate(),
+			Token:       token,
+		},
+	}
+
+	if token == "" {
+		tokens, cerr := sts.NewClient(ctx, vc)
+		if cerr != nil {
+			return cerr
+		}
+
+		req := sts.TokenRequest{
+			Certificate: vc.Certificate(),
+			Userinfo:    cmd.Userinfo(),
+		}
+
+		header.Security, cerr = tokens.Issue(ctx, req)
+		if cerr != nil {
+			return cerr
+		}
+	}
+
+	if err = c.Login(c.WithHeader(ctx, header)); err != nil {
+		return err
+	}
+
+	defer func() {
+		if err := c.Logout(ctx); err != nil {
+			log.Printf("user logout error: %v", err)
+		}
+	}()
+
+	return f(c)
+}

--- a/vendor/github.com/vmware/govmomi/govc/sso/group/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/sso/group/create.go
@@ -1,0 +1,66 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package group
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/govc/sso"
+	"github.com/vmware/govmomi/ssoadmin"
+	"github.com/vmware/govmomi/ssoadmin/types"
+)
+
+type create struct {
+	*flags.ClientFlag
+
+	types.AdminGroupDetails
+}
+
+func (cmd *create) Usage() string {
+	return "NAME"
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.AdminGroupDetails.Description, "d", "", "Group description")
+}
+
+func init() {
+	cli.Register("sso.group.create", &create{})
+}
+
+func (cmd *create) Description() string {
+	return `Create SSO group.
+
+Examples:
+  govc sso.group.create NAME`
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	return sso.WithClient(ctx, cmd.ClientFlag, func(c *ssoadmin.Client) error {
+		return c.CreateGroup(ctx, f.Arg(0), cmd.AdminGroupDetails)
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/sso/group/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/sso/group/ls.go
@@ -1,0 +1,89 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package group
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/govc/sso"
+	"github.com/vmware/govmomi/ssoadmin"
+	"github.com/vmware/govmomi/ssoadmin/types"
+)
+
+type ls struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("sso.group.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *ls) Description() string {
+	return `List SSO groups.
+
+Examples:
+  govc sso.group.ls -s`
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.OutputFlag.Process(ctx)
+}
+
+type groupResult []types.AdminGroup
+
+func (r groupResult) Dump() interface{} {
+	return []types.AdminGroup(r)
+}
+
+func (r groupResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+	for _, info := range r {
+		fmt.Fprintf(tw, "%s\t%s\n", info.Id.Name, info.Details.Description)
+	}
+	return tw.Flush()
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	arg := f.Arg(0)
+
+	return sso.WithClient(ctx, cmd.ClientFlag, func(c *ssoadmin.Client) error {
+		info, err := c.FindGroups(ctx, arg)
+		if err != nil {
+			return err
+		}
+
+		return cmd.WriteResult(groupResult(info))
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/sso/group/rm.go
+++ b/vendor/github.com/vmware/govmomi/govc/sso/group/rm.go
@@ -1,0 +1,57 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package group
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/govc/sso"
+	"github.com/vmware/govmomi/ssoadmin"
+)
+
+type rm struct {
+	*flags.ClientFlag
+}
+
+func init() {
+	cli.Register("sso.group.rm", &rm{})
+}
+
+func (cmd *rm) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+}
+
+func (cmd *rm) Usage() string {
+	return "NAME"
+}
+
+func (cmd *rm) Description() string {
+	return `Remove SSO group.
+
+Examples:
+  govc sso.group.rm NAME`
+}
+
+func (cmd *rm) Run(ctx context.Context, f *flag.FlagSet) error {
+	return sso.WithClient(ctx, cmd.ClientFlag, func(c *ssoadmin.Client) error {
+		return c.DeletePrincipal(ctx, f.Arg(0))
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/sso/group/update.go
+++ b/vendor/github.com/vmware/govmomi/govc/sso/group/update.go
@@ -1,0 +1,96 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package group
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/govc/sso"
+	"github.com/vmware/govmomi/ssoadmin"
+	"github.com/vmware/govmomi/ssoadmin/types"
+)
+
+type update struct {
+	*flags.ClientFlag
+
+	d string
+	a string
+	r string
+}
+
+func init() {
+	cli.Register("sso.group.update", &update{})
+}
+
+func (cmd *update) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.d, "d", "", "Group description")
+	f.StringVar(&cmd.a, "a", "", "Add user to group")
+	f.StringVar(&cmd.r, "r", "", "Remove user from group")
+}
+
+func (cmd *update) Description() string {
+	return `Update SSO group.
+
+Examples:
+  govc sso.group.update -d "Group description" NAME
+  govc sso.group.update -a user1 NAME
+  govc sso.group.update -r user2 NAME`
+}
+
+func (cmd *update) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+	id := f.Arg(0)
+
+	return sso.WithClient(ctx, cmd.ClientFlag, func(c *ssoadmin.Client) error {
+		if cmd.d != "" {
+			err := c.UpdateGroup(ctx, id, types.AdminGroupDetails{Description: cmd.d})
+			if err != nil {
+				return err
+			}
+		}
+
+		if cmd.a != "" {
+			user, err := c.FindUser(ctx, cmd.a)
+			if err != nil {
+				return err
+			}
+			if err = c.AddUsersToGroup(ctx, id, user.Id); err != nil {
+				return err
+			}
+		}
+
+		if cmd.r != "" {
+			user, err := c.FindUser(ctx, cmd.r)
+			if err != nil {
+				return err
+			}
+			if err = c.RemoveUsersFromGroup(ctx, id, user.Id); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/sso/service/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/sso/service/ls.go
@@ -1,0 +1,160 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/lookup"
+	"github.com/vmware/govmomi/lookup/types"
+)
+
+type ls struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+
+	long bool
+	url  bool
+
+	types.LookupServiceRegistrationFilter
+}
+
+func init() {
+	cli.Register("sso.service.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.long, "l", false, "Long listing format")
+	f.BoolVar(&cmd.url, "U", false, "List endpoint URL(s) only")
+
+	cmd.LookupServiceRegistrationFilter.EndpointType = new(types.LookupServiceRegistrationEndpointType)
+	cmd.LookupServiceRegistrationFilter.ServiceType = new(types.LookupServiceRegistrationServiceType)
+	f.StringVar(&cmd.SiteId, "s", "", "Site ID")
+	f.StringVar(&cmd.NodeId, "n", "", "Node ID")
+	f.StringVar(&cmd.ServiceType.Type, "t", "", "Service type")
+	f.StringVar(&cmd.ServiceType.Product, "p", "", "Service product")
+	f.StringVar(&cmd.EndpointType.Type, "T", "", "Endpoint type")
+	f.StringVar(&cmd.EndpointType.Protocol, "P", "", "Endpoint protocol")
+}
+
+func (cmd *ls) Description() string {
+	return `List platform services.
+
+Examples:
+  govc sso.service.ls
+  govc sso.service.ls -t vcenterserver -P vmomi
+  govc sso.service.ls -t cs.identity
+  govc sso.service.ls -t cs.identity -P wsTrust -U
+  govc sso.service.ls -t cs.identity -json | jq -r .[].ServiceEndpoints[].Url`
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.OutputFlag.Process(ctx)
+}
+
+type infoResult []types.LookupServiceRegistrationInfo
+
+func (r infoResult) Dump() interface{} {
+	return []types.LookupServiceRegistrationInfo(r)
+}
+
+func (r infoResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for _, info := range r {
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", info.ServiceType.Product, info.ServiceType.Type, info.ServiceId)
+	}
+
+	return tw.Flush()
+}
+
+type infoResultLong []types.LookupServiceRegistrationInfo
+
+func (r infoResultLong) Dump() interface{} {
+	return []types.LookupServiceRegistrationInfo(r)
+}
+
+func (r infoResultLong) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for _, info := range r {
+		for _, s := range info.ServiceEndpoints {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+				info.ServiceType.Product, info.ServiceType.Type, info.ServiceId,
+				s.EndpointType.Protocol, s.EndpointType.Type, s.Url)
+		}
+	}
+
+	return tw.Flush()
+}
+
+type infoResultURL []types.LookupServiceRegistrationInfo
+
+func (r infoResultURL) Dump() interface{} {
+	return []types.LookupServiceRegistrationInfo(r)
+}
+
+func (r infoResultURL) Write(w io.Writer) error {
+	for _, info := range r {
+		for _, s := range info.ServiceEndpoints {
+			fmt.Fprintln(w, s.Url)
+		}
+	}
+
+	return nil
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	vc, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	c, err := lookup.NewClient(ctx, vc)
+	if err != nil {
+		return err
+	}
+
+	info, err := c.List(ctx, &cmd.LookupServiceRegistrationFilter)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case cmd.long:
+		return cmd.WriteResult(infoResultLong(info))
+	case cmd.url:
+		return cmd.WriteResult(infoResultURL(info))
+	default:
+		return cmd.WriteResult(infoResult(info))
+	}
+}

--- a/vendor/github.com/vmware/govmomi/govc/sso/user/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/sso/user/create.go
@@ -1,0 +1,128 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package user
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/pem"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/govc/sso"
+	"github.com/vmware/govmomi/ssoadmin"
+	"github.com/vmware/govmomi/ssoadmin/types"
+)
+
+type userDetails struct {
+	*flags.ClientFlag
+
+	types.AdminPersonDetails
+	password string
+	solution types.AdminSolutionDetails
+	actas    *bool
+	role     string
+}
+
+func (cmd *userDetails) Usage() string {
+	return "NAME"
+}
+
+func (cmd *userDetails) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.Description, "d", "", "User description")
+	f.StringVar(&cmd.EmailAddress, "m", "", "Email address")
+	f.StringVar(&cmd.FirstName, "f", "", "First name")
+	f.StringVar(&cmd.LastName, "l", "", "Last name")
+	f.StringVar(&cmd.password, "p", "", "Password")
+	f.StringVar(&cmd.solution.Certificate, "C", "", "Certificate for solution user")
+	f.Var(flags.NewOptionalBool(&cmd.actas), "A", "ActAsUser role for solution user WSTrust")
+	f.StringVar(&cmd.role, "R", "", "Role for solution user (RegularUser|Administrator)")
+}
+
+func (cmd *userDetails) Certificate() string {
+	block, _ := pem.Decode([]byte(cmd.solution.Certificate))
+	if block != nil {
+		return base64.StdEncoding.EncodeToString(block.Bytes)
+	}
+	return cmd.solution.Certificate
+}
+
+type create struct {
+	userDetails
+}
+
+func init() {
+	cli.Register("sso.user.create", &create{})
+}
+
+func (cmd *create) Description() string {
+	return `Create SSO users.
+
+Examples:
+  govc sso.user.create -C "$(cat cert.pem)" -A -R Administrator NAME # solution user
+  govc sso.user.create -p password NAME # person user`
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+	id := f.Arg(0)
+	person := cmd.solution.Certificate == ""
+	if person {
+		if cmd.password == "" {
+			return flag.ErrHelp
+		}
+	} else {
+		if cmd.password != "" {
+			return flag.ErrHelp
+		}
+	}
+
+	return sso.WithClient(ctx, cmd.ClientFlag, func(c *ssoadmin.Client) error {
+		if person {
+			return c.CreatePersonUser(ctx, id, cmd.AdminPersonDetails, cmd.password)
+		}
+
+		cmd.solution.Certificate = cmd.Certificate()
+		cmd.solution.Description = cmd.AdminPersonDetails.Description
+
+		if err := c.CreateSolutionUser(ctx, id, cmd.solution); err != nil {
+			return err
+		}
+
+		p := types.PrincipalId{Name: id, Domain: c.Domain}
+
+		if cmd.role != "" {
+			if _, err := c.SetRole(ctx, p, cmd.role); err != nil {
+				return err
+			}
+		}
+
+		if cmd.actas != nil && *cmd.actas {
+			if _, err := c.GrantWSTrustRole(ctx, p, types.RoleActAsUser); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/sso/user/id.go
+++ b/vendor/github.com/vmware/govmomi/govc/sso/user/id.go
@@ -1,0 +1,114 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package user
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/govc/sso"
+	"github.com/vmware/govmomi/ssoadmin"
+	"github.com/vmware/govmomi/ssoadmin/types"
+)
+
+type id struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("sso.user.id", &id{})
+}
+
+func (cmd *id) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *id) Usage() string {
+	return "NAME"
+}
+
+func (cmd *id) Description() string {
+	return `Print SSO user and group IDs.
+
+Examples:
+  govc sso.user.id
+  govc sso.user.id Administrator
+  govc sso.user.id -json Administrator`
+}
+
+func (cmd *id) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.OutputFlag.Process(ctx)
+}
+
+type userID struct {
+	User  *types.AdminUser
+	Group []types.PrincipalId
+}
+
+func (r *userID) Write(w io.Writer) error {
+	var groups []string
+	for _, g := range r.Group {
+		groups = append(groups, g.Name)
+	}
+	fmt.Fprintf(w, "%s=%s@%s groups=%s\n", r.User.Kind, r.User.Id.Name, r.User.Id.Domain, strings.Join(groups, ","))
+	return nil
+}
+
+func (r *userID) Dump() interface{} {
+	return struct {
+		User  *types.AdminUser
+		Group []types.PrincipalId
+	}{r.User, r.Group}
+}
+
+func (cmd *id) Run(ctx context.Context, f *flag.FlagSet) error {
+	arg := f.Arg(0)
+	if arg == "" {
+		arg = cmd.Userinfo().Username()
+	}
+
+	return sso.WithClient(ctx, cmd.ClientFlag, func(c *ssoadmin.Client) error {
+		var err error
+		var u userID
+
+		if u.User, err = c.FindUser(ctx, arg); err != nil {
+			return err
+		}
+		if u.User == nil {
+			return fmt.Errorf("%q: no such user", arg)
+		}
+
+		if u.Group, err = c.FindParentGroups(ctx, u.User.Id); err != nil {
+			return err
+		}
+
+		return cmd.WriteResult(&u)
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/sso/user/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/sso/user/ls.go
@@ -1,0 +1,116 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package user
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/govc/sso"
+	"github.com/vmware/govmomi/ssoadmin"
+	"github.com/vmware/govmomi/ssoadmin/types"
+)
+
+type ls struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+
+	solution bool
+}
+
+func init() {
+	cli.Register("sso.user.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.solution, "s", false, "List solution users")
+}
+
+func (cmd *ls) Description() string {
+	return `List SSO users.
+
+Examples:
+  govc sso.user.ls -s`
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.OutputFlag.Process(ctx)
+}
+
+type solutionResult []types.AdminSolutionUser
+
+func (r solutionResult) Dump() interface{} {
+	return []types.AdminSolutionUser(r)
+}
+
+func (r solutionResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+	for _, info := range r {
+		fmt.Fprintf(tw, "%s\t%s\n", info.Id.Name, info.Details.Description)
+	}
+	return tw.Flush()
+}
+
+type personResult []types.AdminPersonUser
+
+func (r personResult) Dump() interface{} {
+	return []types.AdminPersonUser(r)
+}
+
+func (r personResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+	for _, info := range r {
+		fmt.Fprintf(tw, "%s\t%s\n", info.Id.Name, info.Details.Description)
+	}
+	return tw.Flush()
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	arg := f.Arg(0)
+
+	return sso.WithClient(ctx, cmd.ClientFlag, func(c *ssoadmin.Client) error {
+		if cmd.solution {
+			info, err := c.FindSolutionUsers(ctx, arg)
+			if err != nil {
+				return err
+			}
+
+			return cmd.WriteResult(solutionResult(info))
+		}
+
+		info, err := c.FindPersonUsers(ctx, arg)
+		if err != nil {
+			return err
+		}
+
+		return cmd.WriteResult(personResult(info))
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/sso/user/rm.go
+++ b/vendor/github.com/vmware/govmomi/govc/sso/user/rm.go
@@ -1,0 +1,57 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package user
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/govc/sso"
+	"github.com/vmware/govmomi/ssoadmin"
+)
+
+type rm struct {
+	*flags.ClientFlag
+}
+
+func init() {
+	cli.Register("sso.user.rm", &rm{})
+}
+
+func (cmd *rm) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+}
+
+func (cmd *rm) Usage() string {
+	return "NAME"
+}
+
+func (cmd *rm) Description() string {
+	return `Remove SSO users.
+
+Examples:
+  govc sso.user.rm NAME`
+}
+
+func (cmd *rm) Run(ctx context.Context, f *flag.FlagSet) error {
+	return sso.WithClient(ctx, cmd.ClientFlag, func(c *ssoadmin.Client) error {
+		return c.DeletePrincipal(ctx, f.Arg(0))
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/sso/user/update.go
+++ b/vendor/github.com/vmware/govmomi/govc/sso/user/update.go
@@ -1,0 +1,114 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package user
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/sso"
+	"github.com/vmware/govmomi/ssoadmin"
+	"github.com/vmware/govmomi/ssoadmin/types"
+)
+
+type update struct {
+	userDetails
+}
+
+func init() {
+	cli.Register("sso.user.update", &update{})
+}
+
+func (cmd *update) Description() string {
+	return `Update SSO users.
+
+Examples:
+  govc sso.user.update -C "$(cat cert.pem)" NAME
+  govc sso.user.update -p password NAME`
+}
+
+// merge uses the current value of a field if the corresponding flag was not set.
+// Otherwise the API call would set the current fields to empty strings.
+func merge(src *string, current string) {
+	if *src == "" {
+		*src = current
+	}
+}
+
+func (cmd *update) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+	id := f.Arg(0)
+
+	return sso.WithClient(ctx, cmd.ClientFlag, func(c *ssoadmin.Client) error {
+		user, err := c.FindUser(ctx, id)
+		if err != nil {
+			return err
+		}
+
+		if user.Kind == "person" {
+			current, cerr := c.FindPersonUser(ctx, id)
+			if cerr != nil {
+				return cerr
+			}
+
+			merge(&cmd.AdminPersonDetails.Description, current.Details.Description)
+			merge(&cmd.FirstName, current.Details.FirstName)
+			merge(&cmd.LastName, current.Details.LastName)
+			merge(&cmd.EmailAddress, current.Details.EmailAddress)
+			if err := c.UpdatePersonUser(ctx, id, cmd.AdminPersonDetails); err != nil {
+				return err
+			}
+
+			if cmd.password != "" {
+				return c.ResetPersonPassword(ctx, id, cmd.password)
+			}
+
+			return nil
+		}
+
+		if cmd.actas != nil {
+			action := c.GrantWSTrustRole
+			if !*cmd.actas {
+				action = c.RevokeWSTrustRole
+			}
+			if _, err := action(ctx, user.Id, types.RoleActAsUser); err != nil {
+				return err
+			}
+		}
+
+		if cmd.role != "" {
+			if _, err := c.SetRole(ctx, user.Id, cmd.role); err != nil {
+				return err
+			}
+		}
+
+		cmd.solution.Certificate = cmd.Certificate()
+		cmd.solution.Description = cmd.AdminPersonDetails.Description
+
+		current, cerr := c.FindSolutionUser(ctx, id)
+		if cerr != nil {
+			return cerr
+		}
+
+		merge(&cmd.solution.Certificate, current.Details.Certificate)
+		merge(&cmd.solution.Description, current.Details.Description)
+		return c.UpdateSolutionUser(ctx, id, cmd.solution)
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/tags/association/attach.go
+++ b/vendor/github.com/vmware/govmomi/govc/tags/association/attach.go
@@ -1,0 +1,111 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package association
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/library/finder"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/tags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type attach struct {
+	*flags.DatacenterFlag
+	cat string
+}
+
+func init() {
+	cli.Register("tags.attach", &attach{})
+}
+
+func (cmd *attach) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.cat, "c", "", "Tag category")
+}
+
+func (cmd *attach) Usage() string {
+	return "NAME PATH"
+}
+
+func (cmd *attach) Description() string {
+	return `Attach tag NAME to object PATH.
+
+Examples:
+  govc tags.attach k8s-region-us /dc1
+  govc tags.attach -c k8s-region us-ca1 /dc1/host/cluster1`
+}
+
+func convertPath(ctx context.Context, c *rest.Client, cmd *flags.DatacenterFlag, managedObj string) (*types.ManagedObjectReference, error) {
+	client, err := cmd.ClientFlag.Client()
+	if err != nil {
+		return nil, err
+	}
+
+	ref := client.ServiceContent.RootFolder
+
+	switch managedObj {
+	case "", "-":
+	default:
+		ref, err = cmd.ManagedObject(ctx, managedObj)
+		if err != nil {
+			m := library.NewManager(c)
+			res, _ := finder.NewFinder(m).Find(ctx, managedObj)
+			if len(res) != 1 {
+				return nil, err
+			}
+			switch t := res[0].GetResult().(type) {
+			case library.Library:
+				ref = types.ManagedObjectReference{Type: "com.vmware.content.Library", Value: t.ID}
+			case library.Item:
+				ref = types.ManagedObjectReference{Type: "com.vmware.content.library.Item", Value: t.ID}
+			default:
+				return nil, err
+			}
+		}
+	}
+	return &ref, nil
+}
+
+func (cmd *attach) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 2 {
+		return flag.ErrHelp
+	}
+
+	tagID := f.Arg(0)
+	managedObj := f.Arg(1)
+
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		ref, err := convertPath(ctx, c, cmd.DatacenterFlag, managedObj)
+		if err != nil {
+			return err
+		}
+		m := tags.NewManager(c)
+		tag, err := m.GetTagForCategory(ctx, tagID, cmd.cat)
+		if err != nil {
+			return err
+		}
+		return m.AttachTag(ctx, tag.ID, ref)
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/tags/association/detach.go
+++ b/vendor/github.com/vmware/govmomi/govc/tags/association/detach.go
@@ -1,0 +1,77 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package association
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/tags"
+)
+
+type detach struct {
+	*flags.DatacenterFlag
+	cat string
+}
+
+func init() {
+	cli.Register("tags.detach", &detach{})
+}
+
+func (cmd *detach) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.cat, "c", "", "Tag category")
+}
+
+func (cmd *detach) Usage() string {
+	return "NAME PATH"
+}
+
+func (cmd *detach) Description() string {
+	return `Detach tag NAME from object PATH.
+
+Examples:
+  govc tags.detach k8s-region-us /dc1
+  govc tags.detach -c k8s-region us-ca1 /dc1/host/cluster1`
+}
+
+func (cmd *detach) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 2 {
+		return flag.ErrHelp
+	}
+
+	tagID := f.Arg(0)
+	managedObj := f.Arg(1)
+
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		ref, err := convertPath(ctx, c, cmd.DatacenterFlag, managedObj)
+		if err != nil {
+			return err
+		}
+		m := tags.NewManager(c)
+		tag, err := m.GetTagForCategory(ctx, tagID, cmd.cat)
+		if err != nil {
+			return err
+		}
+		return m.DetachTag(ctx, tag.ID, ref)
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/tags/association/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/tags/association/ls.go
@@ -1,0 +1,152 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package association
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/tags"
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+type ls struct {
+	*flags.DatacenterFlag
+	r bool
+	l bool
+}
+
+func init() {
+	cli.Register("tags.attached.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+	f.BoolVar(&cmd.r, "r", false, "List tags attached to resource")
+	f.BoolVar(&cmd.l, "l", false, "Long listing format")
+}
+
+func (cmd *ls) Usage() string {
+	return "NAME"
+}
+
+func (cmd *ls) Description() string {
+	return `List attached tags or objects.
+
+Examples:
+  govc tags.attached.ls k8s-region-us
+  govc tags.attached.ls -json k8s-zone-us-ca1 | jq .
+  govc tags.attached.ls -r /dc1/host/cluster1
+  govc tags.attached.ls -json -r /dc1 | jq .`
+}
+
+type lsResult []string
+
+func (r lsResult) Write(w io.Writer) error {
+	for i := range r {
+		fmt.Fprintln(w, r[i])
+	}
+	return nil
+}
+
+type lsTagResult []tags.AttachedTags
+
+func (r lsTagResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+	for _, item := range r {
+		var ids []string
+		for _, id := range item.Tags {
+			ids = append(ids, id.Name)
+		}
+		fmt.Fprintf(tw, "%s:\t%s\n", item.ObjectID.Reference(), strings.Join(ids, ","))
+	}
+	return tw.Flush()
+}
+
+type lsObjectResult []tags.AttachedObjects
+
+func (r lsObjectResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+	for _, item := range r {
+		for _, id := range item.ObjectIDs {
+			var ids []string
+			ids = append(ids, id.Reference().String())
+			fmt.Fprintf(tw, "%s:\t%s\n", item.Tag.Name, strings.Join(ids, ","))
+		}
+
+	}
+	return tw.Flush()
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		var res flags.OutputWriter
+		m := tags.NewManager(c)
+
+		if cmd.r {
+			var refs []mo.Reference
+			for _, arg := range f.Args() {
+				ref, err := convertPath(ctx, c, cmd.DatacenterFlag, arg)
+				if err != nil {
+					return err
+				}
+				refs = append(refs, ref)
+			}
+			attached, err := m.GetAttachedTagsOnObjects(ctx, refs)
+			if err != nil {
+				return err
+			}
+			if cmd.l {
+				res = lsTagResult(attached)
+			} else {
+				var r lsResult
+				for i := range attached {
+					for _, tag := range attached[i].Tags {
+						r = append(r, tag.Name)
+					}
+				}
+				res = r
+			}
+		} else {
+			attached, err := m.GetAttachedObjectsOnTags(ctx, f.Args())
+			if err != nil {
+				return err
+			}
+			if cmd.l {
+				res = lsObjectResult(attached)
+			} else {
+				var r lsResult
+				for _, obj := range attached {
+					for _, ref := range obj.ObjectIDs {
+						r = append(r, ref.Reference().String())
+					}
+				}
+				res = r
+			}
+		}
+
+		return cmd.WriteResult(res)
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/tags/category/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/tags/category/create.go
@@ -1,0 +1,97 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package category
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/tags"
+)
+
+type create struct {
+	*flags.ClientFlag
+	cat   tags.Category
+	multi bool
+}
+
+func init() {
+	cli.Register("tags.category.create", &create{})
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+	f.StringVar(&cmd.cat.Description, "d", "", "Description")
+	f.Var((*kinds)(&cmd.cat.AssociableTypes), "t", "Object types")
+	f.BoolVar(&cmd.multi, "m", false, "Allow multiple tags per object")
+}
+
+type kinds []string
+
+func (e *kinds) String() string {
+	return fmt.Sprint(*e)
+}
+
+func (e *kinds) Set(value string) error {
+	*e = append(*e, value)
+	return nil
+}
+
+func cardinality(multi bool) string {
+	if multi {
+		return "MULTIPLE"
+	}
+	return "SINGLE"
+}
+
+func (cmd *create) Usage() string {
+	return "NAME"
+}
+
+func (cmd *create) Description() string {
+	return `Create tag category.
+
+This command will output the ID of the new tag category.
+
+Examples:
+  govc tags.category.create -d "Kubernetes region" -t Datacenter k8s-region
+  govc tags.category.create -d "Kubernetes zone" k8s-zone`
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	cmd.cat.Name = f.Arg(0)
+	cmd.cat.Cardinality = cardinality(cmd.multi)
+
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		id, err := tags.NewManager(c).CreateCategory(ctx, &cmd.cat)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(id)
+		return nil
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/tags/category/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/tags/category/info.go
@@ -1,0 +1,110 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package category
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/tags"
+)
+
+type info struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("tags.category.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.OutputFlag.Process(ctx)
+}
+
+func (cmd *info) Usage() string {
+	return "[NAME]"
+}
+
+func (cmd *info) Description() string {
+	return `Display category info.
+
+If NAME is provided, display info for only that category.
+Otherwise display info for all categories.
+
+Examples:
+  govc tags.category.info
+  govc tags.category.info k8s-zone`
+}
+
+type infoResult []tags.Category
+
+func (t infoResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for _, item := range t {
+		fmt.Fprintf(tw, "Name:\t%s\n", item.Name)
+		fmt.Fprintf(tw, "  ID:\t%s\n", item.ID)
+		fmt.Fprintf(tw, "  Description:\t%s\n", item.Description)
+		fmt.Fprintf(tw, "  Cardinality:\t%s\n", item.Cardinality)
+		fmt.Fprintf(tw, "  AssociableTypes:\t%s\n", item.AssociableTypes)
+		fmt.Fprintf(tw, "  UsedBy: \t%s\n", item.UsedBy)
+	}
+
+	return tw.Flush()
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	arg := f.Arg(0)
+
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		m := tags.NewManager(c)
+		var res infoResult
+		var err error
+
+		if f.NArg() == 1 {
+			cat, cerr := m.GetCategory(ctx, arg)
+			if cerr != nil {
+				return cerr
+			}
+			res = append(res, *cat)
+		} else {
+			res, err = m.GetCategories(ctx)
+			if err != nil {
+				return err
+			}
+		}
+
+		return cmd.WriteResult(res)
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/tags/category/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/tags/category/ls.go
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package category
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/tags"
+)
+
+type ls struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("tags.category.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.OutputFlag.Process(ctx)
+}
+
+func (cmd *ls) Description() string {
+	return `List all categories.
+
+Examples:
+  govc tags.category.ls
+  govc tags.category.ls -json | jq .`
+}
+
+type lsResult []tags.Category
+
+func (r lsResult) Write(w io.Writer) error {
+	for _, c := range r {
+		fmt.Fprintln(w, c.Name)
+	}
+	return nil
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		l, err := tags.NewManager(c).GetCategories(ctx)
+		if err != nil {
+			return err
+		}
+
+		return cmd.WriteResult(lsResult(l))
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/tags/category/rm.go
+++ b/vendor/github.com/vmware/govmomi/govc/tags/category/rm.go
@@ -1,0 +1,82 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package category
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/tags"
+)
+
+type rm struct {
+	*flags.ClientFlag
+	force bool
+}
+
+func init() {
+	cli.Register("tags.category.rm", &rm{})
+}
+
+func (cmd *rm) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+	f.BoolVar(&cmd.force, "f", false, "Delete tag regardless of attached objects")
+}
+
+func (cmd *rm) Usage() string {
+	return "NAME"
+}
+
+func (cmd *rm) Description() string {
+	return `Delete category NAME.
+
+Fails if category is used by any tag, unless the '-f' flag is provided.
+
+Examples:
+  govc tags.category.rm k8s-region
+  govc tags.category.rm -f k8s-zone`
+}
+
+func (cmd *rm) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+	categoryID := f.Arg(0)
+
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		m := tags.NewManager(c)
+		cat, err := m.GetCategory(ctx, categoryID)
+		if err != nil {
+			return err
+		}
+		if !cmd.force {
+			ctags, err := m.ListTagsForCategory(ctx, cat.ID)
+			if err != nil {
+				return err
+			}
+			if len(ctags) > 0 {
+				return fmt.Errorf("category %s used by %d tags", categoryID, len(ctags))
+			}
+		}
+		return m.DeleteCategory(ctx, cat)
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/tags/category/update.go
+++ b/vendor/github.com/vmware/govmomi/govc/tags/category/update.go
@@ -1,0 +1,90 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package category
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/tags"
+)
+
+type update struct {
+	*flags.ClientFlag
+	cat   tags.Category
+	multi *bool
+}
+
+func init() {
+	cli.Register("tags.category.update", &update{})
+}
+
+func (cmd *update) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+	f.StringVar(&cmd.cat.Name, "n", "", "Name of category")
+	f.StringVar(&cmd.cat.Description, "d", "", "Description")
+	f.Var((*kinds)(&cmd.cat.AssociableTypes), "t", "Object types")
+	f.Var(flags.NewOptionalBool(&cmd.multi), "m", "Allow multiple tags per object")
+}
+
+func (cmd *update) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *update) Usage() string {
+	return "NAME"
+}
+
+func (cmd *update) Description() string {
+	return `Update category.
+
+The '-t' flag can only be used to add new object types.  Removing category types is not supported by vCenter.
+
+Examples:
+  govc tags.category.update -n k8s-vcp-region -d "Kubernetes VCP region" k8s-region
+  govc tags.category.update -t ClusterComputeResource k8s-zone`
+}
+
+func (cmd *update) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	arg := f.Arg(0)
+
+	if cmd.multi != nil {
+		cmd.cat.Cardinality = cardinality(*cmd.multi)
+	}
+
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		m := tags.NewManager(c)
+		cat, err := m.GetCategory(ctx, arg)
+		if err != nil {
+			return err
+		}
+		cat.Patch(&cmd.cat)
+
+		return m.UpdateCategory(ctx, cat)
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/tags/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/tags/create.go
@@ -1,0 +1,83 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tags
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/tags"
+)
+
+type create struct {
+	*flags.ClientFlag
+	tag tags.Tag
+}
+
+func init() {
+	cli.Register("tags.create", &create{})
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+	f.StringVar(&cmd.tag.CategoryID, "c", "", "Category name")
+	f.StringVar(&cmd.tag.Description, "d", "", "Description of tag")
+}
+
+func (cmd *create) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *create) Usage() string {
+	return "NAME"
+}
+
+func (cmd *create) Description() string {
+	return `Create tag.
+
+The '-c' option to specify a tag category is required.
+This command will output the ID of the new tag.
+
+Examples:
+  govc tags.create -d "Kubernetes Zone US CA1" -c k8s-zone k8s-zone-us-ca1`
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 || cmd.tag.CategoryID == "" {
+		return flag.ErrHelp
+	}
+
+	cmd.tag.Name = f.Arg(0)
+
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		id, err := tags.NewManager(c).CreateTag(ctx, &cmd.tag)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(id)
+		return nil
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/tags/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/tags/info.go
@@ -1,0 +1,135 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tags
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/tags"
+)
+
+type info struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+	c string
+	C bool
+}
+
+func init() {
+	cli.Register("tags.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+	cmd.OutputFlag.Register(ctx, f)
+	f.StringVar(&cmd.c, "c", "", "Category name")
+	f.BoolVar(&cmd.C, "C", true, "Display category name instead of ID")
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.OutputFlag.Process(ctx)
+}
+
+func (cmd *info) Usage() string {
+	return "NAME"
+}
+
+func (cmd *info) Description() string {
+	return `Display tags info.
+
+If NAME is provided, display info for only that tag.  Otherwise display info for all tags.
+
+Examples:
+  govc tags.info
+  govc tags.info k8s-zone-us-ca1
+  govc tags.info -c k8s-zone`
+}
+
+type infoResult []tags.Tag
+
+func (t infoResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for _, item := range t {
+		fmt.Fprintf(tw, "Name:\t%s\n", item.Name)
+		fmt.Fprintf(tw, "  ID:\t%s\n", item.ID)
+		fmt.Fprintf(tw, "  Description:\t%s\n", item.Description)
+		fmt.Fprintf(tw, "  Category:\t%s\n", item.CategoryID)
+		fmt.Fprintf(tw, "  UsedBy: %s\n", item.UsedBy)
+	}
+
+	return tw.Flush()
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		m := tags.NewManager(c)
+		var res lsResult
+		var err error
+
+		if cmd.c == "" {
+			res, err = m.GetTags(ctx)
+		} else {
+			res, err = m.GetTagsForCategory(ctx, cmd.c)
+		}
+		if err != nil {
+			return err
+		}
+
+		if f.NArg() == 1 {
+			arg := f.Arg(0)
+			src := res
+			res = nil
+			for i := range src {
+				if src[i].Name == arg || src[i].ID == arg {
+					res = append(res, src[i])
+				}
+			}
+			if len(res) == 0 {
+				return fmt.Errorf("tag %q not found", arg)
+			}
+		}
+
+		if cmd.C {
+			categories, err := m.GetCategories(ctx)
+			if err != nil {
+				return err
+			}
+			m := make(map[string]tags.Category)
+			for _, category := range categories {
+				m[category.ID] = category
+			}
+			for i := range res {
+				res[i].CategoryID = m[res[i].CategoryID].Name
+			}
+		}
+
+		return cmd.WriteResult(infoResult(res))
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/tags/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/tags/ls.go
@@ -1,0 +1,110 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tags
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/tags"
+)
+
+type ls struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+	c string
+}
+
+func init() {
+	cli.Register("tags.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+	cmd.OutputFlag.Register(ctx, f)
+	f.StringVar(&cmd.c, "c", "", "Category name")
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ls) Description() string {
+	return `List tags.
+
+Examples:
+  govc tags.ls
+  govc tags.ls -c k8s-zone
+  govc tags.ls -json | jq .
+  govc tags.ls -c k8s-region -json | jq .`
+}
+
+type lsResult []tags.Tag
+
+func (r lsResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for i := range r {
+		fmt.Fprintf(tw, "%s\t%s\n", r[i].Name, r[i].CategoryID)
+	}
+
+	return tw.Flush()
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		m := tags.NewManager(c)
+		var res lsResult
+		var err error
+
+		if cmd.c == "" {
+			res, err = m.GetTags(ctx)
+		} else {
+			res, err = m.GetTagsForCategory(ctx, cmd.c)
+		}
+
+		if err != nil {
+			return err
+		}
+
+		categories, err := m.GetCategories(ctx)
+		if err != nil {
+			return err
+		}
+		cats := make(map[string]tags.Category)
+		for _, category := range categories {
+			cats[category.ID] = category
+		}
+
+		for i, tag := range res {
+			res[i].CategoryID = cats[tag.CategoryID].Name
+		}
+
+		return cmd.WriteResult(res)
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/tags/rm.go
+++ b/vendor/github.com/vmware/govmomi/govc/tags/rm.go
@@ -1,0 +1,87 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tags
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/tags"
+)
+
+type rm struct {
+	*flags.ClientFlag
+
+	cat   string
+	force bool
+}
+
+func init() {
+	cli.Register("tags.rm", &rm{})
+}
+
+func (cmd *rm) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.cat, "c", "", "Tag category")
+	f.BoolVar(&cmd.force, "f", false, "Delete tag regardless of attached objects")
+}
+
+func (cmd *rm) Usage() string {
+	return "NAME"
+}
+
+func (cmd *rm) Description() string {
+	return `Delete tag NAME.
+
+Fails if tag is attached to any object, unless the '-f' flag is provided.
+
+Examples:
+  govc tags.rm k8s-zone-us-ca1
+  govc tags.rm -f -c k8s-zone us-ca2`
+}
+
+func (cmd *rm) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	tagID := f.Arg(0)
+
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		m := tags.NewManager(c)
+		if !cmd.force {
+			objs, err := m.ListAttachedObjects(ctx, tagID)
+			if err != nil {
+				return err
+			}
+			if len(objs) > 0 {
+				return fmt.Errorf("tag %s has %d attached objects", tagID, len(objs))
+			}
+		}
+		tag, err := m.GetTagForCategory(ctx, tagID, cmd.cat)
+		if err != nil {
+			return err
+		}
+		return m.DeleteTag(ctx, tag)
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/tags/update.go
+++ b/vendor/github.com/vmware/govmomi/govc/tags/update.go
@@ -1,0 +1,76 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tags
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/tags"
+)
+
+type update struct {
+	*flags.ClientFlag
+
+	tag tags.Tag
+	cat string
+}
+
+func init() {
+	cli.Register("tags.update", &update{})
+}
+
+func (cmd *update) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.tag.Name, "n", "", "Name of tag")
+	f.StringVar(&cmd.tag.Description, "d", "", "Description of tag")
+	f.StringVar(&cmd.cat, "c", "", "Tag category")
+}
+
+func (cmd *update) Usage() string {
+	return "NAME"
+}
+
+func (cmd *update) Description() string {
+	return `Update tag.
+
+Examples:
+  govc tags.update -d "K8s zone US-CA1" k8s-zone-us-ca1
+  govc tags.update -d "K8s zone US-CA1" -c k8s-zone us-ca1`
+}
+
+func (cmd *update) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+	arg := f.Arg(0)
+
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		m := tags.NewManager(c)
+		tag, err := m.GetTagForCategory(ctx, arg, cmd.cat)
+		if err != nil {
+			return err
+		}
+		tag.Patch(&cmd.tag)
+		return m.UpdateTag(ctx, tag)
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/task/cancel.go
+++ b/vendor/github.com/vmware/govmomi/govc/task/cancel.go
@@ -1,0 +1,81 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package task
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type cancel struct {
+	*flags.ClientFlag
+}
+
+func init() {
+	cli.Register("task.cancel", &cancel{})
+}
+
+func (cmd *cancel) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+}
+
+func (cmd *cancel) Description() string {
+	return `Cancel tasks.
+
+Examples:
+  govc task.cancel task-759`
+}
+
+func (cmd *cancel) Usage() string {
+	return "ID..."
+}
+
+func (cmd *cancel) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *cancel) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	for _, id := range f.Args() {
+		var ref types.ManagedObjectReference
+
+		if !ref.FromString(id) {
+			ref.Type = "Task"
+			ref.Value = id
+		}
+
+		err = object.NewTask(c, ref).Cancel(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/task/recent.go
+++ b/vendor/github.com/vmware/govmomi/govc/task/recent.go
@@ -1,0 +1,221 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package task
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/view"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type recent struct {
+	*flags.DatacenterFlag
+
+	max    int
+	follow bool
+	long   bool
+}
+
+func init() {
+	cli.Register("tasks", &recent{})
+}
+
+func (cmd *recent) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	f.IntVar(&cmd.max, "n", 25, "Output the last N tasks")
+	f.BoolVar(&cmd.follow, "f", false, "Follow recent task updates")
+	f.BoolVar(&cmd.long, "l", false, "Use long task description")
+}
+
+func (cmd *recent) Description() string {
+	return `Display info for recent tasks.
+
+When a task has completed, the result column includes the task duration on success or
+error message on failure.  If a task is still in progress, the result column displays
+the completion percentage and the task ID.  The task ID can be used as an argument to
+the 'task.cancel' command.
+
+By default, all recent tasks are included (via TaskManager), but can be limited by PATH
+to a specific inventory object.
+
+Examples:
+  govc tasks
+  govc tasks -f
+  govc tasks -f /dc1/host/cluster1`
+}
+
+func (cmd *recent) Usage() string {
+	return "[PATH]"
+}
+
+func (cmd *recent) Process(ctx context.Context) error {
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func chop(s string, n int) string {
+	if len(s) < n {
+		return s
+	}
+
+	return s[:n-1] + "*"
+}
+
+// taskName describes the tasks similar to the ESX ui
+func taskName(info *types.TaskInfo) string {
+	name := strings.TrimSuffix(info.Name, "_Task")
+	switch name {
+	case "":
+		return info.DescriptionId
+	case "Destroy", "Rename":
+		return info.Entity.Type + "." + name
+	default:
+		return name
+	}
+}
+
+func (cmd *recent) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m := c.ServiceContent.TaskManager
+
+	tn := taskName
+
+	if cmd.long {
+		var o mo.TaskManager
+		err = property.DefaultCollector(c).RetrieveOne(ctx, *m, []string{"description.methodInfo"}, &o)
+		if err != nil {
+			return err
+		}
+
+		desc := make(map[string]string, len(o.Description.MethodInfo))
+
+		for _, entry := range o.Description.MethodInfo {
+			info := entry.GetElementDescription()
+			desc[info.Key] = info.Label
+		}
+
+		tn = func(info *types.TaskInfo) string {
+			if name, ok := desc[info.DescriptionId]; ok {
+				return name
+			}
+
+			return taskName(info)
+		}
+	}
+
+	watch := *m
+
+	if f.NArg() == 1 {
+		refs, merr := cmd.ManagedObjects(ctx, f.Args())
+		if merr != nil {
+			return merr
+		}
+		watch = refs[0]
+	}
+
+	v, err := view.NewManager(c).CreateTaskView(ctx, &watch)
+	if err != nil {
+		return nil
+	}
+
+	defer func() {
+		_ = v.Destroy(context.Background())
+	}()
+
+	v.Follow = cmd.follow
+
+	stamp := "15:04:05"
+	tmpl := "%-40s %-30s %-30s %9s %9s %9s %s\n"
+	fmt.Fprintf(cmd.Out, tmpl, "Task", "Target", "Initiator", "Queued", "Started", "Completed", "Result")
+
+	var last string
+	updated := false
+
+	return v.Collect(ctx, func(tasks []types.TaskInfo) {
+		if !updated && len(tasks) > cmd.max {
+			tasks = tasks[len(tasks)-cmd.max:]
+		}
+		updated = true
+
+		for _, info := range tasks {
+			var user string
+
+			switch x := info.Reason.(type) {
+			case *types.TaskReasonUser:
+				user = x.UserName
+			}
+
+			if info.EntityName == "" || user == "" {
+				continue
+			}
+
+			ruser := strings.SplitN(user, "\\", 2)
+			if len(ruser) == 2 {
+				user = ruser[1] // discard domain
+			} else {
+				user = strings.TrimPrefix(user, "com.vmware.") // e.g. com.vmware.vsan.health
+			}
+
+			queued := info.QueueTime.Format(stamp)
+			start := "-"
+			end := start
+
+			if info.StartTime != nil {
+				start = info.StartTime.Format(stamp)
+			}
+
+			msg := fmt.Sprintf("%2d%% %s", info.Progress, info.Task)
+
+			if info.CompleteTime != nil {
+				msg = info.CompleteTime.Sub(*info.StartTime).String()
+
+				if info.State == types.TaskInfoStateError {
+					msg = strings.TrimSuffix(info.Error.LocalizedMessage, ".")
+				}
+
+				end = info.CompleteTime.Format(stamp)
+			}
+
+			result := fmt.Sprintf("%-7s [%s]", info.State, msg)
+
+			item := fmt.Sprintf(tmpl, chop(tn(&info), 40), chop(info.EntityName, 30), chop(user, 30), queued, start, end, result)
+
+			if item == last {
+				continue // task info was updated, but the fields we display were not
+			}
+			last = item
+
+			fmt.Fprint(cmd.Out, item)
+		}
+	})
+}

--- a/vendor/github.com/vmware/govmomi/govc/vapp/destroy.go
+++ b/vendor/github.com/vmware/govmomi/govc/vapp/destroy.go
@@ -1,0 +1,115 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vapp
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type destroy struct {
+	*flags.DatacenterFlag
+}
+
+func init() {
+	cli.Register("vapp.destroy", &destroy{})
+}
+
+func (cmd *destroy) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+}
+
+func (cmd *destroy) Process(ctx context.Context) error {
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *destroy) Usage() string {
+	return "VAPP..."
+}
+
+func (cmd *destroy) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	for _, arg := range f.Args() {
+		vapps, err := finder.VirtualAppList(ctx, arg)
+		if err != nil {
+			if _, ok := err.(*find.NotFoundError); ok {
+				// Ignore if vapp cannot be found
+				continue
+			}
+
+			return err
+		}
+
+		for _, vapp := range vapps {
+			powerOff := func() error {
+				task, err := vapp.PowerOff(ctx, false)
+				if err != nil {
+					return err
+				}
+				err = task.Wait(ctx)
+				if err != nil {
+					// it's safe to ignore if the vapp is already powered off
+					if f, ok := err.(types.HasFault); ok {
+						switch f.Fault().(type) {
+						case *types.InvalidPowerState:
+							return nil
+						}
+					}
+					return err
+				}
+				return nil
+			}
+			if err := powerOff(); err != nil {
+				return err
+			}
+
+			destroy := func() error {
+				task, err := vapp.Destroy(ctx)
+				if err != nil {
+					return err
+				}
+				err = task.Wait(ctx)
+				if err != nil {
+					return err
+				}
+				return nil
+			}
+			if err := destroy(); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/vapp/power.go
+++ b/vendor/github.com/vmware/govmomi/govc/vapp/power.go
@@ -1,0 +1,112 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vapp
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type power struct {
+	*flags.SearchFlag
+
+	On      bool
+	Off     bool
+	Suspend bool
+	Force   bool
+}
+
+func init() {
+	cli.Register("vapp.power", &power{})
+}
+
+func (cmd *power) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.SearchFlag, ctx = flags.NewSearchFlag(ctx, flags.SearchVirtualApps)
+	cmd.SearchFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.On, "on", false, "Power on")
+	f.BoolVar(&cmd.Off, "off", false, "Power off")
+	f.BoolVar(&cmd.Suspend, "suspend", false, "Power suspend")
+	f.BoolVar(&cmd.Force, "force", false, "Force (If force is false, the shutdown order in the vApp is executed. If force is true, all virtual machines are powered-off (regardless of shutdown order))")
+}
+
+func (cmd *power) Process(ctx context.Context) error {
+	if err := cmd.SearchFlag.Process(ctx); err != nil {
+		return err
+	}
+	opts := []bool{cmd.On, cmd.Off, cmd.Suspend}
+	selected := false
+
+	for _, opt := range opts {
+		if opt {
+			if selected {
+				return flag.ErrHelp
+			}
+			selected = opt
+		}
+	}
+
+	if !selected {
+		return flag.ErrHelp
+	}
+
+	return nil
+}
+
+func (cmd *power) Run(ctx context.Context, f *flag.FlagSet) error {
+	vapps, err := cmd.VirtualApps(f.Args())
+	if err != nil {
+		return err
+	}
+
+	for _, vapp := range vapps {
+		var task *object.Task
+
+		switch {
+		case cmd.On:
+			fmt.Fprintf(cmd, "Powering on %s... ", vapp.Reference())
+			task, err = vapp.PowerOn(ctx)
+		case cmd.Off:
+			fmt.Fprintf(cmd, "Powering off %s... ", vapp.Reference())
+			task, err = vapp.PowerOff(ctx, cmd.Force)
+		case cmd.Suspend:
+			fmt.Fprintf(cmd, "Suspend %s... ", vapp.Reference())
+			task, err = vapp.Suspend(ctx)
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if task != nil {
+			err = task.Wait(ctx)
+		}
+		if err == nil {
+			fmt.Fprintf(cmd, "OK\n")
+			continue
+		}
+
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/version/command.go
+++ b/vendor/github.com/vmware/govmomi/govc/version/command.go
@@ -1,0 +1,67 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type version struct {
+	*flags.EmptyFlag
+
+	require string
+}
+
+func init() {
+	cli.Register("version", &version{})
+}
+
+func (cmd *version) Register(ctx context.Context, f *flag.FlagSet) {
+	f.StringVar(&cmd.require, "require", "", "Require govc version >= this value")
+}
+
+func (cmd *version) Run(ctx context.Context, f *flag.FlagSet) error {
+	ver := flags.GitVersion
+	if ver == "" {
+		ver = flags.Version
+	}
+
+	if cmd.require != "" {
+		v, err := flags.ParseVersion(ver)
+		if err != nil {
+			panic(err)
+		}
+
+		rv, err := flags.ParseVersion(cmd.require)
+		if err != nil {
+			return fmt.Errorf("failed to parse required version '%s': %s", cmd.require, err)
+		}
+
+		if !rv.Lte(v) {
+			return fmt.Errorf("version %s or higher is required, this is version %s", cmd.require, ver)
+		}
+	}
+
+	fmt.Printf("govc %s\n", ver)
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/change.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/change.go
@@ -1,0 +1,185 @@
+/*
+Copyright (c) 2015-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vm
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type extraConfig []types.BaseOptionValue
+
+func (e *extraConfig) String() string {
+	return fmt.Sprintf("%v", *e)
+}
+
+func (e *extraConfig) Set(v string) error {
+	r := strings.SplitN(v, "=", 2)
+	if len(r) < 2 {
+		return fmt.Errorf("failed to parse extraConfig: %s", v)
+	}
+	*e = append(*e, &types.OptionValue{Key: r[0], Value: r[1]})
+	return nil
+}
+
+type change struct {
+	*flags.VirtualMachineFlag
+	*flags.ResourceAllocationFlag
+
+	types.VirtualMachineConfigSpec
+	extraConfig extraConfig
+	Latency     string
+}
+
+func init() {
+	cli.Register("vm.change", &change{})
+}
+
+var latencyLevels = []string{
+	string(types.LatencySensitivitySensitivityLevelLow),
+	string(types.LatencySensitivitySensitivityLevelNormal),
+	string(types.LatencySensitivitySensitivityLevelHigh),
+}
+
+// setLatency validates latency level if set
+func (cmd *change) setLatency() error {
+	if cmd.Latency == "" {
+		return nil
+	}
+	for _, l := range latencyLevels {
+		if l == cmd.Latency {
+			cmd.LatencySensitivity = &types.LatencySensitivity{
+				Level: types.LatencySensitivitySensitivityLevel(cmd.Latency),
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("latency must be one of: %s", strings.Join(latencyLevels, "|"))
+}
+
+// setAllocation sets *info=nil if none of the fields have been set.
+// We need non-nil fields for use with flag.FlagSet, but we want the
+// VirtualMachineConfigSpec fields to be nil if none of the related flags were given.
+func setAllocation(info **types.ResourceAllocationInfo) {
+	r := *info
+
+	if r.Shares.Level == "" {
+		r.Shares = nil
+	} else {
+		return
+	}
+
+	if r.Limit != nil {
+		return
+	}
+
+	if r.Reservation != nil {
+		return
+	}
+
+	*info = nil
+}
+
+func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	cmd.CpuAllocation = &types.ResourceAllocationInfo{Shares: new(types.SharesInfo)}
+	cmd.MemoryAllocation = &types.ResourceAllocationInfo{Shares: new(types.SharesInfo)}
+	cmd.ResourceAllocationFlag = flags.NewResourceAllocationFlag(cmd.CpuAllocation, cmd.MemoryAllocation)
+	cmd.ResourceAllocationFlag.ExpandableReservation = false
+	cmd.ResourceAllocationFlag.Register(ctx, f)
+
+	f.Int64Var(&cmd.MemoryMB, "m", 0, "Size in MB of memory")
+	f.Var(flags.NewInt32(&cmd.NumCPUs), "c", "Number of CPUs")
+	f.StringVar(&cmd.GuestId, "g", "", "Guest OS")
+	f.StringVar(&cmd.Name, "name", "", "Display name")
+	f.StringVar(&cmd.Latency, "latency", "", fmt.Sprintf("Latency sensitivity (%s)", strings.Join(latencyLevels, "|")))
+	f.StringVar(&cmd.Annotation, "annotation", "", "VM description")
+	f.Var(&cmd.extraConfig, "e", "ExtraConfig. <key>=<value>")
+
+	f.Var(flags.NewOptionalBool(&cmd.NestedHVEnabled), "nested-hv-enabled", "Enable nested hardware-assisted virtualization")
+	cmd.Tools = &types.ToolsConfigInfo{}
+	f.Var(flags.NewOptionalBool(&cmd.Tools.SyncTimeWithHost), "sync-time-with-host", "Enable SyncTimeWithHost")
+	f.Var(flags.NewOptionalBool(&cmd.VPMCEnabled), "vpmc-enabled", "Enable CPU performance counters")
+	f.Var(flags.NewOptionalBool(&cmd.MemoryHotAddEnabled), "memory-hot-add-enabled", "Enable memory hot add")
+	f.Var(flags.NewOptionalBool(&cmd.CpuHotAddEnabled), "cpu-hot-add-enabled", "Enable CPU hot add")
+}
+
+func (cmd *change) Description() string {
+	return `Change VM configuration.
+
+To add ExtraConfig variables that can read within the guest, use the 'guestinfo.' prefix.
+
+Examples:
+  govc vm.change -vm $vm -mem.reservation 2048
+  govc vm.change -vm $vm -e smc.present=TRUE -e ich7m.present=TRUE
+  # Enable both cpu and memory hotplug on a guest:
+  govc vm.change -vm $vm -cpu-hot-add-enabled -memory-hot-add-enabled
+  govc vm.change -vm $vm -e guestinfo.vmname $vm
+  # Read the variable set above inside the guest:
+  vmware-rpctool "info-get guestinfo.vmname"
+  govc vm.change -vm $vm -latency high
+  govc vm.change -vm $vm -latency normal
+  `
+}
+
+func (cmd *change) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	if len(cmd.extraConfig) > 0 {
+		cmd.VirtualMachineConfigSpec.ExtraConfig = cmd.extraConfig
+	}
+
+	setAllocation(&cmd.CpuAllocation)
+	setAllocation(&cmd.MemoryAllocation)
+	if reflect.DeepEqual(cmd.Tools, new(types.ToolsConfigInfo)) {
+		cmd.Tools = nil // no flags set, avoid sending <tools/> in the request
+	}
+
+	if err = cmd.setLatency(); err != nil {
+		return err
+	}
+
+	task, err := vm.Reconfigure(ctx, cmd.VirtualMachineConfigSpec)
+	if err != nil {
+		return err
+	}
+
+	return task.Wait(ctx)
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/clone.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/clone.go
@@ -1,0 +1,479 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vm
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type clone struct {
+	*flags.ClientFlag
+	*flags.ClusterFlag
+	*flags.DatacenterFlag
+	*flags.DatastoreFlag
+	*flags.StoragePodFlag
+	*flags.ResourcePoolFlag
+	*flags.HostSystemFlag
+	*flags.NetworkFlag
+	*flags.FolderFlag
+	*flags.VirtualMachineFlag
+
+	name          string
+	memory        int
+	cpus          int
+	on            bool
+	force         bool
+	template      bool
+	customization string
+	waitForIP     bool
+	annotation    string
+	snapshot      string
+	link          bool
+
+	Client         *vim25.Client
+	Cluster        *object.ClusterComputeResource
+	Datacenter     *object.Datacenter
+	Datastore      *object.Datastore
+	StoragePod     *object.StoragePod
+	ResourcePool   *object.ResourcePool
+	HostSystem     *object.HostSystem
+	Folder         *object.Folder
+	VirtualMachine *object.VirtualMachine
+}
+
+func init() {
+	cli.Register("vm.clone", &clone{})
+}
+
+func (cmd *clone) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.ClusterFlag, ctx = flags.NewClusterFlag(ctx)
+	cmd.ClusterFlag.RegisterPlacement(ctx, f)
+
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	cmd.StoragePodFlag, ctx = flags.NewStoragePodFlag(ctx)
+	cmd.StoragePodFlag.Register(ctx, f)
+
+	cmd.ResourcePoolFlag, ctx = flags.NewResourcePoolFlag(ctx)
+	cmd.ResourcePoolFlag.Register(ctx, f)
+
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	cmd.NetworkFlag, ctx = flags.NewNetworkFlag(ctx)
+	cmd.NetworkFlag.Register(ctx, f)
+
+	cmd.FolderFlag, ctx = flags.NewFolderFlag(ctx)
+	cmd.FolderFlag.Register(ctx, f)
+
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.IntVar(&cmd.memory, "m", 0, "Size in MB of memory")
+	f.IntVar(&cmd.cpus, "c", 0, "Number of CPUs")
+	f.BoolVar(&cmd.on, "on", true, "Power on VM")
+	f.BoolVar(&cmd.force, "force", false, "Create VM if vmx already exists")
+	f.BoolVar(&cmd.template, "template", false, "Create a Template")
+	f.StringVar(&cmd.customization, "customization", "", "Customization Specification Name")
+	f.BoolVar(&cmd.waitForIP, "waitip", false, "Wait for VM to acquire IP address")
+	f.StringVar(&cmd.annotation, "annotation", "", "VM description")
+	f.StringVar(&cmd.snapshot, "snapshot", "", "Snapshot name to clone from")
+	f.BoolVar(&cmd.link, "link", false, "Creates a linked clone from snapshot or source VM")
+}
+
+func (cmd *clone) Usage() string {
+	return "NAME"
+}
+
+func (cmd *clone) Description() string {
+	return `Clone VM to NAME.
+
+Examples:
+  govc vm.clone -vm template-vm new-vm
+  govc vm.clone -vm template-vm -link new-vm
+  govc vm.clone -vm template-vm -snapshot s-name new-vm
+  govc vm.clone -vm template-vm -link -snapshot s-name new-vm
+  govc vm.clone -vm template-vm -cluster cluster1 new-vm # use compute cluster placement
+  govc vm.clone -vm template-vm -datastore-cluster dscluster new-vm # use datastore cluster placement
+  govc vm.clone -vm template-vm -snapshot $(govc snapshot.tree -vm template-vm -C) new-vm`
+}
+
+func (cmd *clone) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.ClusterFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.StoragePodFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.ResourcePoolFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.NetworkFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.FolderFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cmd *clone) Run(ctx context.Context, f *flag.FlagSet) error {
+	var err error
+
+	if len(f.Args()) != 1 {
+		return flag.ErrHelp
+	}
+
+	cmd.name = f.Arg(0)
+	if cmd.name == "" {
+		return flag.ErrHelp
+	}
+
+	cmd.Client, err = cmd.ClientFlag.Client()
+	if err != nil {
+		return err
+	}
+
+	cmd.Cluster, err = cmd.ClusterFlag.ClusterIfSpecified()
+	if err != nil {
+		return err
+	}
+
+	cmd.Datacenter, err = cmd.DatacenterFlag.Datacenter()
+	if err != nil {
+		return err
+	}
+
+	if cmd.StoragePodFlag.Isset() {
+		cmd.StoragePod, err = cmd.StoragePodFlag.StoragePod()
+		if err != nil {
+			return err
+		}
+	} else if cmd.Cluster == nil {
+		cmd.Datastore, err = cmd.DatastoreFlag.Datastore()
+		if err != nil {
+			return err
+		}
+	}
+
+	cmd.HostSystem, err = cmd.HostSystemFlag.HostSystemIfSpecified()
+	if err != nil {
+		return err
+	}
+
+	if cmd.HostSystem != nil {
+		if cmd.ResourcePool, err = cmd.HostSystem.ResourcePool(ctx); err != nil {
+			return err
+		}
+	} else {
+		if cmd.Cluster == nil {
+			// -host is optional
+			if cmd.ResourcePool, err = cmd.ResourcePoolFlag.ResourcePool(); err != nil {
+				return err
+			}
+		} else {
+			if cmd.ResourcePool, err = cmd.Cluster.ResourcePool(ctx); err != nil {
+				return err
+			}
+		}
+	}
+
+	if cmd.Folder, err = cmd.FolderFlag.Folder(); err != nil {
+		return err
+	}
+
+	if cmd.VirtualMachine, err = cmd.VirtualMachineFlag.VirtualMachine(); err != nil {
+		return err
+	}
+
+	if cmd.VirtualMachine == nil {
+		return flag.ErrHelp
+	}
+
+	vm, err := cmd.cloneVM(ctx)
+	if err != nil {
+		return err
+	}
+
+	if cmd.cpus > 0 || cmd.memory > 0 || cmd.annotation != "" {
+		vmConfigSpec := types.VirtualMachineConfigSpec{}
+		if cmd.cpus > 0 {
+			vmConfigSpec.NumCPUs = int32(cmd.cpus)
+		}
+		if cmd.memory > 0 {
+			vmConfigSpec.MemoryMB = int64(cmd.memory)
+		}
+		vmConfigSpec.Annotation = cmd.annotation
+		task, err := vm.Reconfigure(ctx, vmConfigSpec)
+		if err != nil {
+			return err
+		}
+		_, err = task.WaitForResult(ctx, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	if cmd.on {
+		task, err := vm.PowerOn(ctx)
+		if err != nil {
+			return err
+		}
+
+		_, err = task.WaitForResult(ctx, nil)
+		if err != nil {
+			return err
+		}
+
+		if cmd.waitForIP {
+			_, err = vm.WaitForIP(ctx)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (cmd *clone) cloneVM(ctx context.Context) (*object.VirtualMachine, error) {
+	devices, err := cmd.VirtualMachine.Device(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// prepare virtual device config spec for network card
+	configSpecs := []types.BaseVirtualDeviceConfigSpec{}
+
+	if cmd.NetworkFlag.IsSet() {
+		op := types.VirtualDeviceConfigSpecOperationAdd
+		card, derr := cmd.NetworkFlag.Device()
+		if derr != nil {
+			return nil, derr
+		}
+		// search for the first network card of the source
+		for _, device := range devices {
+			if _, ok := device.(types.BaseVirtualEthernetCard); ok {
+				op = types.VirtualDeviceConfigSpecOperationEdit
+				// set new backing info
+				cmd.NetworkFlag.Change(device, card)
+				card = device
+				break
+			}
+		}
+
+		configSpecs = append(configSpecs, &types.VirtualDeviceConfigSpec{
+			Operation: op,
+			Device:    card,
+		})
+	}
+
+	folderref := cmd.Folder.Reference()
+	poolref := cmd.ResourcePool.Reference()
+
+	relocateSpec := types.VirtualMachineRelocateSpec{
+		DeviceChange: configSpecs,
+		Folder:       &folderref,
+		Pool:         &poolref,
+	}
+
+	if cmd.HostSystem != nil {
+		hostref := cmd.HostSystem.Reference()
+		relocateSpec.Host = &hostref
+	}
+
+	cloneSpec := &types.VirtualMachineCloneSpec{
+		PowerOn:  false,
+		Template: cmd.template,
+	}
+
+	if cmd.snapshot == "" {
+		if cmd.link {
+			relocateSpec.DiskMoveType = string(types.VirtualMachineRelocateDiskMoveOptionsMoveAllDiskBackingsAndAllowSharing)
+		}
+	} else {
+		if cmd.link {
+			relocateSpec.DiskMoveType = string(types.VirtualMachineRelocateDiskMoveOptionsCreateNewChildDiskBacking)
+		}
+
+		ref, ferr := cmd.VirtualMachine.FindSnapshot(ctx, cmd.snapshot)
+		if ferr != nil {
+			return nil, ferr
+		}
+
+		cloneSpec.Snapshot = ref
+	}
+
+	cloneSpec.Location = relocateSpec
+	vmref := cmd.VirtualMachine.Reference()
+
+	// clone to storage pod
+	datastoreref := types.ManagedObjectReference{}
+	if cmd.StoragePod != nil && cmd.Datastore == nil {
+		storagePod := cmd.StoragePod.Reference()
+
+		// Build pod selection spec from config spec
+		podSelectionSpec := types.StorageDrsPodSelectionSpec{
+			StoragePod: &storagePod,
+		}
+
+		// Build the placement spec
+		storagePlacementSpec := types.StoragePlacementSpec{
+			Folder:           &folderref,
+			Vm:               &vmref,
+			CloneName:        cmd.name,
+			CloneSpec:        cloneSpec,
+			PodSelectionSpec: podSelectionSpec,
+			Type:             string(types.StoragePlacementSpecPlacementTypeClone),
+		}
+
+		// Get the storage placement result
+		storageResourceManager := object.NewStorageResourceManager(cmd.Client)
+		result, err := storageResourceManager.RecommendDatastores(ctx, storagePlacementSpec)
+		if err != nil {
+			return nil, err
+		}
+
+		// Get the recommendations
+		recommendations := result.Recommendations
+		if len(recommendations) == 0 {
+			return nil, fmt.Errorf("no datastore-cluster recommendations")
+		}
+
+		// Get the first recommendation
+		datastoreref = recommendations[0].Action[0].(*types.StoragePlacementAction).Destination
+	} else if cmd.StoragePod == nil && cmd.Datastore != nil {
+		datastoreref = cmd.Datastore.Reference()
+	} else if cmd.Cluster != nil {
+		spec := types.PlacementSpec{
+			PlacementType: string(types.PlacementSpecPlacementTypeClone),
+			CloneName:     cmd.name,
+			CloneSpec:     cloneSpec,
+			RelocateSpec:  &cloneSpec.Location,
+			Vm:            &vmref,
+		}
+		result, err := cmd.Cluster.PlaceVm(ctx, spec)
+		if err != nil {
+			return nil, err
+		}
+
+		recs := result.Recommendations
+		if len(recs) == 0 {
+			return nil, fmt.Errorf("no cluster recommendations")
+		}
+
+		rspec := *recs[0].Action[0].(*types.PlacementAction).RelocateSpec
+		cloneSpec.Location.Host = rspec.Host
+		cloneSpec.Location.Datastore = rspec.Datastore
+		datastoreref = *rspec.Datastore
+	} else {
+		return nil, fmt.Errorf("please provide either a cluster, datastore or datastore-cluster")
+	}
+
+	// Set the destination datastore
+	cloneSpec.Location.Datastore = &datastoreref
+
+	// Check if vmx already exists
+	if !cmd.force {
+		vmxPath := fmt.Sprintf("%s/%s.vmx", cmd.name, cmd.name)
+
+		var mds mo.Datastore
+		err = property.DefaultCollector(cmd.Client).RetrieveOne(ctx, datastoreref, []string{"name"}, &mds)
+		if err != nil {
+			return nil, err
+		}
+
+		datastore := object.NewDatastore(cmd.Client, datastoreref)
+		datastore.InventoryPath = mds.Name
+
+		_, err := datastore.Stat(ctx, vmxPath)
+		if err == nil {
+			dsPath := cmd.Datastore.Path(vmxPath)
+			return nil, fmt.Errorf("file %s already exists", dsPath)
+		}
+	}
+
+	// check if customization specification requested
+	if len(cmd.customization) > 0 {
+		// get the customization spec manager
+		customizationSpecManager := object.NewCustomizationSpecManager(cmd.Client)
+		// check if customization specification exists
+		exists, err := customizationSpecManager.DoesCustomizationSpecExist(ctx, cmd.customization)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			return nil, fmt.Errorf("customization specification %s does not exists", cmd.customization)
+		}
+		// get the customization specification
+		customSpecItem, err := customizationSpecManager.GetCustomizationSpec(ctx, cmd.customization)
+		if err != nil {
+			return nil, err
+		}
+		customSpec := customSpecItem.Spec
+		// set the customization
+		cloneSpec.Customization = &customSpec
+	}
+
+	task, err := cmd.VirtualMachine.Clone(ctx, cmd.Folder, cmd.name, *cloneSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("Cloning %s to %s...", cmd.VirtualMachine.InventoryPath, cmd.name))
+	defer logger.Wait()
+
+	info, err := task.WaitForResult(ctx, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	return object.NewVirtualMachine(cmd.Client, info.Result.(types.ManagedObjectReference)), nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/console.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/console.go
@@ -1,0 +1,173 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vm
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type console struct {
+	*flags.VirtualMachineFlag
+
+	h5      bool
+	capture string
+}
+
+func init() {
+	cli.Register("vm.console", &console{})
+}
+
+func (cmd *console) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.h5, "h5", false, "Generate HTML5 UI console link")
+	f.StringVar(&cmd.capture, "capture", "", "Capture console screen shot to file")
+}
+
+func (cmd *console) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *console) Usage() string {
+	return "VM"
+}
+
+func (cmd *console) Description() string {
+	return `Generate console URL or screen capture for VM.
+
+One of VMRC, VMware Player, VMware Fusion or VMware Workstation must be installed to
+open VMRC console URLs.
+
+Examples:
+  govc vm.console my-vm
+  govc vm.console -capture screen.png my-vm  # screen capture
+  govc vm.console -capture - my-vm | display # screen capture to stdout
+  open $(govc vm.console my-vm)              # MacOSX VMRC
+  open $(govc vm.console -h5 my-vm)          # MacOSX H5
+  xdg-open $(govc vm.console my-vm)          # Linux VMRC
+  xdg-open $(govc vm.console -h5 my-vm)      # Linux H5`
+}
+
+func (cmd *console) Run(ctx context.Context, f *flag.FlagSet) error {
+	vms, err := cmd.VirtualMachines(f.Args())
+	if err != nil {
+		return err
+	}
+
+	if len(vms) != 1 {
+		return flag.ErrHelp
+	}
+
+	vm := vms[0]
+
+	state, err := vm.PowerState(ctx)
+	if err != nil {
+		return err
+	}
+
+	if state != types.VirtualMachinePowerStatePoweredOn {
+		return fmt.Errorf("vm is not powered on (%s)", state)
+	}
+
+	c := vm.Client()
+
+	u := c.URL()
+
+	if cmd.capture != "" {
+		u.Path = "/screen"
+		query := url.Values{"id": []string{vm.Reference().Value}}
+		u.RawQuery = query.Encode()
+
+		param := soap.DefaultDownload
+
+		if cmd.capture == "-" {
+			w, _, derr := c.Download(ctx, u, &param)
+			if derr != nil {
+				return derr
+			}
+
+			_, err = io.Copy(os.Stdout, w)
+			if err != nil {
+				return err
+			}
+
+			return w.Close()
+		}
+
+		return c.DownloadFile(ctx, cmd.capture, u, &param)
+	}
+
+	m := session.NewManager(c)
+	ticket, err := m.AcquireCloneTicket(ctx)
+	if err != nil {
+		return err
+	}
+
+	var link string
+
+	if cmd.h5 {
+		m := object.NewOptionManager(c, *c.ServiceContent.Setting)
+
+		opt, err := m.Query(ctx, "VirtualCenter.FQDN")
+		if err != nil {
+			return err
+		}
+
+		fqdn := opt[0].GetOptionValue().Value.(string)
+
+		var info object.HostCertificateInfo
+		err = info.FromURL(u, nil)
+		if err != nil {
+			return err
+		}
+
+		u.Path = "/ui/webconsole.html"
+
+		u.RawQuery = url.Values{
+			"vmId":          []string{vm.Reference().Value},
+			"vmName":        []string{vm.Name()},
+			"serverGuid":    []string{c.ServiceContent.About.InstanceUuid},
+			"host":          []string{fqdn},
+			"sessionTicket": []string{ticket},
+			"thumbprint":    []string{info.ThumbprintSHA1},
+		}.Encode()
+
+		link = u.String()
+	} else {
+		link = fmt.Sprintf("vmrc://clone:%s@%s/?moid=%s", ticket, u.Hostname(), vm.Reference().Value)
+	}
+
+	fmt.Fprintln(os.Stdout, link)
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/create.go
@@ -1,0 +1,610 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vm
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/units"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+var hardwareVersions = []struct {
+	esx, vmx string
+}{
+	{"5.0", "vmx-8"},
+	{"5.5", "vmx-10"},
+	{"6.0", "vmx-11"},
+	{"6.5", "vmx-13"},
+	{"6.7", "vmx-14"},
+}
+
+type create struct {
+	*flags.ClientFlag
+	*flags.ClusterFlag
+	*flags.DatacenterFlag
+	*flags.DatastoreFlag
+	*flags.StoragePodFlag
+	*flags.ResourcePoolFlag
+	*flags.HostSystemFlag
+	*flags.NetworkFlag
+	*flags.FolderFlag
+
+	name       string
+	memory     int
+	cpus       int
+	guestID    string
+	link       bool
+	on         bool
+	force      bool
+	controller string
+	annotation string
+	firmware   string
+	version    string
+
+	iso              string
+	isoDatastoreFlag *flags.DatastoreFlag
+	isoDatastore     *object.Datastore
+
+	disk              string
+	diskDatastoreFlag *flags.DatastoreFlag
+	diskDatastore     *object.Datastore
+
+	// Only set if the disk argument is a byte size, which means the disk
+	// doesn't exist yet and should be created
+	diskByteSize int64
+
+	Client       *vim25.Client
+	Cluster      *object.ClusterComputeResource
+	Datacenter   *object.Datacenter
+	Datastore    *object.Datastore
+	StoragePod   *object.StoragePod
+	ResourcePool *object.ResourcePool
+	HostSystem   *object.HostSystem
+	Folder       *object.Folder
+}
+
+func init() {
+	cli.Register("vm.create", &create{})
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.ClusterFlag, ctx = flags.NewClusterFlag(ctx)
+	cmd.ClusterFlag.RegisterPlacement(ctx, f)
+
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	cmd.StoragePodFlag, ctx = flags.NewStoragePodFlag(ctx)
+	cmd.StoragePodFlag.Register(ctx, f)
+
+	cmd.ResourcePoolFlag, ctx = flags.NewResourcePoolFlag(ctx)
+	cmd.ResourcePoolFlag.Register(ctx, f)
+
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	cmd.NetworkFlag, ctx = flags.NewNetworkFlag(ctx)
+	cmd.NetworkFlag.Register(ctx, f)
+
+	cmd.FolderFlag, ctx = flags.NewFolderFlag(ctx)
+	cmd.FolderFlag.Register(ctx, f)
+
+	f.IntVar(&cmd.memory, "m", 1024, "Size in MB of memory")
+	f.IntVar(&cmd.cpus, "c", 1, "Number of CPUs")
+	f.StringVar(&cmd.guestID, "g", "otherGuest", "Guest OS ID")
+	f.BoolVar(&cmd.link, "link", true, "Link specified disk")
+	f.BoolVar(&cmd.on, "on", true, "Power on VM")
+	f.BoolVar(&cmd.force, "force", false, "Create VM if vmx already exists")
+	f.StringVar(&cmd.controller, "disk.controller", "scsi", "Disk controller type")
+	f.StringVar(&cmd.annotation, "annotation", "", "VM description")
+
+	firmwareTypes := []string{
+		string(types.GuestOsDescriptorFirmwareTypeBios),
+		string(types.GuestOsDescriptorFirmwareTypeEfi),
+	}
+
+	f.StringVar(&cmd.firmware, "firmware", firmwareTypes[0],
+		fmt.Sprintf("Firmware type [%s]", strings.Join(firmwareTypes, "|")))
+	var versions []string
+	for i := range hardwareVersions {
+		versions = append(versions, hardwareVersions[i].esx)
+	}
+	f.StringVar(&cmd.version, "version", "",
+		fmt.Sprintf("ESXi hardware version [%s]", strings.Join(versions, "|")))
+
+	f.StringVar(&cmd.iso, "iso", "", "ISO path")
+	cmd.isoDatastoreFlag, ctx = flags.NewCustomDatastoreFlag(ctx)
+	f.StringVar(&cmd.isoDatastoreFlag.Name, "iso-datastore", "", "Datastore for ISO file")
+
+	f.StringVar(&cmd.disk, "disk", "", "Disk path (to use existing) OR size (to create new, e.g. 20GB)")
+	cmd.diskDatastoreFlag, _ = flags.NewCustomDatastoreFlag(ctx)
+	f.StringVar(&cmd.diskDatastoreFlag.Name, "disk-datastore", "", "Datastore for disk file")
+}
+
+func (cmd *create) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.ClusterFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.StoragePodFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.ResourcePoolFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.NetworkFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.FolderFlag.Process(ctx); err != nil {
+		return err
+	}
+
+	// Default iso/disk datastores to the VM's datastore
+	if cmd.isoDatastoreFlag.Name == "" {
+		cmd.isoDatastoreFlag = cmd.DatastoreFlag
+	}
+	if cmd.diskDatastoreFlag.Name == "" {
+		cmd.diskDatastoreFlag = cmd.DatastoreFlag
+	}
+
+	return nil
+}
+
+func (cmd *create) Usage() string {
+	return "NAME"
+}
+
+func (cmd *create) Description() string {
+	return `Create VM.
+
+For a list of possible '-g' IDs, see:
+http://pubs.vmware.com/vsphere-6-5/topic/com.vmware.wssdk.apiref.doc/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html
+
+Examples:
+  govc vm.create -on=false vm-name
+  govc vm.create -cluster cluster1 vm-name # use compute cluster placement
+  govc vm.create -datastore-cluster dscluster vm-name # use datastore cluster placement
+  govc vm.create -m 2048 -c 2 -g freebsd64Guest -net.adapter vmxnet3 -disk.controller pvscsi vm-name`
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	var err error
+
+	if len(f.Args()) != 1 {
+		return flag.ErrHelp
+	}
+
+	cmd.name = f.Arg(0)
+	if cmd.name == "" {
+		return flag.ErrHelp
+	}
+
+	cmd.Client, err = cmd.ClientFlag.Client()
+	if err != nil {
+		return err
+	}
+
+	cmd.Cluster, err = cmd.ClusterFlag.ClusterIfSpecified()
+	if err != nil {
+		return err
+	}
+
+	cmd.Datacenter, err = cmd.DatacenterFlag.Datacenter()
+	if err != nil {
+		return err
+	}
+
+	if cmd.StoragePodFlag.Isset() {
+		cmd.StoragePod, err = cmd.StoragePodFlag.StoragePod()
+		if err != nil {
+			return err
+		}
+	} else if cmd.Cluster == nil {
+		cmd.Datastore, err = cmd.DatastoreFlag.Datastore()
+		if err != nil {
+			return err
+		}
+	}
+
+	cmd.HostSystem, err = cmd.HostSystemFlag.HostSystemIfSpecified()
+	if err != nil {
+		return err
+	}
+
+	if cmd.HostSystem != nil {
+		if cmd.ResourcePool, err = cmd.HostSystem.ResourcePool(ctx); err != nil {
+			return err
+		}
+	} else {
+		if cmd.Cluster == nil {
+			// -host is optional
+			if cmd.ResourcePool, err = cmd.ResourcePoolFlag.ResourcePool(); err != nil {
+				return err
+			}
+		} else {
+			if cmd.ResourcePool, err = cmd.Cluster.ResourcePool(ctx); err != nil {
+				return err
+			}
+		}
+	}
+
+	if cmd.Folder, err = cmd.FolderFlag.Folder(); err != nil {
+		return err
+	}
+
+	// Verify ISO exists
+	if cmd.iso != "" {
+		_, err = cmd.isoDatastoreFlag.Stat(ctx, cmd.iso)
+		if err != nil {
+			return err
+		}
+
+		cmd.isoDatastore, err = cmd.isoDatastoreFlag.Datastore()
+		if err != nil {
+			return err
+		}
+	}
+
+	// Verify disk exists
+	if cmd.disk != "" {
+		var b units.ByteSize
+
+		// If disk can be parsed as byte units, don't stat
+		err = b.Set(cmd.disk)
+		if err == nil {
+			cmd.diskByteSize = int64(b)
+		} else {
+			_, err = cmd.diskDatastoreFlag.Stat(ctx, cmd.disk)
+			if err != nil {
+				return err
+			}
+
+			cmd.diskDatastore, err = cmd.diskDatastoreFlag.Datastore()
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	task, err := cmd.createVM(ctx)
+	if err != nil {
+		return err
+	}
+
+	info, err := task.WaitForResult(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	vm := object.NewVirtualMachine(cmd.Client, info.Result.(types.ManagedObjectReference))
+
+	if cmd.on {
+		task, err := vm.PowerOn(ctx)
+		if err != nil {
+			return err
+		}
+
+		_, err = task.WaitForResult(ctx, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (cmd *create) createVM(ctx context.Context) (*object.Task, error) {
+	var devices object.VirtualDeviceList
+	var err error
+
+	if cmd.version != "" {
+		for i := range hardwareVersions {
+			if hardwareVersions[i].esx == cmd.version {
+				cmd.version = hardwareVersions[i].vmx
+				break
+			}
+		}
+	}
+
+	spec := &types.VirtualMachineConfigSpec{
+		Name:       cmd.name,
+		GuestId:    cmd.guestID,
+		NumCPUs:    int32(cmd.cpus),
+		MemoryMB:   int64(cmd.memory),
+		Annotation: cmd.annotation,
+		Firmware:   cmd.firmware,
+		Version:    cmd.version,
+	}
+
+	devices, err = cmd.addStorage(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	devices, err = cmd.addNetwork(devices)
+	if err != nil {
+		return nil, err
+	}
+
+	deviceChange, err := devices.ConfigSpec(types.VirtualDeviceConfigSpecOperationAdd)
+	if err != nil {
+		return nil, err
+	}
+
+	spec.DeviceChange = deviceChange
+
+	var datastore *object.Datastore
+
+	// If storage pod is specified, collect placement recommendations
+	if cmd.StoragePod != nil {
+		datastore, err = cmd.recommendDatastore(ctx, spec)
+		if err != nil {
+			return nil, err
+		}
+	} else if cmd.Datastore != nil {
+		datastore = cmd.Datastore
+	} else if cmd.Cluster != nil {
+		pspec := types.PlacementSpec{
+			PlacementType: string(types.PlacementSpecPlacementTypeCreate),
+			ConfigSpec:    spec,
+		}
+		result, err := cmd.Cluster.PlaceVm(ctx, pspec)
+		if err != nil {
+			return nil, err
+		}
+
+		recs := result.Recommendations
+		if len(recs) == 0 {
+			return nil, fmt.Errorf("no cluster recommendations")
+		}
+
+		rspec := *recs[0].Action[0].(*types.PlacementAction).RelocateSpec
+		if rspec.Datastore != nil {
+			datastore = object.NewDatastore(cmd.Client, *rspec.Datastore)
+			datastore.InventoryPath, _ = datastore.ObjectName(ctx)
+			cmd.Datastore = datastore
+		}
+		if rspec.Host != nil {
+			cmd.HostSystem = object.NewHostSystem(cmd.Client, *rspec.Host)
+		}
+		if rspec.Pool != nil {
+			cmd.ResourcePool = object.NewResourcePool(cmd.Client, *rspec.Pool)
+		}
+	} else {
+		return nil, fmt.Errorf("please provide either a cluster, datastore or datastore-cluster")
+	}
+
+	if !cmd.force {
+		vmxPath := fmt.Sprintf("%s/%s.vmx", cmd.name, cmd.name)
+
+		_, err := datastore.Stat(ctx, vmxPath)
+		if err == nil {
+			dsPath := cmd.Datastore.Path(vmxPath)
+			return nil, fmt.Errorf("file %s already exists", dsPath)
+		}
+	}
+
+	folder := cmd.Folder
+
+	spec.Files = &types.VirtualMachineFileInfo{
+		VmPathName: fmt.Sprintf("[%s]", datastore.Name()),
+	}
+
+	return folder.CreateVM(ctx, *spec, cmd.ResourcePool, cmd.HostSystem)
+}
+
+func (cmd *create) addStorage(devices object.VirtualDeviceList) (object.VirtualDeviceList, error) {
+	if cmd.controller != "ide" {
+		if cmd.controller == "nvme" {
+			nvme, err := devices.CreateNVMEController()
+			if err != nil {
+				return nil, err
+			}
+
+			devices = append(devices, nvme)
+			cmd.controller = devices.Name(nvme)
+		} else {
+			scsi, err := devices.CreateSCSIController(cmd.controller)
+			if err != nil {
+				return nil, err
+			}
+
+			devices = append(devices, scsi)
+			cmd.controller = devices.Name(scsi)
+		}
+	}
+
+	// If controller is specified to be IDE or if an ISO is specified, add IDE controller.
+	if cmd.controller == "ide" || cmd.iso != "" {
+		ide, err := devices.CreateIDEController()
+		if err != nil {
+			return nil, err
+		}
+
+		devices = append(devices, ide)
+	}
+
+	if cmd.diskByteSize != 0 {
+		controller, err := devices.FindDiskController(cmd.controller)
+		if err != nil {
+			return nil, err
+		}
+
+		disk := &types.VirtualDisk{
+			VirtualDevice: types.VirtualDevice{
+				Key: devices.NewKey(),
+				Backing: &types.VirtualDiskFlatVer2BackingInfo{
+					DiskMode:        string(types.VirtualDiskModePersistent),
+					ThinProvisioned: types.NewBool(true),
+				},
+			},
+			CapacityInKB: cmd.diskByteSize / 1024,
+		}
+
+		devices.AssignController(disk, controller)
+		devices = append(devices, disk)
+	} else if cmd.disk != "" {
+		controller, err := devices.FindDiskController(cmd.controller)
+		if err != nil {
+			return nil, err
+		}
+
+		ds := cmd.diskDatastore.Reference()
+		path := cmd.diskDatastore.Path(cmd.disk)
+		disk := devices.CreateDisk(controller, ds, path)
+
+		if cmd.link {
+			disk = devices.ChildDisk(disk)
+		}
+
+		devices = append(devices, disk)
+	}
+
+	if cmd.iso != "" {
+		ide, err := devices.FindIDEController("")
+		if err != nil {
+			return nil, err
+		}
+
+		cdrom, err := devices.CreateCdrom(ide)
+		if err != nil {
+			return nil, err
+		}
+
+		cdrom = devices.InsertIso(cdrom, cmd.isoDatastore.Path(cmd.iso))
+		devices = append(devices, cdrom)
+	}
+
+	return devices, nil
+}
+
+func (cmd *create) addNetwork(devices object.VirtualDeviceList) (object.VirtualDeviceList, error) {
+	netdev, err := cmd.NetworkFlag.Device()
+	if err != nil {
+		return nil, err
+	}
+
+	devices = append(devices, netdev)
+	return devices, nil
+}
+
+func (cmd *create) recommendDatastore(ctx context.Context, spec *types.VirtualMachineConfigSpec) (*object.Datastore, error) {
+	sp := cmd.StoragePod.Reference()
+
+	// Build pod selection spec from config spec
+	podSelectionSpec := types.StorageDrsPodSelectionSpec{
+		StoragePod: &sp,
+	}
+
+	// Keep list of disks that need to be placed
+	var disks []*types.VirtualDisk
+
+	// Collect disks eligible for placement
+	for _, deviceConfigSpec := range spec.DeviceChange {
+		s := deviceConfigSpec.GetVirtualDeviceConfigSpec()
+		if s.Operation != types.VirtualDeviceConfigSpecOperationAdd {
+			continue
+		}
+
+		if s.FileOperation != types.VirtualDeviceConfigSpecFileOperationCreate {
+			continue
+		}
+
+		d, ok := s.Device.(*types.VirtualDisk)
+		if !ok {
+			continue
+		}
+
+		podConfigForPlacement := types.VmPodConfigForPlacement{
+			StoragePod: sp,
+			Disk: []types.PodDiskLocator{
+				{
+					DiskId:          d.Key,
+					DiskBackingInfo: d.Backing,
+				},
+			},
+		}
+
+		podSelectionSpec.InitialVmConfig = append(podSelectionSpec.InitialVmConfig, podConfigForPlacement)
+		disks = append(disks, d)
+	}
+
+	sps := types.StoragePlacementSpec{
+		Type:             string(types.StoragePlacementSpecPlacementTypeCreate),
+		ResourcePool:     types.NewReference(cmd.ResourcePool.Reference()),
+		PodSelectionSpec: podSelectionSpec,
+		ConfigSpec:       spec,
+	}
+
+	srm := object.NewStorageResourceManager(cmd.Client)
+	result, err := srm.RecommendDatastores(ctx, sps)
+	if err != nil {
+		return nil, err
+	}
+
+	// Use result to pin disks to recommended datastores
+	recs := result.Recommendations
+	if len(recs) == 0 {
+		return nil, fmt.Errorf("no datastore-cluster recommendations")
+	}
+
+	ds := recs[0].Action[0].(*types.StoragePlacementAction).Destination
+
+	var mds mo.Datastore
+	err = property.DefaultCollector(cmd.Client).RetrieveOne(ctx, ds, []string{"name"}, &mds)
+	if err != nil {
+		return nil, err
+	}
+
+	datastore := object.NewDatastore(cmd.Client, ds)
+	datastore.InventoryPath = mds.Name
+
+	// Apply recommendation to eligible disks
+	for _, disk := range disks {
+		backing := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
+		backing.Datastore = &ds
+	}
+
+	return datastore, nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/customize.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/customize.go
@@ -1,0 +1,238 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vm
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type customize struct {
+	*flags.VirtualMachineFlag
+
+	alc       int
+	prefix    types.CustomizationPrefixName
+	tz        string
+	domain    string
+	host      types.CustomizationFixedName
+	mac       flags.StringList
+	ip        flags.StringList
+	gateway   flags.StringList
+	netmask   flags.StringList
+	dnsserver flags.StringList
+	kind      string
+}
+
+func init() {
+	cli.Register("vm.customize", &customize{})
+}
+
+func (cmd *customize) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.IntVar(&cmd.alc, "auto-login", 0, "Number of times the VM should automatically login as an administrator")
+	f.StringVar(&cmd.prefix.Base, "prefix", "", "Host name generator prefix")
+	f.StringVar(&cmd.tz, "tz", "", "Time zone")
+	f.StringVar(&cmd.domain, "domain", "", "Domain name")
+	f.StringVar(&cmd.host.Name, "name", "", "Host name")
+	f.Var(&cmd.mac, "mac", "MAC address")
+	f.Var(&cmd.ip, "ip", "IP address")
+	f.Var(&cmd.gateway, "gateway", "Gateway")
+	f.Var(&cmd.netmask, "netmask", "Netmask")
+	f.Var(&cmd.dnsserver, "dns-server", "DNS server")
+	f.StringVar(&cmd.kind, "type", "Linux", "Customization type if spec NAME is not specified (Linux|Windows)")
+}
+
+func (cmd *customize) Usage() string {
+	return "[NAME]"
+}
+
+func (cmd *customize) Description() string {
+	return `Customize VM.
+
+Optionally specify a customization spec NAME.
+
+The '-ip', '-netmask' and '-gateway' flags are for static IP configuration.
+If the VM has multiple NICs, an '-ip' and '-netmask' must be specified for each.
+
+Windows -tz value requires the Index (hex): https://support.microsoft.com/en-us/help/973627/microsoft-time-zone-index-values
+
+Examples:
+  govc vm.customize -vm VM NAME
+  govc vm.customize -vm VM -name my-hostname -ip dhcp
+  govc vm.customize -vm VM -gateway GATEWAY -ip NEWIP -netmask NETMASK -dns-server DNS1,DNS2 NAME
+  # Multiple -ip without -mac are applied by vCenter in the order in which the NICs appear on the bus
+  govc vm.customize -vm VM -ip 10.0.0.178 -netmask 255.255.255.0 -ip 10.0.0.162 -netmask 255.255.255.0
+  # Multiple -ip with -mac are applied by vCenter to the NIC with the given MAC address
+  govc vm.customize -vm VM -mac 00:50:56:be:dd:f8 -ip 10.0.0.178 -netmask 255.255.255.0 -mac 00:50:56:be:60:cf -ip 10.0.0.162 -netmask 255.255.255.0
+  govc vm.customize -vm VM -auto-login 3 NAME
+  govc vm.customize -vm VM -prefix demo NAME
+  govc vm.customize -vm VM -tz America/New_York NAME`
+}
+
+func (cmd *customize) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachineFlag.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	var spec *types.CustomizationSpec
+
+	name := f.Arg(0)
+	if name == "" {
+		spec = &types.CustomizationSpec{
+			NicSettingMap: make([]types.CustomizationAdapterMapping, len(cmd.ip)),
+		}
+
+		switch cmd.kind {
+		case "Linux":
+			spec.Identity = &types.CustomizationLinuxPrep{
+				HostName: new(types.CustomizationVirtualMachineName),
+			}
+		case "Windows":
+			spec.Identity = &types.CustomizationSysprep{
+				UserData: types.CustomizationUserData{
+					ComputerName: new(types.CustomizationVirtualMachineName),
+				},
+			}
+		default:
+			return flag.ErrHelp
+		}
+	} else {
+		m := object.NewCustomizationSpecManager(vm.Client())
+
+		exists, err := m.DoesCustomizationSpecExist(ctx, name)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("specification %q does not exist", name)
+		}
+
+		item, err := m.GetCustomizationSpec(ctx, name)
+		if err != nil {
+			return err
+		}
+
+		spec = &item.Spec
+	}
+
+	if len(cmd.ip) > len(spec.NicSettingMap) {
+		return fmt.Errorf("%d -ip specified, spec %q has %d", len(cmd.ip), name, len(spec.NicSettingMap))
+	}
+
+	sysprep, isWindows := spec.Identity.(*types.CustomizationSysprep)
+	linprep, _ := spec.Identity.(*types.CustomizationLinuxPrep)
+
+	if cmd.domain != "" {
+		if isWindows {
+			sysprep.Identification.JoinDomain = cmd.domain
+		} else {
+			linprep.Domain = cmd.domain
+		}
+	}
+
+	if len(cmd.dnsserver) != 0 {
+		if !isWindows {
+			for _, s := range cmd.dnsserver {
+				spec.GlobalIPSettings.DnsServerList =
+					append(spec.GlobalIPSettings.DnsServerList, strings.Split(s, ",")...)
+			}
+		}
+	}
+
+	if cmd.prefix.Base != "" {
+		if isWindows {
+			sysprep.UserData.ComputerName = &cmd.prefix
+		} else {
+			linprep.HostName = &cmd.prefix
+		}
+	}
+
+	if cmd.host.Name != "" {
+		if isWindows {
+			sysprep.UserData.ComputerName = &cmd.host
+		} else {
+			linprep.HostName = &cmd.host
+		}
+	}
+
+	if cmd.alc != 0 {
+		if !isWindows {
+			return fmt.Errorf("option '-auto-login' is Windows only")
+		}
+		sysprep.GuiUnattended.AutoLogon = true
+		sysprep.GuiUnattended.AutoLogonCount = int32(cmd.alc)
+	}
+
+	if cmd.tz != "" {
+		if isWindows {
+			tz, err := strconv.ParseInt(cmd.tz, 16, 32)
+			if err != nil {
+				return fmt.Errorf("converting -tz=%q: %s", cmd.tz, err)
+			}
+			sysprep.GuiUnattended.TimeZone = int32(tz)
+		} else {
+			linprep.TimeZone = cmd.tz
+		}
+	}
+
+	for i, ip := range cmd.ip {
+		nic := &spec.NicSettingMap[i]
+		switch ip {
+		case "dhcp":
+			nic.Adapter.Ip = new(types.CustomizationDhcpIpGenerator)
+		default:
+			nic.Adapter.Ip = &types.CustomizationFixedIp{IpAddress: ip}
+		}
+
+		if i < len(cmd.netmask) {
+			nic.Adapter.SubnetMask = cmd.netmask[i]
+		}
+		if i < len(cmd.mac) {
+			nic.MacAddress = cmd.mac[i]
+		}
+		if i < len(cmd.gateway) {
+			nic.Adapter.Gateway = strings.Split(cmd.gateway[i], ",")
+		}
+		if isWindows {
+			if i < len(cmd.dnsserver) {
+				nic.Adapter.DnsServerList = strings.Split(cmd.dnsserver[i], ",")
+			}
+		}
+	}
+
+	task, err := vm.Customize(ctx, *spec)
+	if err != nil {
+		return err
+	}
+
+	return task.Wait(ctx)
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/destroy.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/destroy.go
@@ -1,0 +1,97 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vm
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type destroy struct {
+	*flags.ClientFlag
+	*flags.SearchFlag
+}
+
+func init() {
+	cli.Register("vm.destroy", &destroy{})
+}
+
+func (cmd *destroy) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.SearchFlag, ctx = flags.NewSearchFlag(ctx, flags.SearchVirtualMachines)
+	cmd.SearchFlag.Register(ctx, f)
+}
+
+func (cmd *destroy) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.SearchFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *destroy) Usage() string {
+	return "VM..."
+}
+
+func (cmd *destroy) Description() string {
+	return `Power off and delete VM.
+
+When a VM is destroyed, any attached virtual disks are also deleted.
+Use the 'device.remove -vm VM -keep disk-*' command to detach and
+keep disks if needed, prior to calling vm.destroy.
+
+Examples:
+  govc vm.destroy my-vm`
+}
+
+func (cmd *destroy) Run(ctx context.Context, f *flag.FlagSet) error {
+	vms, err := cmd.VirtualMachines(f.Args())
+	if err != nil {
+		return err
+	}
+
+	for _, vm := range vms {
+		task, err := vm.PowerOff(ctx)
+		if err != nil {
+			return err
+		}
+
+		// Ignore error since the VM may already been in powered off state.
+		// vm.Destroy will fail if the VM is still powered on.
+		_ = task.Wait(ctx)
+
+		task, err = vm.Destroy(ctx)
+		if err != nil {
+			return err
+		}
+
+		err = task.Wait(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/disk/attach.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/disk/attach.go
@@ -1,0 +1,130 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type attach struct {
+	*flags.DatastoreFlag
+	*flags.VirtualMachineFlag
+
+	persist    bool
+	link       bool
+	disk       string
+	controller string
+	mode       string
+	sharing    string
+}
+
+func init() {
+	cli.Register("vm.disk.attach", &attach{})
+}
+
+func (cmd *attach) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.persist, "persist", true, "Persist attached disk")
+	f.BoolVar(&cmd.link, "link", true, "Link specified disk")
+	f.StringVar(&cmd.controller, "controller", "", "Disk controller")
+	f.StringVar(&cmd.disk, "disk", "", "Disk path name")
+	f.StringVar(&cmd.mode, "mode", "", fmt.Sprintf("Disk mode (%s)", strings.Join(vdmTypes, "|")))
+	f.StringVar(&cmd.sharing, "sharing", "", fmt.Sprintf("Sharing (%s)", strings.Join(sharing, "|")))
+}
+
+func (cmd *attach) Process(ctx context.Context) error {
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *attach) Description() string {
+	return `Attach existing disk to VM.
+
+Examples:
+  govc vm.disk.attach -vm $name -disk $name/disk1.vmdk
+  govc vm.disk.attach -vm $name -disk $name/shared.vmdk -link=false -sharing sharingMultiWriter
+  govc device.remove -vm $name -keep disk-* # detach disk(s)`
+}
+
+func (cmd *attach) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	controller, err := devices.FindDiskController(cmd.controller)
+	if err != nil {
+		return err
+	}
+
+	disk := devices.CreateDisk(controller, ds.Reference(), ds.Path(cmd.disk))
+	backing := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
+	backing.Sharing = cmd.sharing
+
+	if len(cmd.mode) != 0 {
+		backing.DiskMode = cmd.mode
+	}
+
+	if cmd.link {
+		if cmd.persist {
+			backing.DiskMode = string(types.VirtualDiskModeIndependent_persistent)
+		} else {
+			backing.DiskMode = string(types.VirtualDiskModeIndependent_nonpersistent)
+		}
+
+		disk = devices.ChildDisk(disk)
+		return vm.AddDevice(ctx, disk)
+	}
+
+	if cmd.persist {
+		backing.DiskMode = string(types.VirtualDiskModePersistent)
+	} else {
+		backing.DiskMode = string(types.VirtualDiskModeNonpersistent)
+	}
+
+	return vm.AddDevice(ctx, disk)
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/disk/change.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/disk/change.go
@@ -1,0 +1,177 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/units"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type change struct {
+	*flags.VirtualMachineFlag
+
+	name     string
+	key      int
+	label    string
+	filePath string
+	sharing  string
+
+	bytes units.ByteSize
+	mode  string
+}
+
+func init() {
+	cli.Register("vm.disk.change", &change{})
+}
+
+func (cmd *change) Description() string {
+	return `Change some properties of a VM's DISK
+
+In particular, you can change the DISK mode, and the size (as long as it is bigger)
+
+Examples:
+  govc vm.disk.change -vm VM -disk.key 2001 -size 10G
+  govc vm.disk.change -vm VM -disk.label "BDD disk" -size 10G
+  govc vm.disk.change -vm VM -disk.name "hard-1000-0" -size 12G
+  govc vm.disk.change -vm VM -disk.filePath "[DS] VM/VM-1.vmdk" -mode nonpersistent`
+}
+
+func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+	err := (&cmd.bytes).Set("0G")
+	if err != nil {
+		panic(err)
+	}
+	f.Var(&cmd.bytes, "size", "New disk size")
+	f.StringVar(&cmd.name, "disk.name", "", "Disk name")
+	f.StringVar(&cmd.label, "disk.label", "", "Disk label")
+	f.StringVar(&cmd.filePath, "disk.filePath", "", "Disk file name")
+	f.IntVar(&cmd.key, "disk.key", 0, "Disk unique key")
+	f.StringVar(&cmd.mode, "mode", "", fmt.Sprintf("Disk mode (%s)", strings.Join(vdmTypes, "|")))
+	f.StringVar(&cmd.sharing, "sharing", "", fmt.Sprintf("Sharing (%s)", strings.Join(sharing, "|")))
+}
+
+func (cmd *change) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *change) FindDisk(ctx context.Context, list object.VirtualDeviceList) (*types.VirtualDisk, error) {
+	var disks []*types.VirtualDisk
+	for _, device := range list {
+		switch md := device.(type) {
+		case *types.VirtualDisk:
+			if cmd.CheckDiskProperties(ctx, list.Name(device), md) {
+				disks = append(disks, md)
+			}
+		default:
+			continue
+		}
+	}
+
+	switch len(disks) {
+	case 0:
+		return nil, errors.New("no disk found using the given values")
+	case 1:
+		return disks[0], nil
+	}
+	return nil, errors.New("the given disk values match multiple disks")
+}
+
+func (cmd *change) CheckDiskProperties(ctx context.Context, name string, disk *types.VirtualDisk) bool {
+	switch {
+	case cmd.key != 0 && disk.Key != int32(cmd.key):
+		fallthrough
+	case cmd.name != "" && name != cmd.name:
+		fallthrough
+	case cmd.label != "" && disk.DeviceInfo.GetDescription().Label != cmd.label:
+		return false
+	case cmd.filePath != "":
+		if b, ok := disk.Backing.(types.BaseVirtualDeviceFileBackingInfo); ok {
+			if b.GetVirtualDeviceFileBackingInfo().FileName != cmd.filePath {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	editdisk, err := cmd.FindDisk(ctx, devices)
+	if err != nil {
+		return err
+	}
+
+	if int64(cmd.bytes) != 0 {
+		editdisk.CapacityInKB = int64(cmd.bytes) / 1024
+	}
+
+	backing := editdisk.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
+	backing.Sharing = cmd.sharing
+
+	if len(cmd.mode) != 0 {
+		backing.DiskMode = cmd.mode
+	}
+
+	spec := types.VirtualMachineConfigSpec{}
+
+	config := &types.VirtualDeviceConfigSpec{
+		Device:    editdisk,
+		Operation: types.VirtualDeviceConfigSpecOperationEdit,
+	}
+
+	config.FileOperation = ""
+
+	spec.DeviceChange = append(spec.DeviceChange, config)
+
+	task, err := vm.Reconfigure(ctx, spec)
+	if err != nil {
+		return err
+	}
+
+	err = task.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("error resizing main disk\nLogged Item:  %s", err)
+	}
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/disk/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/disk/create.go
@@ -1,0 +1,168 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/units"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type create struct {
+	*flags.DatastoreFlag
+	*flags.OutputFlag
+	*flags.VirtualMachineFlag
+
+	controller string
+	Name       string
+	Bytes      units.ByteSize
+	Thick      bool
+	Eager      bool
+	DiskMode   string
+	Sharing    string
+}
+
+var vdmTypes = []string{
+	string(types.VirtualDiskModePersistent),
+	string(types.VirtualDiskModeNonpersistent),
+	string(types.VirtualDiskModeUndoable),
+	string(types.VirtualDiskModeIndependent_persistent),
+	string(types.VirtualDiskModeIndependent_nonpersistent),
+	string(types.VirtualDiskModeAppend),
+}
+
+var sharing = []string{
+	string(types.VirtualDiskSharingSharingNone),
+	string(types.VirtualDiskSharingSharingMultiWriter),
+}
+
+func init() {
+	cli.Register("vm.disk.create", &create{})
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	err := (&cmd.Bytes).Set("10G")
+	if err != nil {
+		panic(err)
+	}
+
+	f.StringVar(&cmd.controller, "controller", "", "Disk controller")
+	f.StringVar(&cmd.Name, "name", "", "Name for new disk")
+	f.Var(&cmd.Bytes, "size", "Size of new disk")
+	f.BoolVar(&cmd.Thick, "thick", false, "Thick provision new disk")
+	f.BoolVar(&cmd.Eager, "eager", false, "Eagerly scrub new disk")
+	f.StringVar(&cmd.DiskMode, "mode", vdmTypes[0], fmt.Sprintf("Disk mode (%s)", strings.Join(vdmTypes, "|")))
+	f.StringVar(&cmd.Sharing, "sharing", "", fmt.Sprintf("Sharing (%s)", strings.Join(sharing, "|")))
+}
+
+func (cmd *create) Process(ctx context.Context) error {
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *create) Description() string {
+	return `Create disk and attach to VM.
+
+Examples:
+  govc vm.disk.create -vm $name -name $name/disk1 -size 10G
+  govc vm.disk.create -vm $name -name $name/disk2 -size 10G -eager -thick -sharing sharingMultiWriter`
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	if len(cmd.Name) == 0 {
+		return errors.New("please specify a disk name")
+	}
+
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+	if vm == nil {
+		return errors.New("please specify a vm")
+	}
+
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	controller, err := devices.FindDiskController(cmd.controller)
+	if err != nil {
+		return err
+	}
+
+	vdmMatch := false
+	for _, vdm := range vdmTypes {
+		if cmd.DiskMode == vdm {
+			vdmMatch = true
+		}
+	}
+
+	if !vdmMatch {
+		return errors.New("please specify a valid disk mode")
+	}
+
+	disk := devices.CreateDisk(controller, ds.Reference(), ds.Path(cmd.Name))
+
+	existing := devices.SelectByBackingInfo(disk.Backing)
+
+	if len(existing) > 0 {
+		_, _ = cmd.Log("Disk already present\n")
+		return nil
+	}
+
+	backing := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
+
+	if cmd.Thick {
+		backing.ThinProvisioned = types.NewBool(false)
+		backing.EagerlyScrub = types.NewBool(cmd.Eager)
+	}
+
+	backing.DiskMode = cmd.DiskMode
+	backing.Sharing = cmd.Sharing
+
+	_, _ = cmd.Log("Creating disk\n")
+	disk.CapacityInKB = int64(cmd.Bytes) / 1024
+	return vm.AddDevice(ctx, disk)
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/auth.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/auth.go
@@ -1,0 +1,74 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type AuthFlag struct {
+	auth types.NamePasswordAuthentication
+	proc bool
+}
+
+func newAuthFlag(ctx context.Context) (*AuthFlag, context.Context) {
+	return &AuthFlag{}, ctx
+}
+
+func (flag *AuthFlag) String() string {
+	return fmt.Sprintf("%s:%s", flag.auth.Username, strings.Repeat("x", len(flag.auth.Password)))
+}
+
+func (flag *AuthFlag) Set(s string) error {
+	c := strings.SplitN(s, ":", 2)
+	if len(c) > 0 {
+		flag.auth.Username = c[0]
+		if len(c) > 1 {
+			flag.auth.Password = c[1]
+		}
+	}
+
+	return nil
+}
+
+func (flag *AuthFlag) Register(ctx context.Context, f *flag.FlagSet) {
+	env := "GOVC_GUEST_LOGIN"
+	value := os.Getenv(env)
+	err := flag.Set(value)
+	if err != nil {
+		fmt.Printf("couldn't set guest login values: %v", err)
+	}
+	usage := fmt.Sprintf("Guest VM credentials [%s]", env)
+	f.Var(flag, "l", usage)
+	if flag.proc {
+		f.BoolVar(&flag.auth.GuestAuthentication.InteractiveSession, "i", false, "Interactive session")
+	}
+}
+
+func (flag *AuthFlag) Process(ctx context.Context) error {
+	return nil
+}
+
+func (flag *AuthFlag) Auth() types.BaseGuestAuthentication {
+	return &flag.auth
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/chmod.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/chmod.go
@@ -1,0 +1,77 @@
+/*
+Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"context"
+	"flag"
+	"strconv"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type chmod struct {
+	*GuestFlag
+}
+
+func init() {
+	cli.Register("guest.chmod", &chmod{})
+}
+
+func (cmd *chmod) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.GuestFlag, ctx = newGuestFlag(ctx)
+	cmd.GuestFlag.Register(ctx, f)
+}
+
+func (cmd *chmod) Process(ctx context.Context) error {
+	if err := cmd.GuestFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *chmod) Usage() string {
+	return "MODE FILE"
+}
+
+func (cmd *chmod) Description() string {
+	return `Change FILE MODE on VM.
+
+Examples:
+  govc guest.chmod -vm $name 0644 /var/log/foo.log`
+}
+
+func (cmd *chmod) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 2 {
+		return flag.ErrHelp
+	}
+
+	m, err := cmd.FileManager()
+	if err != nil {
+		return err
+	}
+
+	var attr types.GuestPosixFileAttributes
+
+	attr.Permissions, err = strconv.ParseInt(f.Arg(0), 0, 64)
+	if err != nil {
+		return err
+	}
+
+	return m.ChangeFileAttributes(ctx, cmd.Auth(), f.Arg(1), &attr)
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/chown.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/chown.go
@@ -1,0 +1,96 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"context"
+	"flag"
+	"strconv"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type chown struct {
+	*GuestFlag
+}
+
+func init() {
+	cli.Register("guest.chown", &chown{})
+}
+
+func (cmd *chown) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.GuestFlag, ctx = newGuestFlag(ctx)
+	cmd.GuestFlag.Register(ctx, f)
+}
+
+func (cmd *chown) Process(ctx context.Context) error {
+	if err := cmd.GuestFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *chown) Usage() string {
+	return "UID[:GID] FILE"
+}
+
+func (cmd *chown) Description() string {
+	return `Change FILE UID and GID on VM.
+
+Examples:
+  govc guest.chown -vm $name UID[:GID] /var/log/foo.log`
+}
+
+func (cmd *chown) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 2 {
+		return flag.ErrHelp
+	}
+
+	m, err := cmd.FileManager()
+	if err != nil {
+		return err
+	}
+
+	var attr types.GuestPosixFileAttributes
+
+	ids := strings.SplitN(f.Arg(0), ":", 2)
+	if len(ids) == 0 {
+		return flag.ErrHelp
+	}
+
+	id, err := strconv.Atoi(ids[0])
+	if err != nil {
+		return err
+	}
+
+	attr.OwnerId = new(int32)
+	*attr.OwnerId = int32(id)
+
+	if len(ids) == 2 {
+		id, err = strconv.Atoi(ids[1])
+		if err != nil {
+			return err
+		}
+
+		attr.GroupId = new(int32)
+		*attr.GroupId = int32(id)
+	}
+
+	return m.ChangeFileAttributes(ctx, cmd.Auth(), f.Arg(1), &attr)
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/df.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/df.go
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/units"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type df struct {
+	*flags.VirtualMachineFlag
+}
+
+func init() {
+	cli.Register("guest.df", &df{})
+}
+
+func (cmd *df) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+}
+
+func (cmd *df) Description() string {
+	return `Report file system disk space usage.
+
+Examples:
+  govc guest.df -vm $name`
+}
+
+type dfResult []types.GuestDiskInfo
+
+func (r dfResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", "Filesystem", "Size", "Used", "Avail", "Use%")
+	for _, disk := range r {
+		used := disk.Capacity - disk.FreeSpace
+		use := 100.0 * float32(used) / float32(disk.Capacity)
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%.0f%%\n", disk.DiskPath,
+			units.ByteSize(disk.Capacity), units.ByteSize(used), units.ByteSize(disk.FreeSpace), use)
+	}
+	return tw.Flush()
+}
+
+func (cmd *df) Run(ctx context.Context, f *flag.FlagSet) error {
+	obj, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	var vm mo.VirtualMachine
+	err = obj.Properties(ctx, obj.Reference(), []string{"guest.disk"}, &vm)
+	if err != nil {
+		return err
+	}
+
+	return cmd.WriteResult(dfResult(vm.Guest.Disk))
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/download.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/download.go
@@ -1,0 +1,104 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"context"
+	"flag"
+	"io"
+	"os"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/progress"
+)
+
+type download struct {
+	*GuestFlag
+
+	overwrite bool
+}
+
+func init() {
+	cli.Register("guest.download", &download{})
+}
+
+func (cmd *download) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.GuestFlag, ctx = newGuestFlag(ctx)
+	cmd.GuestFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.overwrite, "f", false, "If set, the local destination file is clobbered")
+}
+
+func (cmd *download) Usage() string {
+	return "SOURCE DEST"
+}
+
+func (cmd *download) Description() string {
+	return `Copy SOURCE from the guest VM to DEST on the local system.
+
+If DEST name is "-", source is written to stdout.
+
+Examples:
+  govc guest.download -l user:pass -vm=my-vm /var/log/my.log ./local.log
+  govc guest.download -l user:pass -vm=my-vm /etc/motd -`
+}
+
+func (cmd *download) Process(ctx context.Context) error {
+	if err := cmd.GuestFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *download) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 2 {
+		return flag.ErrHelp
+	}
+
+	src := f.Arg(0)
+	dst := f.Arg(1)
+
+	_, err := os.Stat(dst)
+	if err == nil && !cmd.overwrite {
+		return os.ErrExist
+	}
+
+	c, err := cmd.Toolbox()
+	if err != nil {
+		return err
+	}
+
+	s, n, err := c.Download(ctx, src)
+	if err != nil {
+		return err
+	}
+
+	if dst == "-" {
+		_, err = io.Copy(os.Stdout, s)
+		return err
+	}
+
+	var p progress.Sinker
+
+	if cmd.OutputFlag.TTY {
+		logger := cmd.ProgressLogger("Downloading... ")
+		p = logger
+		defer logger.Wait()
+	}
+
+	return c.ProcessManager.Client().WriteFile(ctx, dst, s, n, p, nil)
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/file_attr.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/file_attr.go
@@ -1,0 +1,47 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type FileAttrFlag struct {
+	types.GuestPosixFileAttributes
+}
+
+func newFileAttrFlag(ctx context.Context) (*FileAttrFlag, context.Context) {
+	return &FileAttrFlag{}, ctx
+}
+
+func (flag *FileAttrFlag) Register(ctx context.Context, f *flag.FlagSet) {
+	f.Var(flags.NewOptionalInt32(&flag.OwnerId), "uid", "User ID")
+	f.Var(flags.NewOptionalInt32(&flag.GroupId), "gid", "Group ID")
+	f.Int64Var(&flag.Permissions, "perm", 0, "File permissions")
+}
+
+func (flag *FileAttrFlag) Process(ctx context.Context) error {
+	return nil
+}
+
+func (flag *FileAttrFlag) Attr() types.BaseGuestFileAttributes {
+	return &flag.GuestPosixFileAttributes
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/getenv.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/getenv.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+)
+
+type getenv struct {
+	*GuestFlag
+}
+
+func init() {
+	cli.Register("guest.getenv", &getenv{})
+}
+
+func (cmd *getenv) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.GuestFlag, ctx = newGuestProcessFlag(ctx)
+	cmd.GuestFlag.Register(ctx, f)
+}
+
+func (cmd *getenv) Process(ctx context.Context) error {
+	if err := cmd.GuestFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *getenv) Usage() string {
+	return "[NAME]..."
+}
+
+func (cmd *getenv) Description() string {
+	return `Read NAME environment variables from VM.
+
+Examples:
+  govc guest.getenv -vm $name
+  govc guest.getenv -vm $name HOME`
+}
+
+func (cmd *getenv) Run(ctx context.Context, f *flag.FlagSet) error {
+	m, err := cmd.ProcessManager()
+	if err != nil {
+		return err
+	}
+
+	vars, err := m.ReadEnvironmentVariable(ctx, cmd.Auth(), f.Args())
+	if err != nil {
+		return err
+	}
+
+	for _, v := range vars {
+		fmt.Printf("%s\n", v)
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/guest.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/guest.go
@@ -1,0 +1,157 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"net/url"
+
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/guest"
+	"github.com/vmware/govmomi/guest/toolbox"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type GuestFlag struct {
+	*flags.ClientFlag
+	*flags.VirtualMachineFlag
+
+	*AuthFlag
+}
+
+func newGuestFlag(ctx context.Context) (*GuestFlag, context.Context) {
+	f := &GuestFlag{}
+	f.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	f.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	f.AuthFlag, ctx = newAuthFlag(ctx)
+	return f, ctx
+}
+
+func newGuestProcessFlag(ctx context.Context) (*GuestFlag, context.Context) {
+	f, gctx := newGuestFlag(ctx)
+	f.proc = true
+	return f, gctx
+}
+
+func (flag *GuestFlag) Register(ctx context.Context, f *flag.FlagSet) {
+	flag.ClientFlag.Register(ctx, f)
+	flag.VirtualMachineFlag.Register(ctx, f)
+	flag.AuthFlag.Register(ctx, f)
+}
+
+func (flag *GuestFlag) Process(ctx context.Context) error {
+	if err := flag.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := flag.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := flag.AuthFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (flag *GuestFlag) Toolbox() (*toolbox.Client, error) {
+	pm, err := flag.ProcessManager()
+	if err != nil {
+		return nil, err
+	}
+
+	fm, err := flag.FileManager()
+	if err != nil {
+		return nil, err
+	}
+
+	vm, err := flag.VirtualMachine()
+	if err != nil {
+		return nil, err
+	}
+
+	family := ""
+	var props mo.VirtualMachine
+	err = vm.Properties(context.Background(), vm.Reference(), []string{"guest.guestFamily"}, &props)
+	if err != nil {
+		return nil, err
+	}
+	if props.Guest != nil {
+		family = props.Guest.GuestFamily
+	}
+
+	return &toolbox.Client{
+		ProcessManager: pm,
+		FileManager:    fm,
+		Authentication: flag.Auth(),
+		GuestFamily:    types.VirtualMachineGuestOsFamily(family),
+	}, nil
+}
+
+func (flag *GuestFlag) FileManager() (*guest.FileManager, error) {
+	ctx := context.TODO()
+	c, err := flag.Client()
+	if err != nil {
+		return nil, err
+	}
+
+	vm, err := flag.VirtualMachine()
+	if err != nil {
+		return nil, err
+	}
+
+	o := guest.NewOperationsManager(c, vm.Reference())
+	return o.FileManager(ctx)
+}
+
+func (flag *GuestFlag) ProcessManager() (*guest.ProcessManager, error) {
+	ctx := context.TODO()
+	c, err := flag.Client()
+	if err != nil {
+		return nil, err
+	}
+
+	vm, err := flag.VirtualMachine()
+	if err != nil {
+		return nil, err
+	}
+
+	o := guest.NewOperationsManager(c, vm.Reference())
+	return o.ProcessManager(ctx)
+}
+
+func (flag *GuestFlag) ParseURL(urlStr string) (*url.URL, error) {
+	c, err := flag.Client()
+	if err != nil {
+		return nil, err
+	}
+
+	return c.Client.ParseURL(urlStr)
+}
+
+func (flag *GuestFlag) VirtualMachine() (*object.VirtualMachine, error) {
+	vm, err := flag.VirtualMachineFlag.VirtualMachine()
+	if err != nil {
+		return nil, err
+	}
+	if vm == nil {
+		return nil, errors.New("no vm specified")
+	}
+	return vm, nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/kill.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/kill.go
@@ -1,0 +1,70 @@
+/*
+Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+)
+
+type kill struct {
+	*GuestFlag
+
+	pids pidSelector
+}
+
+func init() {
+	cli.Register("guest.kill", &kill{})
+}
+
+func (cmd *kill) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.GuestFlag, ctx = newGuestProcessFlag(ctx)
+	cmd.GuestFlag.Register(ctx, f)
+
+	f.Var(&cmd.pids, "p", "Process ID")
+}
+
+func (cmd *kill) Process(ctx context.Context) error {
+	if err := cmd.GuestFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *kill) Description() string {
+	return `Kill process ID on VM.
+
+Examples:
+  govc guest.kill -vm $name -p 12345`
+}
+
+func (cmd *kill) Run(ctx context.Context, f *flag.FlagSet) error {
+	m, err := cmd.ProcessManager()
+	if err != nil {
+		return err
+	}
+
+	for _, pid := range cmd.pids {
+		if err := m.TerminateProcess(ctx, cmd.Auth(), pid); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/ls.go
@@ -1,0 +1,128 @@
+/*
+Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/units"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ls struct {
+	*GuestFlag
+
+	simple bool
+}
+
+func init() {
+	cli.Register("guest.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.GuestFlag, ctx = newGuestFlag(ctx)
+	cmd.GuestFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.simple, "s", false, "Simple path only listing") // sadly we used '-l' for guest login
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.GuestFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ls) Usage() string {
+	return "PATH"
+}
+
+func (cmd *ls) Description() string {
+	return `List PATH files in VM.
+
+Examples:
+  govc guest.ls -vm $name /tmp`
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	m, err := cmd.FileManager()
+	if err != nil {
+		return err
+	}
+
+	var offset int32
+	tw := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
+
+	for {
+		info, err := m.ListFiles(ctx, cmd.Auth(), f.Arg(0), offset, 0, f.Arg(1))
+		if err != nil {
+			return err
+		}
+
+		for _, f := range info.Files {
+			if cmd.simple {
+				fmt.Fprintln(tw, f.Path)
+				continue
+			}
+
+			var kind byte
+
+			switch types.GuestFileType(f.Type) {
+			case types.GuestFileTypeDirectory:
+				kind = 'd'
+				if f.Size == 0 {
+					f.Size = 4092
+				}
+			case types.GuestFileTypeSymlink:
+				kind = 'l'
+			case types.GuestFileTypeFile:
+				kind = '-'
+			}
+
+			switch x := f.Attributes.(type) {
+			case *types.GuestPosixFileAttributes:
+				perm := os.FileMode(x.Permissions).Perm().String()[1:]
+				fmt.Fprintf(tw, "%c%s\t%d\t%d\t", kind, perm, *x.OwnerId, *x.GroupId)
+			}
+
+			attr := f.Attributes.GetGuestFileAttributes()
+
+			fmt.Fprintf(tw, "%s\t%s\t%s", units.FileSize(f.Size), attr.ModificationTime.Format("Jan 2 15:04 2006"), f.Path)
+			if attr.SymlinkTarget != "" {
+				fmt.Fprintf(tw, " -> %s", attr.SymlinkTarget)
+			}
+			fmt.Fprintln(tw)
+		}
+
+		err = tw.Flush()
+		if err != nil {
+			return err
+		}
+
+		if info.Remaining == 0 {
+			break
+		}
+		offset += int32(len(info.Files))
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/mkdir.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/mkdir.go
@@ -1,0 +1,83 @@
+/*
+Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type mkdir struct {
+	*GuestFlag
+
+	createParents bool
+}
+
+func init() {
+	cli.Register("guest.mkdir", &mkdir{})
+}
+
+func (cmd *mkdir) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.GuestFlag, ctx = newGuestFlag(ctx)
+	cmd.GuestFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.createParents, "p", false, "Create intermediate directories as needed")
+}
+
+func (cmd *mkdir) Process(ctx context.Context) error {
+	if err := cmd.GuestFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *mkdir) Usage() string {
+	return "PATH"
+}
+
+func (cmd *mkdir) Description() string {
+	return `Create directory PATH in VM.
+
+Examples:
+  govc guest.mkdir -vm $name /tmp/logs
+  govc guest.mkdir -vm $name -p /tmp/logs/foo/bar`
+}
+
+func (cmd *mkdir) Run(ctx context.Context, f *flag.FlagSet) error {
+	m, err := cmd.FileManager()
+	if err != nil {
+		return err
+	}
+
+	err = m.MakeDirectory(ctx, cmd.Auth(), f.Arg(0), cmd.createParents)
+
+	// ignore EEXIST if -p flag is given
+	if err != nil && cmd.createParents {
+		if soap.IsSoapFault(err) {
+			soapFault := soap.ToSoapFault(err)
+			if _, ok := soapFault.VimFault().(types.FileAlreadyExists); ok {
+				return nil
+			}
+		}
+	}
+
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/mktemp.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/mktemp.go
@@ -1,0 +1,86 @@
+/*
+Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+)
+
+type mktemp struct {
+	*GuestFlag
+
+	dir    bool
+	path   string
+	prefix string
+	suffix string
+}
+
+func init() {
+	cli.Register("guest.mktemp", &mktemp{})
+}
+
+func (cmd *mktemp) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.GuestFlag, ctx = newGuestFlag(ctx)
+	cmd.GuestFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.dir, "d", false, "Make a directory instead of a file")
+	f.StringVar(&cmd.path, "p", "", "If specified, create relative to this directory")
+	f.StringVar(&cmd.prefix, "t", "", "Prefix")
+	f.StringVar(&cmd.suffix, "s", "", "Suffix")
+}
+
+func (cmd *mktemp) Process(ctx context.Context) error {
+	if err := cmd.GuestFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *mktemp) Description() string {
+	return `Create a temporary file or directory in VM.
+
+Examples:
+  govc guest.mktemp -vm $name
+  govc guest.mktemp -vm $name -d
+  govc guest.mktemp -vm $name -t myprefix
+  govc guest.mktemp -vm $name -p /var/tmp/$USER`
+}
+
+func (cmd *mktemp) Run(ctx context.Context, f *flag.FlagSet) error {
+	m, err := cmd.FileManager()
+	if err != nil {
+		return err
+	}
+
+	mk := m.CreateTemporaryFile
+	if cmd.dir {
+		mk = m.CreateTemporaryDirectory
+	}
+
+	name, err := mk(ctx, cmd.Auth(), cmd.prefix, cmd.suffix, cmd.path)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(name)
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/mv.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/mv.go
@@ -1,0 +1,85 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type mv struct {
+	*GuestFlag
+
+	noclobber bool
+}
+
+func init() {
+	cli.Register("guest.mv", &mv{})
+}
+
+func (cmd *mv) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.GuestFlag, ctx = newGuestFlag(ctx)
+	cmd.GuestFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.noclobber, "n", false, "Do not overwrite an existing file")
+}
+
+func (cmd *mv) Process(ctx context.Context) error {
+	if err := cmd.GuestFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *mv) Usage() string {
+	return "SOURCE DEST"
+}
+
+func (cmd *mv) Description() string {
+	return `Move (rename) files in VM.
+
+Examples:
+  govc guest.mv -vm $name /tmp/foo.sh /tmp/bar.sh
+  govc guest.mv -vm $name -n /tmp/baz.sh /tmp/bar.sh`
+}
+
+func (cmd *mv) Run(ctx context.Context, f *flag.FlagSet) error {
+	m, err := cmd.FileManager()
+	if err != nil {
+		return err
+	}
+
+	src := f.Arg(0)
+	dst := f.Arg(1)
+
+	err = m.MoveFile(ctx, cmd.Auth(), src, dst, !cmd.noclobber)
+
+	if err != nil {
+		if soap.IsSoapFault(err) {
+			soapFault := soap.ToSoapFault(err)
+			if _, ok := soapFault.VimFault().(types.NotAFile); ok {
+				err = m.MoveDirectory(ctx, cmd.Auth(), src, dst)
+			}
+		}
+	}
+
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/ps.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/ps.go
@@ -1,0 +1,199 @@
+/*
+Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ps struct {
+	*flags.OutputFlag
+	*GuestFlag
+
+	every bool
+	exit  bool
+	wait  bool
+
+	pids pidSelector
+	uids uidSelector
+}
+
+type pidSelector []int64
+
+func (s *pidSelector) String() string {
+	return fmt.Sprint(*s)
+}
+
+func (s *pidSelector) Set(value string) error {
+	v, err := strconv.ParseInt(value, 0, 64)
+	if err != nil {
+		return err
+	}
+	*s = append(*s, v)
+	return nil
+}
+
+type uidSelector map[string]bool
+
+func (s uidSelector) String() string {
+	return ""
+}
+
+func (s uidSelector) Set(value string) error {
+	s[value] = true
+	return nil
+}
+
+func init() {
+	cli.Register("guest.ps", &ps{})
+}
+
+func (cmd *ps) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	cmd.GuestFlag, ctx = newGuestProcessFlag(ctx)
+	cmd.GuestFlag.Register(ctx, f)
+
+	cmd.uids = make(map[string]bool)
+	f.BoolVar(&cmd.every, "e", false, "Select all processes")
+	f.BoolVar(&cmd.exit, "x", false, "Output exit time and code")
+	f.BoolVar(&cmd.wait, "X", false, "Wait for process to exit")
+	f.Var(&cmd.pids, "p", "Select by process ID")
+	f.Var(&cmd.uids, "U", "Select by process UID")
+}
+
+func (cmd *ps) Process(ctx context.Context) error {
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.GuestFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ps) Description() string {
+	return `List processes in VM.
+
+By default, unless the '-e', '-p' or '-U' flag is specified, only processes owned
+by the '-l' flag user are displayed.
+
+The '-x' and '-X' flags only apply to processes started by vmware-tools,
+such as those started with the govc guest.start command.
+
+Examples:
+  govc guest.ps -vm $name
+  govc guest.ps -vm $name -e
+  govc guest.ps -vm $name -p 12345
+  govc guest.ps -vm $name -U root`
+}
+
+func running(procs []types.GuestProcessInfo) bool {
+	for _, p := range procs {
+		if p.EndTime == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (cmd *ps) list(ctx context.Context) ([]types.GuestProcessInfo, error) {
+	m, err := cmd.ProcessManager()
+	if err != nil {
+		return nil, err
+	}
+
+	auth := cmd.Auth()
+
+	for {
+		procs, err := m.ListProcesses(ctx, auth, cmd.pids)
+		if err != nil {
+			return nil, err
+		}
+
+		if cmd.wait && running(procs) {
+			<-time.After(time.Second)
+			continue
+		}
+
+		return procs, nil
+	}
+}
+
+func (cmd *ps) Run(ctx context.Context, f *flag.FlagSet) error {
+	procs, err := cmd.list(ctx)
+	if err != nil {
+		return err
+	}
+
+	r := &psResult{cmd, procs}
+
+	return cmd.WriteResult(r)
+}
+
+type psResult struct {
+	cmd         *ps
+	ProcessInfo []types.GuestProcessInfo
+}
+
+func (r *psResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	fmt.Fprintf(tw, "%s\t%s\t%s", "UID", "PID", "STIME")
+	if r.cmd.exit {
+		fmt.Fprintf(tw, "\t%s\t%s", "XTIME", "XCODE")
+	}
+	fmt.Fprint(tw, "\tCMD\n")
+
+	if len(r.cmd.pids) != 0 {
+		r.cmd.every = true
+	}
+
+	if !r.cmd.every && len(r.cmd.uids) == 0 {
+		r.cmd.uids[r.cmd.auth.Username] = true
+	}
+
+	for _, p := range r.ProcessInfo {
+		if r.cmd.every || r.cmd.uids[p.Owner] {
+			fmt.Fprintf(tw, "%s\t%d\t%s", p.Owner, p.Pid, p.StartTime.Format("15:04"))
+			if r.cmd.exit {
+				etime := "-"
+				ecode := "-"
+				if p.EndTime != nil {
+					etime = p.EndTime.Format("15:04")
+					ecode = strconv.Itoa(int(p.ExitCode))
+				}
+				fmt.Fprintf(tw, "\t%s\t%s", etime, ecode)
+			}
+			fmt.Fprintf(tw, "\t%s\n", strings.TrimSpace(p.CmdLine))
+		}
+	}
+
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/rm.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/rm.go
@@ -1,0 +1,64 @@
+/*
+Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+)
+
+type rm struct {
+	*GuestFlag
+}
+
+func init() {
+	cli.Register("guest.rm", &rm{})
+}
+
+func (cmd *rm) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.GuestFlag, ctx = newGuestFlag(ctx)
+	cmd.GuestFlag.Register(ctx, f)
+}
+
+func (cmd *rm) Process(ctx context.Context) error {
+	if err := cmd.GuestFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *rm) Usage() string {
+	return "PATH"
+}
+
+func (cmd *rm) Description() string {
+	return `Remove file PATH in VM.
+
+Examples:
+  govc guest.rm -vm $name /tmp/foo.log`
+}
+
+func (cmd *rm) Run(ctx context.Context, f *flag.FlagSet) error {
+	m, err := cmd.FileManager()
+	if err != nil {
+		return err
+	}
+
+	return m.DeleteFile(ctx, cmd.Auth(), f.Arg(0))
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/rmdir.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/rmdir.go
@@ -1,0 +1,69 @@
+/*
+Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+)
+
+type rmdir struct {
+	*GuestFlag
+
+	recursive bool
+}
+
+func init() {
+	cli.Register("guest.rmdir", &rmdir{})
+}
+
+func (cmd *rmdir) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.GuestFlag, ctx = newGuestFlag(ctx)
+	cmd.GuestFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.recursive, "r", false, "Recursive removal")
+}
+
+func (cmd *rmdir) Process(ctx context.Context) error {
+	if err := cmd.GuestFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *rmdir) Usage() string {
+	return "PATH"
+}
+
+func (cmd *rmdir) Description() string {
+	return `Remove directory PATH in VM.
+
+Examples:
+  govc guest.rmdir -vm $name /tmp/empty-dir
+  govc guest.rmdir -vm $name -r /tmp/non-empty-dir`
+}
+
+func (cmd *rmdir) Run(ctx context.Context, f *flag.FlagSet) error {
+	m, err := cmd.FileManager()
+	if err != nil {
+		return err
+	}
+
+	return m.DeleteDirectory(ctx, cmd.Auth(), f.Arg(0), cmd.recursive)
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/run.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/run.go
@@ -1,0 +1,99 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"os"
+	"os/exec"
+
+	"github.com/vmware/govmomi/govc/cli"
+)
+
+type run struct {
+	*GuestFlag
+
+	data string
+	dir  string
+	vars env
+}
+
+func init() {
+	cli.Register("guest.run", &run{})
+}
+
+func (cmd *run) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.GuestFlag, ctx = newGuestProcessFlag(ctx)
+	cmd.GuestFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.data, "d", "", "Input data string. A value of '-' reads from OS stdin")
+	f.StringVar(&cmd.dir, "C", "", "The absolute path of the working directory for the program to start")
+	f.Var(&cmd.vars, "e", "Set environment variables")
+}
+
+func (cmd *run) Usage() string {
+	return "PATH [ARG]..."
+}
+
+func (cmd *run) Description() string {
+	return `Run program PATH in VM and display output.
+
+The guest.run command starts a program in the VM with i/o redirected, waits for the process to exit and
+propagates the exit code to the govc process exit code.  Note that stdout and stderr are redirected by default,
+stdin is only redirected when the '-d' flag is specified.
+
+Examples:
+  govc guest.run -vm $name ifconfig
+  govc guest.run -vm $name ifconfig eth0
+  cal | govc guest.run -vm $name -d - cat
+  govc guest.run -vm $name -d "hello $USER" cat
+  govc guest.run -vm $name curl -s :invalid: || echo $? # exit code 6
+  govc guest.run -vm $name -e FOO=bar -e BIZ=baz -C /tmp env`
+}
+
+func (cmd *run) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+	name := f.Arg(0)
+
+	c, err := cmd.Toolbox()
+	if err != nil {
+		return err
+	}
+
+	ecmd := &exec.Cmd{
+		Path:   name,
+		Args:   f.Args()[1:],
+		Env:    cmd.vars,
+		Dir:    cmd.dir,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+
+	switch cmd.data {
+	case "":
+	case "-":
+		ecmd.Stdin = os.Stdin
+	default:
+		ecmd.Stdin = bytes.NewBuffer([]byte(cmd.data))
+	}
+
+	return c.Run(ctx, ecmd)
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/start.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/start.go
@@ -1,0 +1,103 @@
+/*
+Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type start struct {
+	*GuestFlag
+
+	dir  string
+	vars env
+}
+
+type env []string
+
+func (e *env) String() string {
+	return fmt.Sprint(*e)
+}
+
+func (e *env) Set(value string) error {
+	*e = append(*e, value)
+	return nil
+}
+
+func init() {
+	cli.Register("guest.start", &start{})
+}
+
+func (cmd *start) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.GuestFlag, ctx = newGuestProcessFlag(ctx)
+	cmd.GuestFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.dir, "C", "", "The absolute path of the working directory for the program to start")
+	f.Var(&cmd.vars, "e", "Set environment variable (key=val)")
+}
+
+func (cmd *start) Process(ctx context.Context) error {
+	if err := cmd.GuestFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *start) Usage() string {
+	return "PATH [ARG]..."
+}
+
+func (cmd *start) Description() string {
+	return `Start program in VM.
+
+The process can have its status queried with govc guest.ps.
+When the process completes, its exit code and end time will be available for 5 minutes after completion.
+
+Examples:
+  govc guest.start -vm $name /bin/mount /dev/hdb1 /data
+  pid=$(govc guest.start -vm $name /bin/long-running-thing)
+  govc guest.ps -vm $name -p $pid -X`
+}
+
+func (cmd *start) Run(ctx context.Context, f *flag.FlagSet) error {
+	m, err := cmd.ProcessManager()
+	if err != nil {
+		return err
+	}
+
+	spec := types.GuestProgramSpec{
+		ProgramPath:      f.Arg(0),
+		Arguments:        strings.Join(f.Args()[1:], " "),
+		WorkingDirectory: cmd.dir,
+		EnvVariables:     cmd.vars,
+	}
+
+	pid, err := m.StartProgram(ctx, cmd.Auth(), &spec)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%d\n", pid)
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/tools.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/tools.go
@@ -1,0 +1,116 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type tools struct {
+	*flags.ClientFlag
+	*flags.SearchFlag
+
+	mount   bool
+	upgrade bool
+	options string
+	unmount bool
+}
+
+func init() {
+	cli.Register("vm.guest.tools", &tools{})
+}
+
+func (cmd *tools) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.SearchFlag, ctx = flags.NewSearchFlag(ctx, flags.SearchVirtualMachines)
+	cmd.SearchFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.mount, "mount", false, "Mount tools CD installer in the guest")
+	f.BoolVar(&cmd.upgrade, "upgrade", false, "Upgrade tools in the guest")
+	f.StringVar(&cmd.options, "options", "", "Installer options")
+	f.BoolVar(&cmd.unmount, "unmount", false, "Unmount tools CD installer in the guest")
+}
+
+func (cmd *tools) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.SearchFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *tools) Usage() string {
+	return "VM..."
+}
+
+func (cmd *tools) Description() string {
+	return `Manage guest tools in VM.
+
+Examples:
+  govc vm.guest.tools -mount VM
+  govc vm.guest.tools -unmount VM
+  govc vm.guest.tools -upgrade -options "opt1 opt2" VM`
+}
+
+func (cmd *tools) Upgrade(ctx context.Context, vm *object.VirtualMachine) error {
+	task, err := vm.UpgradeTools(ctx, cmd.options)
+	if err != nil {
+		return err
+	}
+
+	return task.Wait(ctx)
+}
+
+func (cmd *tools) Run(ctx context.Context, f *flag.FlagSet) error {
+	vms, err := cmd.VirtualMachines(f.Args())
+	if err != nil {
+		return err
+	}
+
+	for _, vm := range vms {
+		switch {
+		case cmd.mount:
+			err = vm.MountToolsInstaller(ctx)
+			if err != nil {
+				return err
+			}
+		case cmd.upgrade:
+			err = cmd.Upgrade(ctx, vm)
+			if err != nil {
+				return err
+			}
+		case cmd.unmount:
+			err = vm.UnmountToolsInstaller(ctx)
+			if err != nil {
+				return err
+			}
+		default:
+			return flag.ErrHelp
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/touch.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/touch.go
@@ -1,0 +1,126 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"time"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type touch struct {
+	*GuestFlag
+
+	nocreate bool
+	atime    bool
+	date     string
+}
+
+func init() {
+	cli.Register("guest.touch", &touch{})
+}
+
+func (cmd *touch) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.GuestFlag, ctx = newGuestFlag(ctx)
+	cmd.GuestFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.atime, "a", false, "Change only the access time")
+	f.BoolVar(&cmd.nocreate, "c", false, "Do not create any files")
+	f.StringVar(&cmd.date, "d", "", "Use DATE instead of current time")
+}
+
+func (cmd *touch) Process(ctx context.Context) error {
+	if err := cmd.GuestFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *touch) Usage() string {
+	return "FILE"
+}
+
+func (cmd *touch) Description() string {
+	return `Change FILE times on VM.
+
+Examples:
+  govc guest.touch -vm $name /var/log/foo.log
+  govc guest.touch -vm $name -d "$(date -d '1 day ago')" /var/log/foo.log`
+}
+
+func (cmd *touch) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	m, err := cmd.FileManager()
+	if err != nil {
+		return err
+	}
+
+	name := f.Arg(0)
+
+	var attr types.GuestFileAttributes
+	now := time.Now()
+
+	if cmd.date != "" {
+		now, err = time.Parse(time.UnixDate, cmd.date)
+		if err != nil {
+			return err
+		}
+	}
+
+	if cmd.atime {
+		attr.AccessTime = &now
+	} else {
+		attr.ModificationTime = &now
+	}
+
+	err = m.ChangeFileAttributes(ctx, cmd.Auth(), name, &attr)
+	if err != nil && !cmd.nocreate && soap.IsSoapFault(err) {
+		fault := soap.ToSoapFault(err)
+		if _, ok := fault.VimFault().(types.FileNotFound); ok {
+			// create a new empty file
+			url, cerr := m.InitiateFileTransferToGuest(ctx, cmd.Auth(), name, &attr, 0, false)
+			if cerr != nil {
+				return cerr
+			}
+
+			u, cerr := cmd.ParseURL(url)
+			if cerr != nil {
+				return cerr
+			}
+
+			c, cerr := cmd.Client()
+			if cerr != nil {
+				return cerr
+			}
+
+			err = c.Client.Upload(ctx, new(bytes.Buffer), u, &soap.DefaultUpload)
+			if err == nil && cmd.date != "" {
+				err = m.ChangeFileAttributes(ctx, cmd.Auth(), name, &attr)
+			}
+		}
+	}
+
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/upload.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/upload.go
@@ -1,0 +1,108 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"context"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+type upload struct {
+	*GuestFlag
+	*FileAttrFlag
+
+	overwrite bool
+}
+
+func init() {
+	cli.Register("guest.upload", &upload{})
+}
+
+func (cmd *upload) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.GuestFlag, ctx = newGuestFlag(ctx)
+	cmd.GuestFlag.Register(ctx, f)
+	cmd.FileAttrFlag, ctx = newFileAttrFlag(ctx)
+	cmd.FileAttrFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.overwrite, "f", false, "If set, the guest destination file is clobbered")
+}
+
+func (cmd *upload) Usage() string {
+	return "SOURCE DEST"
+}
+
+func (cmd *upload) Description() string {
+	return `Copy SOURCE from the local system to DEST in the guest VM.
+
+If SOURCE name is "-", read source from stdin.
+
+Examples:
+  govc guest.upload -l user:pass -vm=my-vm ~/.ssh/id_rsa.pub /home/$USER/.ssh/authorized_keys
+  cowsay "have a great day" | govc guest.upload -l user:pass -vm=my-vm - /etc/motd`
+}
+
+func (cmd *upload) Process(ctx context.Context) error {
+	if err := cmd.GuestFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.FileAttrFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *upload) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 2 {
+		return flag.ErrHelp
+	}
+
+	c, err := cmd.Toolbox()
+	if err != nil {
+		return err
+	}
+
+	src := f.Arg(0)
+	dst := f.Arg(1)
+
+	p := soap.DefaultUpload
+
+	var r io.Reader = os.Stdin
+
+	if src != "-" {
+		f, err := os.Open(filepath.Clean(src))
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		r = f
+
+		if cmd.OutputFlag.TTY {
+			logger := cmd.ProgressLogger("Uploading... ")
+			p.Progress = logger
+			defer logger.Wait()
+		}
+	}
+
+	return c.Upload(ctx, r, dst, p, cmd.Attr(), cmd.overwrite)
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/info.go
@@ -1,0 +1,361 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vm
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/units"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+	*flags.SearchFlag
+
+	WaitForIP       bool
+	General         bool
+	ExtraConfig     bool
+	Resources       bool
+	ToolsConfigInfo bool
+}
+
+func init() {
+	cli.Register("vm.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	cmd.SearchFlag, ctx = flags.NewSearchFlag(ctx, flags.SearchVirtualMachines)
+	cmd.SearchFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.WaitForIP, "waitip", false, "Wait for VM to acquire IP address")
+	f.BoolVar(&cmd.General, "g", true, "Show general summary")
+	f.BoolVar(&cmd.ExtraConfig, "e", false, "Show ExtraConfig")
+	f.BoolVar(&cmd.Resources, "r", false, "Show resource summary")
+	f.BoolVar(&cmd.ToolsConfigInfo, "t", false, "Show ToolsConfigInfo")
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.SearchFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *info) Usage() string {
+	return `VM...`
+}
+
+func (cmd *info) Description() string {
+	return `Display info for VM.
+
+The '-r' flag displays additional info for CPU, memory and storage usage,
+along with the VM's Datastores, Networks and PortGroups.
+
+Examples:
+  govc vm.info $vm
+  govc vm.info -r $vm | grep Network:
+  govc vm.info -json $vm
+  govc find . -type m -runtime.powerState poweredOn | xargs govc vm.info`
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	vms, err := cmd.VirtualMachines(f.Args())
+	if err != nil {
+		if _, ok := err.(*find.NotFoundError); ok {
+			// Continue with empty VM slice
+		} else {
+			return err
+		}
+	}
+
+	refs := make([]types.ManagedObjectReference, 0, len(vms))
+	for _, vm := range vms {
+		refs = append(refs, vm.Reference())
+	}
+
+	var res infoResult
+	var props []string
+
+	if cmd.OutputFlag.All() {
+		props = nil // Load everything
+	} else {
+		props = []string{"summary"} // Load summary
+		if cmd.General {
+			props = append(props, "guest.ipAddress")
+		}
+		if cmd.ExtraConfig {
+			props = append(props, "config.extraConfig")
+		}
+		if cmd.Resources {
+			props = append(props, "datastore", "network")
+		}
+		if cmd.ToolsConfigInfo {
+			props = append(props, "config.tools")
+		}
+	}
+
+	pc := property.DefaultCollector(c)
+	if len(refs) != 0 {
+		err = pc.Retrieve(ctx, refs, props, &res.VirtualMachines)
+		if err != nil {
+			return err
+		}
+	}
+
+	if cmd.WaitForIP {
+		for i, vm := range res.VirtualMachines {
+			if vm.Guest == nil || vm.Guest.IpAddress == "" {
+				_, err = vms[i].WaitForIP(ctx)
+				if err != nil {
+					return err
+				}
+				// Reload virtual machine object
+				err = pc.RetrieveOne(ctx, vms[i].Reference(), props, &res.VirtualMachines[i])
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	if !cmd.OutputFlag.All() {
+		res.objects = vms
+		res.cmd = cmd
+		if err = res.collectReferences(pc, ctx); err != nil {
+			return err
+		}
+	}
+
+	return cmd.WriteResult(&res)
+}
+
+type infoResult struct {
+	VirtualMachines []mo.VirtualMachine
+	objects         []*object.VirtualMachine
+	entities        map[types.ManagedObjectReference]string
+	cmd             *info
+}
+
+// collectReferences builds a unique set of MORs to the set of VirtualMachines,
+// so we can collect properties in a single call for each reference type {host,datastore,network}.
+func (r *infoResult) collectReferences(pc *property.Collector, ctx context.Context) error {
+	// MOR -> Name map
+	r.entities = make(map[types.ManagedObjectReference]string)
+
+	var host []mo.HostSystem
+	var network []mo.Network
+	var opaque []mo.OpaqueNetwork
+	var dvp []mo.DistributedVirtualPortgroup
+	var datastore []mo.Datastore
+	// Table to drive inflating refs to their mo.* counterparts (dest)
+	// and save() the Name to r.entities w/o using reflection here.
+	// Note that we cannot use a []mo.ManagedEntity here, since mo.Network has its own 'Name' field,
+	// the mo.Network.ManagedEntity.Name field will not be set.
+	vrefs := map[string]*struct {
+		dest interface{}
+		refs []types.ManagedObjectReference
+		save func()
+	}{
+		"HostSystem": {
+			&host, nil, func() {
+				for _, e := range host {
+					r.entities[e.Reference()] = e.Name
+				}
+			},
+		},
+		"Network": {
+			&network, nil, func() {
+				for _, e := range network {
+					r.entities[e.Reference()] = e.Name
+				}
+			},
+		},
+		"OpaqueNetwork": {
+			&opaque, nil, func() {
+				for _, e := range opaque {
+					r.entities[e.Reference()] = e.Name
+				}
+			},
+		},
+		"DistributedVirtualPortgroup": {
+			&dvp, nil, func() {
+				for _, e := range dvp {
+					r.entities[e.Reference()] = e.Name
+				}
+			},
+		},
+		"Datastore": {
+			&datastore, nil, func() {
+				for _, e := range datastore {
+					r.entities[e.Reference()] = e.Name
+				}
+			},
+		},
+	}
+
+	xrefs := make(map[types.ManagedObjectReference]bool)
+	// Add MOR to vrefs[kind].refs avoiding any duplicates.
+	addRef := func(refs ...types.ManagedObjectReference) {
+		for _, ref := range refs {
+			if _, exists := xrefs[ref]; exists {
+				return
+			}
+			xrefs[ref] = true
+			vref := vrefs[ref.Type]
+			vref.refs = append(vref.refs, ref)
+		}
+	}
+
+	for _, vm := range r.VirtualMachines {
+		if r.cmd.General {
+			if ref := vm.Summary.Runtime.Host; ref != nil {
+				addRef(*ref)
+			}
+		}
+
+		if r.cmd.Resources {
+			addRef(vm.Datastore...)
+			addRef(vm.Network...)
+		}
+	}
+
+	for _, vref := range vrefs {
+		if vref.refs == nil {
+			continue
+		}
+		err := pc.Retrieve(ctx, vref.refs, []string{"name"}, vref.dest)
+		if err != nil {
+			return err
+		}
+		vref.save()
+	}
+
+	return nil
+}
+
+func (r *infoResult) entityNames(refs []types.ManagedObjectReference) string {
+	var names []string
+	for _, ref := range refs {
+		names = append(names, r.entities[ref])
+	}
+	return strings.Join(names, ", ")
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	// Maintain order via r.objects as Property collector does not always return results in order.
+	objects := make(map[types.ManagedObjectReference]mo.VirtualMachine, len(r.VirtualMachines))
+	for _, o := range r.VirtualMachines {
+		objects[o.Reference()] = o
+	}
+
+	tw := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
+
+	for _, o := range r.objects {
+		vm := objects[o.Reference()]
+		s := vm.Summary
+
+		fmt.Fprintf(tw, "Name:\t%s\n", s.Config.Name)
+
+		if r.cmd.General {
+			hostName := "<unavailable>"
+
+			if href := vm.Summary.Runtime.Host; href != nil {
+				if name, ok := r.entities[*href]; ok {
+					hostName = name
+				}
+			}
+
+			fmt.Fprintf(tw, "  Path:\t%s\n", o.InventoryPath)
+			fmt.Fprintf(tw, "  UUID:\t%s\n", s.Config.Uuid)
+			fmt.Fprintf(tw, "  Guest name:\t%s\n", s.Config.GuestFullName)
+			fmt.Fprintf(tw, "  Memory:\t%dMB\n", s.Config.MemorySizeMB)
+			fmt.Fprintf(tw, "  CPU:\t%d vCPU(s)\n", s.Config.NumCpu)
+			fmt.Fprintf(tw, "  Power state:\t%s\n", s.Runtime.PowerState)
+			fmt.Fprintf(tw, "  Boot time:\t%s\n", s.Runtime.BootTime)
+			fmt.Fprintf(tw, "  IP address:\t%s\n", s.Guest.IpAddress)
+			fmt.Fprintf(tw, "  Host:\t%s\n", hostName)
+		}
+
+		if r.cmd.Resources {
+			if s.Storage == nil {
+				s.Storage = new(types.VirtualMachineStorageSummary)
+			}
+			fmt.Fprintf(tw, "  CPU usage:\t%dMHz\n", s.QuickStats.OverallCpuUsage)
+			fmt.Fprintf(tw, "  Host memory usage:\t%dMB\n", s.QuickStats.HostMemoryUsage)
+			fmt.Fprintf(tw, "  Guest memory usage:\t%dMB\n", s.QuickStats.GuestMemoryUsage)
+			fmt.Fprintf(tw, "  Storage uncommitted:\t%s\n", units.ByteSize(s.Storage.Uncommitted))
+			fmt.Fprintf(tw, "  Storage committed:\t%s\n", units.ByteSize(s.Storage.Committed))
+			fmt.Fprintf(tw, "  Storage unshared:\t%s\n", units.ByteSize(s.Storage.Unshared))
+			fmt.Fprintf(tw, "  Storage:\t%s\n", r.entityNames(vm.Datastore))
+			fmt.Fprintf(tw, "  Network:\t%s\n", r.entityNames(vm.Network))
+		}
+
+		if r.cmd.ExtraConfig {
+			fmt.Fprintf(tw, "  ExtraConfig:\n")
+			for _, v := range vm.Config.ExtraConfig {
+				fmt.Fprintf(tw, "    %s:\t%s\n", v.GetOptionValue().Key, v.GetOptionValue().Value)
+			}
+		}
+
+		if r.cmd.ToolsConfigInfo {
+			t := vm.Config.Tools
+			fmt.Fprintf(tw, "  ToolsConfigInfo:\n")
+			fmt.Fprintf(tw, "    ToolsVersion:\t%d\n", t.ToolsVersion)
+			fmt.Fprintf(tw, "    AfterPowerOn:\t%s\n", flags.NewOptionalBool(&t.AfterPowerOn).String())
+			fmt.Fprintf(tw, "    AfterResume:\t%s\n", flags.NewOptionalBool(&t.AfterResume).String())
+			fmt.Fprintf(tw, "    BeforeGuestStandby:\t%s\n", flags.NewOptionalBool(&t.BeforeGuestStandby).String())
+			fmt.Fprintf(tw, "    BeforeGuestShutdown:\t%s\n", flags.NewOptionalBool(&t.BeforeGuestShutdown).String())
+			fmt.Fprintf(tw, "    BeforeGuestReboot:\t%s\n", flags.NewOptionalBool(&t.BeforeGuestReboot).String())
+			fmt.Fprintf(tw, "    ToolsUpgradePolicy:\t%s\n", t.ToolsUpgradePolicy)
+			fmt.Fprintf(tw, "    PendingCustomization:\t%s\n", t.PendingCustomization)
+			fmt.Fprintf(tw, "    SyncTimeWithHost:\t%s\n", flags.NewOptionalBool(&t.SyncTimeWithHost).String())
+		}
+	}
+
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/ip.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/ip.go
@@ -1,0 +1,192 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vm
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/govc/host/esxcli"
+	"github.com/vmware/govmomi/object"
+)
+
+type ip struct {
+	*flags.OutputFlag
+	*flags.SearchFlag
+
+	esx  bool
+	all  bool
+	v4   bool
+	wait time.Duration
+	nic  string
+}
+
+func init() {
+	cli.Register("vm.ip", &ip{})
+}
+
+func (cmd *ip) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	cmd.SearchFlag, ctx = flags.NewSearchFlag(ctx, flags.SearchVirtualMachines)
+	cmd.SearchFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.esx, "esxcli", false, "Use esxcli instead of guest tools")
+	f.BoolVar(&cmd.all, "a", false, "Wait for an IP address on all NICs")
+	f.StringVar(&cmd.nic, "n", "", "Wait for IP address on NIC, specified by device name or MAC")
+	f.BoolVar(&cmd.v4, "v4", false, "Only report IPv4 addresses")
+	f.DurationVar(&cmd.wait, "wait", time.Hour, "Wait time for the VM obtain an IP address")
+}
+
+func (cmd *ip) Usage() string {
+	return "VM..."
+}
+
+func (cmd *ip) Description() string {
+	return `List IPs for VM.
+
+By default the vm.ip command depends on vmware-tools to report the 'guest.ipAddress' field and will
+wait until it has done so.  This value can also be obtained using:
+
+  govc vm.info -json $vm | jq -r .VirtualMachines[].Guest.IpAddress
+
+When given the '-a' flag, only IP addresses for which there is a corresponding virtual nic are listed.
+If there are multiple nics, the listed addresses will be comma delimited.  The '-a' flag depends on
+vmware-tools to report the 'guest.net' field and will wait until it has done so for all nics.
+Note that this list includes IPv6 addresses if any, use '-v4' to filter them out.  IP addresses reported
+by tools for which there is no virtual nic are not included, for example that of the 'docker0' interface.
+
+These values can also be obtained using:
+
+  govc vm.info -json $vm | jq -r .VirtualMachines[].Guest.Net[].IpConfig.IpAddress[].IpAddress
+
+When given the '-n' flag, filters '-a' behavior to the nic specified by MAC address or device name.
+
+The 'esxcli' flag does not require vmware-tools to be installed, but does require the ESX host to
+have the /Net/GuestIPHack setting enabled.
+
+The 'wait' flag default to 1hr (original default was infinite).  If a VM does not obtain an IP within
+the wait time, the command will still exit with status 0.
+
+Examples:
+  govc vm.ip $vm
+  govc vm.ip -wait 5m $vm
+  govc vm.ip -a -v4 $vm
+  govc vm.ip -n 00:0c:29:57:7b:c3 $vm
+  govc vm.ip -n ethernet-0 $vm
+  govc host.esxcli system settings advanced set -o /Net/GuestIPHack -i 1
+  govc vm.ip -esxcli $vm`
+}
+
+func (cmd *ip) Process(ctx context.Context) error {
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.SearchFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ip) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	vms, err := cmd.VirtualMachines(f.Args())
+	if err != nil {
+		return err
+	}
+
+	var get func(*object.VirtualMachine, context.Context) (string, error)
+
+	if cmd.esx {
+		get = func(vm *object.VirtualMachine, deadline context.Context) (string, error) {
+			guest := esxcli.NewGuestInfo(c)
+
+			ticker := time.NewTicker(time.Millisecond * 500)
+			defer ticker.Stop()
+
+			for {
+				select {
+				case <-ticker.C:
+					ip, err := guest.IpAddress(vm)
+					if err != nil {
+						return "", err
+					}
+
+					if ip != "0.0.0.0" {
+						return ip, nil
+					}
+				case <-deadline.Done():
+					return "", nil
+				}
+			}
+		}
+	} else {
+		var hwaddr []string
+		if cmd.nic != "" {
+			hwaddr = strings.Split(cmd.nic, ",")
+		}
+
+		get = func(vm *object.VirtualMachine, deadline context.Context) (string, error) {
+			if cmd.all || hwaddr != nil {
+				macs, err := vm.WaitForNetIP(deadline, cmd.v4, hwaddr...)
+				if err != nil {
+					return "", err
+				}
+
+				var ips []string
+				for _, addrs := range macs {
+					ips = append(ips, addrs...)
+				}
+				return strings.Join(ips, ","), nil
+			}
+			return vm.WaitForIP(deadline, cmd.v4)
+		}
+	}
+
+	for _, vm := range vms {
+		deadline, cancel := context.WithDeadline(ctx, time.Now().Add(cmd.wait))
+
+		ip, err := get(vm, deadline)
+		if err != nil {
+			if deadline.Err() != context.DeadlineExceeded {
+				cancel()
+				return err
+			}
+		}
+
+		cancel()
+
+		if ip == "" {
+			continue
+		}
+
+		// TODO(PN): Display inventory path to VM
+		fmt.Fprintf(cmd, "%s\n", ip)
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/keystrokes.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/keystrokes.go
@@ -1,0 +1,710 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vm
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type hidKey struct {
+	Code         int32
+	ShiftPressed bool
+}
+
+// stolen from
+// https://gist.github.com/MightyPork/6da26e382a7ad91b5496ee55fdc73db2#file-usb_hid_keys-h-L110
+const (
+	KEY_MOD_LCTRL          = 0x01
+	KEY_MOD_LSHIFT         = 0x02
+	KEY_MOD_LALT           = 0x04
+	KEY_MOD_LMETA          = 0x08
+	KEY_MOD_RCTRL          = 0x10
+	KEY_MOD_RSHIFT         = 0x20
+	KEY_MOD_RALT           = 0x40
+	KEY_MOD_RMETA          = 0x80
+	KEY_NONE               = 0x00
+	KEY_ERR_OVF            = 0x01
+	KEY_A                  = 0x04
+	KEY_B                  = 0x05
+	KEY_C                  = 0x06
+	KEY_D                  = 0x07
+	KEY_E                  = 0x08
+	KEY_F                  = 0x09
+	KEY_G                  = 0x0a
+	KEY_H                  = 0x0b
+	KEY_I                  = 0x0c
+	KEY_J                  = 0x0d
+	KEY_K                  = 0x0e
+	KEY_L                  = 0x0f
+	KEY_M                  = 0x10
+	KEY_N                  = 0x11
+	KEY_O                  = 0x12
+	KEY_P                  = 0x13
+	KEY_Q                  = 0x14
+	KEY_R                  = 0x15
+	KEY_S                  = 0x16
+	KEY_T                  = 0x17
+	KEY_U                  = 0x18
+	KEY_V                  = 0x19
+	KEY_W                  = 0x1a
+	KEY_X                  = 0x1b
+	KEY_Y                  = 0x1c
+	KEY_Z                  = 0x1d
+	KEY_1                  = 0x1e
+	KEY_2                  = 0x1f
+	KEY_3                  = 0x20
+	KEY_4                  = 0x21
+	KEY_5                  = 0x22
+	KEY_6                  = 0x23
+	KEY_7                  = 0x24
+	KEY_8                  = 0x25
+	KEY_9                  = 0x26
+	KEY_0                  = 0x27
+	KEY_ENTER              = 0x28
+	KEY_ESC                = 0x29
+	KEY_BACKSPACE          = 0x2a
+	KEY_TAB                = 0x2b
+	KEY_SPACE              = 0x2c
+	KEY_MINUS              = 0x2d
+	KEY_EQUAL              = 0x2e
+	KEY_LEFTBRACE          = 0x2f
+	KEY_RIGHTBRACE         = 0x30
+	KEY_BACKSLASH          = 0x31
+	KEY_HASHTILDE          = 0x32
+	KEY_SEMICOLON          = 0x33
+	KEY_APOSTROPHE         = 0x34
+	KEY_GRAVE              = 0x35
+	KEY_COMMA              = 0x36
+	KEY_DOT                = 0x37
+	KEY_SLASH              = 0x38
+	KEY_CAPSLOCK           = 0x39
+	KEY_F1                 = 0x3a
+	KEY_F2                 = 0x3b
+	KEY_F3                 = 0x3c
+	KEY_F4                 = 0x3d
+	KEY_F5                 = 0x3e
+	KEY_F6                 = 0x3f
+	KEY_F7                 = 0x40
+	KEY_F8                 = 0x41
+	KEY_F9                 = 0x42
+	KEY_F10                = 0x43
+	KEY_F11                = 0x44
+	KEY_F12                = 0x45
+	KEY_SYSRQ              = 0x46
+	KEY_SCROLLLOCK         = 0x47
+	KEY_PAUSE              = 0x48
+	KEY_INSERT             = 0x49
+	KEY_HOME               = 0x4a
+	KEY_PAGEUP             = 0x4b
+	KEY_DELETE             = 0x4c
+	KEY_END                = 0x4d
+	KEY_PAGEDOWN           = 0x4e
+	KEY_RIGHT              = 0x4f
+	KEY_LEFT               = 0x50
+	KEY_DOWN               = 0x51
+	KEY_UP                 = 0x52
+	KEY_NUMLOCK            = 0x53
+	KEY_KPSLASH            = 0x54
+	KEY_KPASTERISK         = 0x55
+	KEY_KPMINUS            = 0x56
+	KEY_KPPLUS             = 0x57
+	KEY_KPENTER            = 0x58
+	KEY_KP1                = 0x59
+	KEY_KP2                = 0x5a
+	KEY_KP3                = 0x5b
+	KEY_KP4                = 0x5c
+	KEY_KP5                = 0x5d
+	KEY_KP6                = 0x5e
+	KEY_KP7                = 0x5f
+	KEY_KP8                = 0x60
+	KEY_KP9                = 0x61
+	KEY_KP0                = 0x62
+	KEY_KPDOT              = 0x63
+	KEY_102ND              = 0x64
+	KEY_COMPOSE            = 0x65
+	KEY_POWER              = 0x66
+	KEY_KPEQUAL            = 0x67
+	KEY_F13                = 0x68
+	KEY_F14                = 0x69
+	KEY_F15                = 0x6a
+	KEY_F16                = 0x6b
+	KEY_F17                = 0x6c
+	KEY_F18                = 0x6d
+	KEY_F19                = 0x6e
+	KEY_F20                = 0x6f
+	KEY_F21                = 0x70
+	KEY_F22                = 0x71
+	KEY_F23                = 0x72
+	KEY_F24                = 0x73
+	KEY_OPEN               = 0x74
+	KEY_HELP               = 0x75
+	KEY_PROPS              = 0x76
+	KEY_FRONT              = 0x77
+	KEY_STOP               = 0x78
+	KEY_AGAIN              = 0x79
+	KEY_UNDO               = 0x7a
+	KEY_CUT                = 0x7b
+	KEY_COPY               = 0x7c
+	KEY_PASTE              = 0x7d
+	KEY_FIND               = 0x7e
+	KEY_MUTE               = 0x7f
+	KEY_VOLUMEUP           = 0x80
+	KEY_VOLUMEDOWN         = 0x81
+	KEY_KPCOMMA            = 0x85
+	KEY_RO                 = 0x87
+	KEY_KATAKANAHIRAGANA   = 0x88
+	KEY_YEN                = 0x89
+	KEY_HENKAN             = 0x8a
+	KEY_MUHENKAN           = 0x8b
+	KEY_KPJPCOMMA          = 0x8c
+	KEY_HANGEUL            = 0x90
+	KEY_HANJA              = 0x91
+	KEY_KATAKANA           = 0x92
+	KEY_HIRAGANA           = 0x93
+	KEY_ZENKAKUHANKAKU     = 0x94
+	KEY_KPLEFTPAREN        = 0xb6
+	KEY_KPRIGHTPAREN       = 0xb7
+	KEY_LEFTCTRL           = 0xe0
+	KEY_LEFTSHIFT          = 0xe1
+	KEY_LEFTALT            = 0xe2
+	KEY_LEFTMETA           = 0xe3
+	KEY_RIGHTCTRL          = 0xe4
+	KEY_RIGHTSHIFT         = 0xe5
+	KEY_RIGHTALT           = 0xe6
+	KEY_RIGHTMETA          = 0xe7
+	KEY_MEDIA_PLAYPAUSE    = 0xe8
+	KEY_MEDIA_STOPCD       = 0xe9
+	KEY_MEDIA_PREVIOUSSONG = 0xea
+	KEY_MEDIA_NEXTSONG     = 0xeb
+	KEY_MEDIA_EJECTCD      = 0xec
+	KEY_MEDIA_VOLUMEUP     = 0xed
+	KEY_MEDIA_VOLUMEDOWN   = 0xee
+	KEY_MEDIA_MUTE         = 0xef
+	KEY_MEDIA_WWW          = 0xf0
+	KEY_MEDIA_BACK         = 0xf1
+	KEY_MEDIA_FORWARD      = 0xf2
+	KEY_MEDIA_STOP         = 0xf3
+	KEY_MEDIA_FIND         = 0xf4
+	KEY_MEDIA_SCROLLUP     = 0xf5
+	KEY_MEDIA_SCROLLDOWN   = 0xf6
+	KEY_MEDIA_EDIT         = 0xf7
+	KEY_MEDIA_SLEEP        = 0xf8
+	KEY_MEDIA_COFFEE       = 0xf9
+	KEY_MEDIA_REFRESH      = 0xfa
+	KEY_MEDIA_CALC         = 0xfb
+)
+
+var hidKeyMap = map[string]int32{
+	"KEY_MOD_LCTRL":          KEY_MOD_LCTRL,
+	"KEY_MOD_LSHIFT":         KEY_MOD_LSHIFT,
+	"KEY_MOD_LALT":           KEY_MOD_LALT,
+	"KEY_MOD_LMETA":          KEY_MOD_LMETA,
+	"KEY_MOD_RCTRL":          KEY_MOD_RCTRL,
+	"KEY_MOD_RSHIFT":         KEY_MOD_RSHIFT,
+	"KEY_MOD_RALT":           KEY_MOD_RALT,
+	"KEY_MOD_RMETA":          KEY_MOD_RMETA,
+	"KEY_NONE":               KEY_NONE,
+	"KEY_ERR_OVF":            KEY_ERR_OVF,
+	"KEY_A":                  KEY_A,
+	"KEY_B":                  KEY_B,
+	"KEY_C":                  KEY_C,
+	"KEY_D":                  KEY_D,
+	"KEY_E":                  KEY_E,
+	"KEY_F":                  KEY_F,
+	"KEY_G":                  KEY_G,
+	"KEY_H":                  KEY_H,
+	"KEY_I":                  KEY_I,
+	"KEY_J":                  KEY_J,
+	"KEY_K":                  KEY_K,
+	"KEY_L":                  KEY_L,
+	"KEY_M":                  KEY_M,
+	"KEY_N":                  KEY_N,
+	"KEY_O":                  KEY_O,
+	"KEY_P":                  KEY_P,
+	"KEY_Q":                  KEY_Q,
+	"KEY_R":                  KEY_R,
+	"KEY_S":                  KEY_S,
+	"KEY_T":                  KEY_T,
+	"KEY_U":                  KEY_U,
+	"KEY_V":                  KEY_V,
+	"KEY_W":                  KEY_W,
+	"KEY_X":                  KEY_X,
+	"KEY_Y":                  KEY_Y,
+	"KEY_Z":                  KEY_Z,
+	"KEY_1":                  KEY_1,
+	"KEY_2":                  KEY_2,
+	"KEY_3":                  KEY_3,
+	"KEY_4":                  KEY_4,
+	"KEY_5":                  KEY_5,
+	"KEY_6":                  KEY_6,
+	"KEY_7":                  KEY_7,
+	"KEY_8":                  KEY_8,
+	"KEY_9":                  KEY_9,
+	"KEY_0":                  KEY_0,
+	"KEY_ENTER":              KEY_ENTER,
+	"KEY_ESC":                KEY_ESC,
+	"KEY_BACKSPACE":          KEY_BACKSPACE,
+	"KEY_TAB":                KEY_TAB,
+	"KEY_SPACE":              KEY_SPACE,
+	"KEY_MINUS":              KEY_MINUS,
+	"KEY_EQUAL":              KEY_EQUAL,
+	"KEY_LEFTBRACE":          KEY_LEFTBRACE,
+	"KEY_RIGHTBRACE":         KEY_RIGHTBRACE,
+	"KEY_BACKSLASH":          KEY_BACKSLASH,
+	"KEY_HASHTILDE":          KEY_HASHTILDE,
+	"KEY_SEMICOLON":          KEY_SEMICOLON,
+	"KEY_APOSTROPHE":         KEY_APOSTROPHE,
+	"KEY_GRAVE":              KEY_GRAVE,
+	"KEY_COMMA":              KEY_COMMA,
+	"KEY_DOT":                KEY_DOT,
+	"KEY_SLASH":              KEY_SLASH,
+	"KEY_CAPSLOCK":           KEY_CAPSLOCK,
+	"KEY_F1":                 KEY_F1,
+	"KEY_F2":                 KEY_F2,
+	"KEY_F3":                 KEY_F3,
+	"KEY_F4":                 KEY_F4,
+	"KEY_F5":                 KEY_F5,
+	"KEY_F6":                 KEY_F6,
+	"KEY_F7":                 KEY_F7,
+	"KEY_F8":                 KEY_F8,
+	"KEY_F9":                 KEY_F9,
+	"KEY_F10":                KEY_F10,
+	"KEY_F11":                KEY_F11,
+	"KEY_F12":                KEY_F12,
+	"KEY_SYSRQ":              KEY_SYSRQ,
+	"KEY_SCROLLLOCK":         KEY_SCROLLLOCK,
+	"KEY_PAUSE":              KEY_PAUSE,
+	"KEY_INSERT":             KEY_INSERT,
+	"KEY_HOME":               KEY_HOME,
+	"KEY_PAGEUP":             KEY_PAGEUP,
+	"KEY_DELETE":             KEY_DELETE,
+	"KEY_END":                KEY_END,
+	"KEY_PAGEDOWN":           KEY_PAGEDOWN,
+	"KEY_RIGHT":              KEY_RIGHT,
+	"KEY_LEFT":               KEY_LEFT,
+	"KEY_DOWN":               KEY_DOWN,
+	"KEY_UP":                 KEY_UP,
+	"KEY_NUMLOCK":            KEY_NUMLOCK,
+	"KEY_KPSLASH":            KEY_KPSLASH,
+	"KEY_KPASTERISK":         KEY_KPASTERISK,
+	"KEY_KPMINUS":            KEY_KPMINUS,
+	"KEY_KPPLUS":             KEY_KPPLUS,
+	"KEY_KPENTER":            KEY_KPENTER,
+	"KEY_KP1":                KEY_KP1,
+	"KEY_KP2":                KEY_KP2,
+	"KEY_KP3":                KEY_KP3,
+	"KEY_KP4":                KEY_KP4,
+	"KEY_KP5":                KEY_KP5,
+	"KEY_KP6":                KEY_KP6,
+	"KEY_KP7":                KEY_KP7,
+	"KEY_KP8":                KEY_KP8,
+	"KEY_KP9":                KEY_KP9,
+	"KEY_KP0":                KEY_KP0,
+	"KEY_KPDOT":              KEY_KPDOT,
+	"KEY_102ND":              KEY_102ND,
+	"KEY_COMPOSE":            KEY_COMPOSE,
+	"KEY_POWER":              KEY_POWER,
+	"KEY_KPEQUAL":            KEY_KPEQUAL,
+	"KEY_F13":                KEY_F13,
+	"KEY_F14":                KEY_F14,
+	"KEY_F15":                KEY_F15,
+	"KEY_F16":                KEY_F16,
+	"KEY_F17":                KEY_F17,
+	"KEY_F18":                KEY_F18,
+	"KEY_F19":                KEY_F19,
+	"KEY_F20":                KEY_F20,
+	"KEY_F21":                KEY_F21,
+	"KEY_F22":                KEY_F22,
+	"KEY_F23":                KEY_F23,
+	"KEY_F24":                KEY_F24,
+	"KEY_OPEN":               KEY_OPEN,
+	"KEY_HELP":               KEY_HELP,
+	"KEY_PROPS":              KEY_PROPS,
+	"KEY_FRONT":              KEY_FRONT,
+	"KEY_STOP":               KEY_STOP,
+	"KEY_AGAIN":              KEY_AGAIN,
+	"KEY_UNDO":               KEY_UNDO,
+	"KEY_CUT":                KEY_CUT,
+	"KEY_COPY":               KEY_COPY,
+	"KEY_PASTE":              KEY_PASTE,
+	"KEY_FIND":               KEY_FIND,
+	"KEY_MUTE":               KEY_MUTE,
+	"KEY_VOLUMEUP":           KEY_VOLUMEUP,
+	"KEY_VOLUMEDOWN":         KEY_VOLUMEDOWN,
+	"KEY_KPCOMMA":            KEY_KPCOMMA,
+	"KEY_RO":                 KEY_RO,
+	"KEY_KATAKANAHIRAGANA":   KEY_KATAKANAHIRAGANA,
+	"KEY_YEN":                KEY_YEN,
+	"KEY_HENKAN":             KEY_HENKAN,
+	"KEY_MUHENKAN":           KEY_MUHENKAN,
+	"KEY_KPJPCOMMA":          KEY_KPJPCOMMA,
+	"KEY_HANGEUL":            KEY_HANGEUL,
+	"KEY_HANJA":              KEY_HANJA,
+	"KEY_KATAKANA":           KEY_KATAKANA,
+	"KEY_HIRAGANA":           KEY_HIRAGANA,
+	"KEY_ZENKAKUHANKAKU":     KEY_ZENKAKUHANKAKU,
+	"KEY_KPLEFTPAREN":        KEY_KPLEFTPAREN,
+	"KEY_KPRIGHTPAREN":       KEY_KPRIGHTPAREN,
+	"KEY_LEFTCTRL":           KEY_LEFTCTRL,
+	"KEY_LEFTSHIFT":          KEY_LEFTSHIFT,
+	"KEY_LEFTALT":            KEY_LEFTALT,
+	"KEY_LEFTMETA":           KEY_LEFTMETA,
+	"KEY_RIGHTCTRL":          KEY_RIGHTCTRL,
+	"KEY_RIGHTSHIFT":         KEY_RIGHTSHIFT,
+	"KEY_RIGHTALT":           KEY_RIGHTALT,
+	"KEY_RIGHTMETA":          KEY_RIGHTMETA,
+	"KEY_MEDIA_PLAYPAUSE":    KEY_MEDIA_PLAYPAUSE,
+	"KEY_MEDIA_STOPCD":       KEY_MEDIA_STOPCD,
+	"KEY_MEDIA_PREVIOUSSONG": KEY_MEDIA_PREVIOUSSONG,
+	"KEY_MEDIA_NEXTSONG":     KEY_MEDIA_NEXTSONG,
+	"KEY_MEDIA_EJECTCD":      KEY_MEDIA_EJECTCD,
+	"KEY_MEDIA_VOLUMEUP":     KEY_MEDIA_VOLUMEUP,
+	"KEY_MEDIA_VOLUMEDOWN":   KEY_MEDIA_VOLUMEDOWN,
+	"KEY_MEDIA_MUTE":         KEY_MEDIA_MUTE,
+	"KEY_MEDIA_WWW":          KEY_MEDIA_WWW,
+	"KEY_MEDIA_BACK":         KEY_MEDIA_BACK,
+	"KEY_MEDIA_FORWARD":      KEY_MEDIA_FORWARD,
+	"KEY_MEDIA_STOP":         KEY_MEDIA_STOP,
+	"KEY_MEDIA_FIND":         KEY_MEDIA_FIND,
+	"KEY_MEDIA_SCROLLUP":     KEY_MEDIA_SCROLLUP,
+	"KEY_MEDIA_SCROLLDOWN":   KEY_MEDIA_SCROLLDOWN,
+	"KEY_MEDIA_EDIT":         KEY_MEDIA_EDIT,
+	"KEY_MEDIA_SLEEP":        KEY_MEDIA_SLEEP,
+	"KEY_MEDIA_COFFEE":       KEY_MEDIA_COFFEE,
+	"KEY_MEDIA_REFRESH":      KEY_MEDIA_REFRESH,
+	"KEY_MEDIA_CALC":         KEY_MEDIA_CALC,
+}
+
+var hidCharacterMap = map[string]hidKey{
+	"a": {KEY_A, false},
+	"b": {KEY_B, false},
+	"c": {KEY_C, false},
+	"d": {KEY_D, false},
+	"e": {KEY_E, false},
+	"f": {KEY_F, false},
+	"g": {KEY_G, false},
+	"h": {KEY_H, false},
+	"i": {KEY_I, false},
+	"j": {KEY_J, false},
+	"k": {KEY_K, false},
+	"l": {KEY_L, false},
+	"m": {KEY_M, false},
+	"n": {KEY_N, false},
+	"o": {KEY_O, false},
+	"p": {KEY_P, false},
+	"q": {KEY_Q, false},
+	"r": {KEY_R, false},
+	"s": {KEY_S, false},
+	"t": {KEY_T, false},
+	"u": {KEY_U, false},
+	"v": {KEY_V, false},
+	"w": {KEY_W, false},
+	"x": {KEY_X, false},
+	"y": {KEY_Y, false},
+	"z": {KEY_Z, false},
+	"1": {KEY_1, false},
+	"2": {KEY_2, false},
+	"3": {KEY_3, false},
+	"4": {KEY_4, false},
+	"5": {KEY_5, false},
+	"6": {KEY_6, false},
+	"7": {KEY_7, false},
+	"8": {KEY_8, false},
+	"9": {KEY_9, false},
+	"0": {KEY_0, false},
+	"A": {KEY_A, true},
+	"B": {KEY_B, true},
+	"C": {KEY_C, true},
+	"D": {KEY_D, true},
+	"E": {KEY_E, true},
+	"F": {KEY_F, true},
+	"G": {KEY_G, true},
+	"H": {KEY_H, true},
+	"I": {KEY_I, true},
+	"J": {KEY_J, true},
+	"K": {KEY_K, true},
+	"L": {KEY_L, true},
+	"M": {KEY_M, true},
+	"N": {KEY_N, true},
+	"O": {KEY_O, true},
+	"P": {KEY_P, true},
+	"Q": {KEY_Q, true},
+	"R": {KEY_R, true},
+	"S": {KEY_S, true},
+	"T": {KEY_T, true},
+	"U": {KEY_U, true},
+	"V": {KEY_V, true},
+	"W": {KEY_W, true},
+	"X": {KEY_X, true},
+	"Y": {KEY_Y, true},
+	"Z": {KEY_Z, true},
+	"!": {KEY_1, true},
+	"@": {KEY_2, true},
+	"#": {KEY_3, true},
+	"$": {KEY_4, true},
+	"%": {KEY_5, true},
+	"^": {KEY_6, true},
+	"&": {KEY_7, true},
+	"*": {KEY_8, true},
+	"(": {KEY_9, true},
+	")": {KEY_0, true},
+	" ": {KEY_SPACE, false},
+	"-": {KEY_MINUS, false},
+	"_": {KEY_MINUS, true},
+	"=": {KEY_EQUAL, false},
+	"+": {KEY_EQUAL, true},
+	"[": {KEY_LEFTBRACE, false},
+	"{": {KEY_LEFTBRACE, true},
+	"]": {KEY_RIGHTBRACE, false},
+	"}": {KEY_RIGHTBRACE, true},
+	`\`: {KEY_BACKSLASH, false},
+	"|": {KEY_BACKSLASH, true},
+	";": {KEY_SEMICOLON, false},
+	":": {KEY_SEMICOLON, true},
+	"'": {KEY_APOSTROPHE, false},
+	`"`: {KEY_APOSTROPHE, true},
+	"`": {KEY_GRAVE, false},
+	"~": {KEY_GRAVE, true},
+	",": {KEY_COMMA, false},
+	"<": {KEY_COMMA, true},
+	".": {KEY_DOT, false},
+	">": {KEY_DOT, true},
+	"/": {KEY_SLASH, false},
+	"?": {KEY_SLASH, true},
+}
+
+type keystrokes struct {
+	*flags.VirtualMachineFlag
+
+	UsbHidCodeValue int32
+	UsbHidCodes     string
+	UsbHidString    string
+	LeftControl     bool
+	LeftShift       bool
+	LeftAlt         bool
+	LeftGui         bool
+	RightControl    bool
+	RightShift      bool
+	RightAlt        bool
+	RightGui        bool
+}
+
+func init() {
+	cli.Register("vm.keystrokes", &keystrokes{})
+}
+
+func (cmd *keystrokes) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.UsbHidString, "s", "", "Raw String to Send")
+	f.StringVar(&cmd.UsbHidCodes, "c", "", "USB HID Codes (hex) or aliases, comma separated")
+	f.Var(flags.NewInt32(&cmd.UsbHidCodeValue), "r", "Raw USB HID Code Value (int32)")
+	f.BoolVar(&cmd.LeftControl, "lc", false, "Enable/Disable Left Control")
+	f.BoolVar(&cmd.LeftShift, "ls", false, "Enable/Disable Left Shift")
+	f.BoolVar(&cmd.LeftAlt, "la", false, "Enable/Disable Left Alt")
+	f.BoolVar(&cmd.LeftGui, "lg", false, "Enable/Disable Left Gui")
+	f.BoolVar(&cmd.RightControl, "rc", false, "Enable/Disable Right Control")
+	f.BoolVar(&cmd.RightShift, "rs", false, "Enable/Disable Right Shift")
+	f.BoolVar(&cmd.RightAlt, "ra", false, "Enable/Disable Right Alt")
+	f.BoolVar(&cmd.RightGui, "rg", false, "Enable/Disable Right Gui")
+}
+
+func (cmd *keystrokes) Usage() string {
+	return "VM"
+}
+
+func (cmd *keystrokes) Description() string {
+	description := `Send Keystrokes to VM.
+
+Examples:
+ Default Scenario
+  govc vm.keystrokes -vm $vm -s "root" 	# writes 'root' to the console
+  govc vm.keystrokes -vm $vm -c 0x15 	# writes an 'r' to the console
+  govc vm.keystrokes -vm $vm -r 1376263 # writes an 'r' to the console
+  govc vm.keystrokes -vm $vm -c 0x28 	# presses ENTER on the console
+  govc vm.keystrokes -vm $vm -c 0x4c -la=true -lc=true 	# sends CTRL+ALT+DEL to console
+  govc vm.keystrokes -vm $vm -c 0x15,KEY_ENTER # writes an 'r' to the console and press ENTER
+
+List of available aliases:
+`
+	keys := make([]string, 0)
+	for key, _ := range hidKeyMap {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for i, key := range keys {
+		if i > 0 {
+			description += ", "
+		}
+		description += key
+	}
+	return description + "\n"
+}
+
+func (cmd *keystrokes) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *keystrokes) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	err = cmd.processUserInput(ctx, vm)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *keystrokes) processUserInput(ctx context.Context, vm *object.VirtualMachine) error {
+	if err := cmd.checkValidInputs(); err != nil {
+		return err
+	}
+
+	codes, err := cmd.processUsbCode()
+
+	if err != nil {
+		return err
+	}
+
+	var keyEventArray []types.UsbScanCodeSpecKeyEvent
+	for _, code := range codes {
+		leftShiftSetting := false
+		if code.ShiftPressed || cmd.LeftShift {
+			leftShiftSetting = true
+		}
+		modifiers := types.UsbScanCodeSpecModifierType{
+			LeftControl:  &cmd.LeftControl,
+			LeftShift:    &leftShiftSetting,
+			LeftAlt:      &cmd.LeftAlt,
+			LeftGui:      &cmd.LeftGui,
+			RightControl: &cmd.RightControl,
+			RightShift:   &cmd.RightShift,
+			RightAlt:     &cmd.RightAlt,
+			RightGui:     &cmd.RightGui,
+		}
+		keyEvent := types.UsbScanCodeSpecKeyEvent{
+			UsbHidCode: code.Code,
+			Modifiers:  &modifiers,
+		}
+		keyEventArray = append(keyEventArray, keyEvent)
+	}
+
+	spec := types.UsbScanCodeSpec{
+		KeyEvents: keyEventArray,
+	}
+
+	_, err = vm.PutUsbScanCodes(ctx, spec)
+
+	return err
+}
+
+func (cmd *keystrokes) processUsbCode() ([]hidKey, error) {
+	if cmd.rawCodeProvided() {
+		return []hidKey{{cmd.UsbHidCodeValue, false}}, nil
+	}
+
+	if cmd.hexCodeProvided() {
+		var retKeyArray []hidKey
+		for _, c := range strings.Split(cmd.UsbHidCodes, ",") {
+			var s int32
+			lookupvalue, ok := hidKeyMap[c]
+			if ok {
+				s = intToHidCode(lookupvalue)
+			} else {
+				var err error
+				s, err = hexStringToHidCode(c)
+				if err != nil {
+					return nil, err
+				}
+			}
+			retKeyArray = append(retKeyArray, hidKey{s, false})
+		}
+		return retKeyArray, nil
+	}
+
+	if cmd.stringProvided() {
+		var retKeyArray []hidKey
+		for _, c := range cmd.UsbHidString {
+			lookupValue, ok := hidCharacterMap[string(c)]
+			if !ok {
+				return nil, fmt.Errorf("invalid Character %s in String: %s", string(c), cmd.UsbHidString)
+			}
+			lookupValue.Code = intToHidCode(lookupValue.Code)
+			retKeyArray = append(retKeyArray, lookupValue)
+		}
+		return retKeyArray, nil
+	}
+	return nil, nil
+}
+
+func hexStringToHidCode(hex string) (int32, error) {
+	s, err := strconv.ParseInt(hex, 0, 32)
+	if err != nil {
+		return 0, err
+	}
+	return intToHidCode(int32(s)), nil
+}
+
+func intToHidCode(v int32) int32 {
+	var s int32 = v << 16
+	s |= 7
+	return s
+}
+
+func (cmd *keystrokes) checkValidInputs() error {
+	// poor man's boolean XOR -> A xor B xor C = A'BC' + AB'C' + A'B'C + ABC
+	if (!cmd.rawCodeProvided() && cmd.hexCodeProvided() && !cmd.stringProvided()) || // A'BC'
+		(cmd.rawCodeProvided() && !cmd.hexCodeProvided() && !cmd.stringProvided()) || // AB'C'
+		(!cmd.rawCodeProvided() && !cmd.hexCodeProvided() && cmd.stringProvided()) || // A'B'C
+		(cmd.rawCodeProvided() && cmd.hexCodeProvided() && cmd.stringProvided()) { // ABC
+		return nil
+	}
+	return fmt.Errorf("specify only 1 argument")
+}
+
+func (cmd keystrokes) rawCodeProvided() bool {
+	return cmd.UsbHidCodeValue != 0
+}
+
+func (cmd keystrokes) hexCodeProvided() bool {
+	return cmd.UsbHidCodes != ""
+}
+
+func (cmd keystrokes) stringProvided() bool {
+	return cmd.UsbHidString != ""
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/markastemplate.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/markastemplate.go
@@ -1,0 +1,72 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vm
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type markastemplate struct {
+	*flags.SearchFlag
+}
+
+func init() {
+	cli.Register("vm.markastemplate", &markastemplate{})
+}
+
+func (cmd *markastemplate) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.SearchFlag, ctx = flags.NewSearchFlag(ctx, flags.SearchVirtualMachines)
+	cmd.SearchFlag.Register(ctx, f)
+}
+
+func (cmd *markastemplate) Process(ctx context.Context) error {
+	if err := cmd.SearchFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *markastemplate) Usage() string {
+	return "VM..."
+}
+
+func (cmd *markastemplate) Description() string {
+	return `Mark VM as a virtual machine template.
+
+Examples:
+  govc vm.markastemplate $name`
+}
+
+func (cmd *markastemplate) Run(ctx context.Context, f *flag.FlagSet) error {
+	vms, err := cmd.VirtualMachines(f.Args())
+	if err != nil {
+		return err
+	}
+
+	for _, vm := range vms {
+		err := vm.MarkAsTemplate(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/markasvm.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/markasvm.go
@@ -1,0 +1,106 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vm
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type markasvm struct {
+	*flags.SearchFlag
+	*flags.ResourcePoolFlag
+	*flags.HostSystemFlag
+}
+
+func init() {
+	cli.Register("vm.markasvm", &markasvm{})
+}
+
+func (cmd *markasvm) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.SearchFlag, ctx = flags.NewSearchFlag(ctx, flags.SearchVirtualMachines)
+	cmd.SearchFlag.Register(ctx, f)
+	cmd.ResourcePoolFlag, ctx = flags.NewResourcePoolFlag(ctx)
+	cmd.ResourcePoolFlag.Register(ctx, f)
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+}
+
+func (cmd *markasvm) Process(ctx context.Context) error {
+	if err := cmd.SearchFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.ResourcePoolFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *markasvm) Usage() string {
+	return "VM..."
+}
+
+func (cmd *markasvm) Description() string {
+	return `Mark VM template as a virtual machine.
+
+Examples:
+  govc vm.markasvm $name -host host1
+  govc vm.markasvm $name -pool cluster1/Resources`
+}
+
+func (cmd *markasvm) Run(ctx context.Context, f *flag.FlagSet) error {
+	vms, err := cmd.VirtualMachines(f.Args())
+	if err != nil {
+		return err
+	}
+
+	pool, err := cmd.ResourcePoolIfSpecified()
+	if err != nil {
+		return err
+	}
+
+	host, err := cmd.HostSystemFlag.HostSystemIfSpecified()
+	if err != nil {
+		return err
+	}
+
+	if pool == nil {
+		if host == nil {
+			return flag.ErrHelp
+		}
+
+		pool, err = host.ResourcePool(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, vm := range vms {
+		err := vm.MarkAsVirtualMachine(ctx, *pool, host)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/migrate.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/migrate.go
@@ -1,0 +1,155 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vm
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type migrate struct {
+	*flags.ResourcePoolFlag
+	*flags.HostSystemFlag
+	*flags.DatastoreFlag
+	*flags.SearchFlag
+
+	priority types.VirtualMachineMovePriority
+	spec     types.VirtualMachineRelocateSpec
+}
+
+func init() {
+	cli.Register("vm.migrate", &migrate{})
+}
+
+func (cmd *migrate) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.SearchFlag, ctx = flags.NewSearchFlag(ctx, flags.SearchVirtualMachines)
+	cmd.SearchFlag.Register(ctx, f)
+
+	cmd.ResourcePoolFlag, ctx = flags.NewResourcePoolFlag(ctx)
+	cmd.ResourcePoolFlag.Register(ctx, f)
+
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	f.StringVar((*string)(&cmd.priority), "priority", string(types.VirtualMachineMovePriorityDefaultPriority), "The task priority")
+}
+
+func (cmd *migrate) Process(ctx context.Context) error {
+	if err := cmd.ResourcePoolFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cmd *migrate) Usage() string {
+	return "VM..."
+}
+
+func (cmd *migrate) Description() string {
+	return `Migrates VM to a specific resource pool, host or datastore.
+
+Examples:
+  govc vm.migrate -host another-host vm-1 vm-2 vm-3
+  govc vm.migrate -pool another-pool vm-1 vm-2 vm-3
+  govc vm.migrate -ds another-ds vm-1 vm-2 vm-3`
+}
+
+func (cmd *migrate) relocate(ctx context.Context, vm *object.VirtualMachine) error {
+	task, err := vm.Relocate(ctx, cmd.spec, cmd.priority)
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.DatastoreFlag.ProgressLogger(fmt.Sprintf("migrating %s... ", vm.Reference()))
+	_, err = task.WaitForResult(ctx, logger)
+	if err != nil {
+		return err
+	}
+
+	logger.Wait()
+
+	return nil
+}
+
+func (cmd *migrate) Run(ctx context.Context, f *flag.FlagSet) error {
+	vms, err := cmd.VirtualMachines(f.Args())
+	if err != nil {
+		return err
+	}
+
+	host, err := cmd.HostSystemFlag.HostSystemIfSpecified()
+	if err != nil {
+		return err
+	}
+
+	if host != nil {
+		ref := host.Reference()
+		cmd.spec.Host = &ref
+	}
+
+	pool, err := cmd.ResourcePoolFlag.ResourcePoolIfSpecified()
+	if err != nil {
+		return err
+	}
+
+	if pool == nil && host != nil {
+		pool, err = host.ResourcePool(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	if pool != nil {
+		ref := pool.Reference()
+		cmd.spec.Pool = &ref
+	}
+
+	ds, err := cmd.DatastoreFlag.DatastoreIfSpecified()
+	if err != nil {
+		return err
+	}
+
+	if ds != nil {
+		ref := ds.Reference()
+		cmd.spec.Datastore = &ref
+	}
+
+	for _, vm := range vms {
+		err = cmd.relocate(ctx, vm)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/network/add.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/network/add.go
@@ -1,0 +1,88 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type add struct {
+	*flags.VirtualMachineFlag
+	*flags.NetworkFlag
+}
+
+func init() {
+	cli.Register("vm.network.add", &add{})
+}
+
+func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+	cmd.NetworkFlag, ctx = flags.NewNetworkFlag(ctx)
+	cmd.NetworkFlag.Register(ctx, f)
+}
+
+func (cmd *add) Description() string {
+	return `Add network adapter to VM.
+
+Examples:
+  govc vm.network.add -vm $vm -net "VM Network" -net.adapter e1000e
+  govc device.info -vm $vm ethernet-*`
+}
+
+func (cmd *add) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.NetworkFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachineFlag.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return errors.New("please specify a vm")
+	}
+
+	// Set network if specified as extra argument.
+	if f.NArg() > 0 {
+		err = cmd.NetworkFlag.Set(f.Arg(0))
+		if err != nil {
+			return fmt.Errorf("couldn't set specified network %v",
+				err)
+		}
+	}
+
+	net, err := cmd.NetworkFlag.Device()
+	if err != nil {
+		return err
+	}
+
+	return vm.AddDevice(ctx, net)
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/network/change.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/network/change.go
@@ -1,0 +1,114 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type change struct {
+	*flags.VirtualMachineFlag
+	*flags.NetworkFlag
+}
+
+func init() {
+	cli.Register("vm.network.change", &change{})
+}
+
+func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+	cmd.NetworkFlag, ctx = flags.NewNetworkFlag(ctx)
+	cmd.NetworkFlag.Register(ctx, f)
+}
+
+func (cmd *change) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.NetworkFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *change) Usage() string {
+	return "DEVICE"
+}
+
+func (cmd *change) Description() string {
+	return `Change network DEVICE configuration.
+
+Note that '-net' is currently required with '-net.address', even when not changing the VM network.
+
+Examples:
+  govc vm.network.change -vm $vm -net PG2 ethernet-0
+  govc vm.network.change -vm $vm -net PG2 -net.address 00:00:0f:2e:5d:69 ethernet-0
+  govc device.info -vm $vm ethernet-*`
+}
+
+func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachineFlag.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return errors.New("please specify a vm")
+	}
+
+	name := f.Arg(0)
+
+	if name == "" {
+		return errors.New("please specify a device name")
+	}
+
+	// Set network if specified as extra argument.
+	if f.NArg() > 1 {
+		err = cmd.NetworkFlag.Set(f.Arg(1))
+		if err != nil {
+			return fmt.Errorf("couldn't set specified network %v",
+				err)
+		}
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	net := devices.Find(name)
+
+	if net == nil {
+		return fmt.Errorf("device '%s' not found", name)
+	}
+
+	dev, err := cmd.NetworkFlag.Device()
+	if err != nil {
+		return err
+	}
+
+	cmd.NetworkFlag.Change(net, dev)
+
+	return vm.EditDevice(ctx, net)
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/option/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/option/info.go
@@ -1,0 +1,165 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package option
+
+import (
+	"context"
+	"flag"
+	"io"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*flags.ClusterFlag
+	*flags.HostSystemFlag
+	*flags.VirtualMachineFlag
+}
+
+func init() {
+	cli.Register("vm.option.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClusterFlag, ctx = flags.NewClusterFlag(ctx)
+	cmd.ClusterFlag.Register(ctx, f)
+
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.ClusterFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.VirtualMachineFlag.Process(ctx)
+}
+
+func (cmd *info) Usage() string {
+	return "[GUEST_ID]..."
+}
+
+func (cmd *info) Description() string {
+	return `VM config options for CLUSTER.
+
+The config option data contains information about the execution environment for a VM
+in the given CLUSTER, and optionally for a specific HOST.
+
+This command only supports '-json' or '-dump' output, defaulting to the latter.
+
+Examples:
+  govc vm.option.info -cluster C0
+  govc vm.option.info -cluster C0 ubuntu64Guest
+  govc vm.option.info -cluster C0 -json | jq .GuestOSDescriptor[].Id
+  govc vm.option.info -host my_hostname
+  govc vm.option.info -vm my_vm`
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	vmf := cmd.VirtualMachineFlag
+
+	if !vmf.JSON && !vmf.Dump {
+		vmf.Dump = true // Default to -dump as there is no plain-text format atm
+	}
+
+	c, err := vmf.Client()
+	if err != nil {
+		return err
+	}
+
+	var ref types.ManagedObjectReference
+
+	host, err := cmd.HostSystemIfSpecified()
+	if err != nil {
+		return err
+	}
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+	if vm == nil {
+		if host == nil {
+			finder, ferr := cmd.ClusterFlag.Finder()
+			if ferr != nil {
+				return ferr
+			}
+
+			cr, ferr := finder.ComputeResourceOrDefault(ctx, cmd.ClusterFlag.Name)
+			if ferr != nil {
+				return ferr
+			}
+			ref = cr.Reference()
+		} else {
+			var h mo.HostSystem
+			err = host.Properties(ctx, host.Reference(), []string{"parent"}, &h)
+			if err != nil {
+				return err
+			}
+			ref = *h.Parent
+		}
+	} else {
+		ref = vm.Reference()
+	}
+
+	var content []types.ObjectContent
+
+	err = property.DefaultCollector(c).RetrieveOne(ctx, ref, []string{"environmentBrowser"}, &content)
+	if err != nil {
+		return err
+	}
+
+	req := types.QueryConfigOptionEx{
+		This: content[0].PropSet[0].Val.(types.ManagedObjectReference),
+		Spec: &types.EnvironmentBrowserConfigOptionQuerySpec{
+			GuestId: f.Args(),
+		},
+	}
+
+	if host != nil {
+		req.Spec.Host = types.NewReference(host.Reference())
+	}
+
+	opt, err := methods.QueryConfigOptionEx(ctx, c, &req)
+	if err != nil {
+		return err
+	}
+
+	return vmf.WriteResult(&infoResult{opt.Returnval})
+}
+
+type infoResult struct {
+	*types.VirtualMachineConfigOption
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	return flag.ErrHelp
+}
+
+func (r *infoResult) Dump() interface{} {
+	return r.VirtualMachineConfigOption
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/power.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/power.go
@@ -1,0 +1,214 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vm
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type power struct {
+	*flags.ClientFlag
+	*flags.SearchFlag
+
+	On       bool
+	Off      bool
+	Reset    bool
+	Reboot   bool
+	Shutdown bool
+	Suspend  bool
+	Force    bool
+	Multi    bool
+	Wait     bool
+}
+
+func init() {
+	cli.Register("vm.power", &power{})
+}
+
+func (cmd *power) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.SearchFlag, ctx = flags.NewSearchFlag(ctx, flags.SearchVirtualMachines)
+	cmd.SearchFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.On, "on", false, "Power on")
+	f.BoolVar(&cmd.Off, "off", false, "Power off")
+	f.BoolVar(&cmd.Reset, "reset", false, "Power reset")
+	f.BoolVar(&cmd.Suspend, "suspend", false, "Power suspend")
+	f.BoolVar(&cmd.Reboot, "r", false, "Reboot guest")
+	f.BoolVar(&cmd.Shutdown, "s", false, "Shutdown guest")
+	f.BoolVar(&cmd.Force, "force", false, "Force (ignore state error and hard shutdown/reboot if tools unavailable)")
+	f.BoolVar(&cmd.Multi, "M", false, "Use Datacenter.PowerOnMultiVM method instead of VirtualMachine.PowerOnVM")
+	f.BoolVar(&cmd.Wait, "wait", true, "Wait for the operation to complete")
+}
+
+func (cmd *power) Usage() string {
+	return "NAME..."
+}
+
+func (cmd *power) Description() string {
+	return `Invoke VM power operations.
+
+Examples:
+  govc vm.power -on VM1 VM2 VM3
+  govc vm.power -on -M VM1 VM2 VM3
+  govc vm.power -off -force VM1`
+}
+
+func (cmd *power) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.SearchFlag.Process(ctx); err != nil {
+		return err
+	}
+	opts := []bool{cmd.On, cmd.Off, cmd.Reset, cmd.Suspend, cmd.Reboot, cmd.Shutdown}
+	selected := false
+
+	for _, opt := range opts {
+		if opt {
+			if selected {
+				return flag.ErrHelp
+			}
+			selected = opt
+		}
+	}
+
+	if !selected {
+		return flag.ErrHelp
+	}
+
+	return nil
+}
+
+func isToolsUnavailable(err error) bool {
+	if soap.IsSoapFault(err) {
+		soapFault := soap.ToSoapFault(err)
+		if _, ok := soapFault.VimFault().(types.ToolsUnavailable); ok {
+			return ok
+		}
+	}
+
+	return false
+}
+
+// this is annoying, but the likely use cases for Datacenter.PowerOnVM outside of this command would
+// use []types.ManagedObjectReference via ContainerView or field such as ResourcePool.Vm rather than the Finder.
+func vmReferences(vms []*object.VirtualMachine) []types.ManagedObjectReference {
+	refs := make([]types.ManagedObjectReference, len(vms))
+	for i, vm := range vms {
+		refs[i] = vm.Reference()
+	}
+	return refs
+}
+
+func (cmd *power) Run(ctx context.Context, f *flag.FlagSet) error {
+	vms, err := cmd.VirtualMachines(f.Args())
+	if err != nil {
+		return err
+	}
+
+	if cmd.On && cmd.Multi {
+		dc, derr := cmd.Datacenter()
+		if derr != nil {
+			return derr
+		}
+
+		task, derr := dc.PowerOnVM(ctx, vmReferences(vms))
+		if derr != nil {
+			return derr
+		}
+
+		msg := fmt.Sprintf("Powering on %d VMs...", len(vms))
+		if task == nil {
+			// running against ESX
+			fmt.Fprintf(cmd, "%s OK\n", msg)
+			return nil
+		}
+
+		if cmd.Wait {
+			logger := cmd.ProgressLogger(msg)
+			defer logger.Wait()
+
+			_, err = task.WaitForResult(ctx, logger)
+			return err
+		}
+	}
+
+	for _, vm := range vms {
+		var task *object.Task
+
+		switch {
+		case cmd.On:
+			fmt.Fprintf(cmd, "Powering on %s... ", vm.Reference())
+			task, err = vm.PowerOn(ctx)
+		case cmd.Off:
+			fmt.Fprintf(cmd, "Powering off %s... ", vm.Reference())
+			task, err = vm.PowerOff(ctx)
+		case cmd.Reset:
+			fmt.Fprintf(cmd, "Reset %s... ", vm.Reference())
+			task, err = vm.Reset(ctx)
+		case cmd.Suspend:
+			fmt.Fprintf(cmd, "Suspend %s... ", vm.Reference())
+			task, err = vm.Suspend(ctx)
+		case cmd.Reboot:
+			fmt.Fprintf(cmd, "Reboot guest %s... ", vm.Reference())
+			err = vm.RebootGuest(ctx)
+
+			if err != nil && cmd.Force && isToolsUnavailable(err) {
+				task, err = vm.Reset(ctx)
+			}
+		case cmd.Shutdown:
+			fmt.Fprintf(cmd, "Shutdown guest %s... ", vm.Reference())
+			err = vm.ShutdownGuest(ctx)
+
+			if err != nil && cmd.Force && isToolsUnavailable(err) {
+				task, err = vm.PowerOff(ctx)
+			}
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if cmd.Wait && task != nil {
+			err = task.Wait(ctx)
+		}
+		if err == nil {
+			fmt.Fprintf(cmd, "OK\n")
+			continue
+		}
+
+		if cmd.Force {
+			fmt.Fprintf(cmd, "Error: %s\n", err)
+			continue
+		}
+
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/question.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/question.go
@@ -1,0 +1,98 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vm
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type question struct {
+	*flags.VirtualMachineFlag
+
+	answer string
+}
+
+func init() {
+	cli.Register("vm.question", &question{})
+}
+
+func (cmd *question) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.answer, "answer", "", "Answer to question")
+}
+
+func (cmd *question) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *question) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return errors.New("no VM specified")
+	}
+
+	var mvm mo.VirtualMachine
+
+	pc := property.DefaultCollector(c)
+	err = pc.RetrieveOne(ctx, vm.Reference(), []string{"runtime.question"}, &mvm)
+	if err != nil {
+		return err
+	}
+
+	q := mvm.Runtime.Question
+	if q == nil {
+		fmt.Printf("No pending question\n")
+		return nil
+	}
+
+	// Print question if no answer is specified
+	if cmd.answer == "" {
+		fmt.Printf("Question:\n%s\n\n", q.Text)
+		fmt.Printf("Possible answers:\n")
+		for _, e := range q.Choice.ChoiceInfo {
+			ed := e.(*types.ElementDescription)
+			fmt.Printf("%s) %s\n", ed.Key, ed.Description.Label)
+		}
+		return nil
+	}
+
+	// Answer question
+	return vm.Answer(ctx, q.Id, cmd.answer)
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/rdm/attach.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/rdm/attach.go
@@ -1,0 +1,149 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rdm
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type attach struct {
+	*flags.VirtualMachineFlag
+
+	device string
+}
+
+func init() {
+	cli.Register("vm.rdm.attach", &attach{})
+}
+
+func (cmd *attach) Register(ctx context.Context, f *flag.FlagSet) {
+
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.device, "device", "", "Device Name")
+}
+
+func (cmd *attach) Description() string {
+	return `Attach DEVICE to VM with RDM.
+
+Examples:
+  govc vm.rdm.attach -vm VM -device /vmfs/devices/disks/naa.000000000000000000000000000000000`
+}
+
+func (cmd *attach) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+//This piece of code was developed mainly thanks to the project govmax on github.com
+//This file in particular https://github.com/codedellemc/govmax/blob/master/api/v1/vmomi.go
+func (cmd *attach) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	controller, err := devices.FindSCSIController("")
+	if err != nil {
+		return err
+	}
+
+	vmConfigOptions, err := vm.QueryConfigTarget(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, scsiDisk := range vmConfigOptions.ScsiDisk {
+		if !strings.Contains(scsiDisk.Disk.CanonicalName, cmd.device) {
+			continue
+		}
+		var backing types.VirtualDiskRawDiskMappingVer1BackingInfo
+		backing.CompatibilityMode = string(types.VirtualDiskCompatibilityModePhysicalMode)
+		backing.DeviceName = scsiDisk.Disk.DeviceName
+		for _, descriptor := range scsiDisk.Disk.Descriptor {
+			if strings.HasPrefix(descriptor.Id, "vml.") {
+				backing.LunUuid = descriptor.Id
+				break
+			}
+		}
+		var device types.VirtualDisk
+		device.Backing = &backing
+		device.ControllerKey = controller.VirtualController.Key
+
+		var unitNumber *int32
+		scsiCtrlUnitNumber := controller.VirtualController.UnitNumber
+		var u int32
+		for u = 0; u < 16; u++ {
+			free := true
+			for _, d := range devices {
+				if d.GetVirtualDevice().ControllerKey == device.GetVirtualDevice().ControllerKey {
+					if u == *(d.GetVirtualDevice().UnitNumber) || u == *scsiCtrlUnitNumber {
+						free = false
+					}
+				}
+			}
+			if free {
+				unitNumber = &u
+				break
+			}
+		}
+		device.UnitNumber = unitNumber
+
+		spec := types.VirtualMachineConfigSpec{}
+
+		config := &types.VirtualDeviceConfigSpec{
+			Device:    &device,
+			Operation: types.VirtualDeviceConfigSpecOperationAdd,
+		}
+
+		config.FileOperation = types.VirtualDeviceConfigSpecFileOperationCreate
+
+		spec.DeviceChange = append(spec.DeviceChange, config)
+
+		task, err := vm.Reconfigure(ctx, spec)
+		if err != nil {
+			return err
+		}
+
+		err = task.Wait(ctx)
+		if err != nil {
+			return fmt.Errorf("error adding device %+v \n with backing %+v \nLogged Item:  %s", device, backing, err)
+		}
+		return nil
+
+	}
+	return fmt.Errorf("error: No LUN with device name containing %s found", cmd.device)
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/rdm/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/rdm/ls.go
@@ -1,0 +1,109 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rdm
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ls struct {
+	*flags.VirtualMachineFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("vm.rdm.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *ls) Description() string {
+	return `List available devices that could be attach to VM with RDM.
+
+Examples:
+  govc vm.rdm.ls -vm VM`
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	vmConfigOptions, err := vm.QueryConfigTarget(ctx)
+	if err != nil {
+		return err
+	}
+
+	res := infoResult{
+		Disks: vmConfigOptions.ScsiDisk,
+	}
+	return cmd.WriteResult(&res)
+}
+
+type infoResult struct {
+	Disks []types.VirtualMachineScsiDiskDeviceInfo
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
+	for _, disk := range r.Disks {
+		fmt.Fprintf(tw, "Name:\t%s\n", disk.Name)
+		fmt.Fprintf(tw, "  Device name:\t%s\n", disk.Disk.DeviceName)
+		fmt.Fprintf(tw, "  Device path:\t%s\n", disk.Disk.DevicePath)
+		fmt.Fprintf(tw, "  Canonical Name:\t%s\n", disk.Disk.CanonicalName)
+
+		var uids []string
+		for _, descriptor := range disk.Disk.Descriptor {
+			uids = append(uids, descriptor.Id)
+		}
+
+		fmt.Fprintf(tw, "  UIDS:\t%s\n", strings.Join(uids, " ,"))
+	}
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/register.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/register.go
@@ -1,0 +1,139 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vm
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type register struct {
+	*flags.DatastoreFlag
+	*flags.ResourcePoolFlag
+	*flags.HostSystemFlag
+	*flags.FolderFlag
+
+	name     string
+	template bool
+}
+
+func init() {
+	cli.Register("vm.register", &register{})
+}
+
+func (cmd *register) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	cmd.ResourcePoolFlag, ctx = flags.NewResourcePoolFlag(ctx)
+	cmd.ResourcePoolFlag.Register(ctx, f)
+
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	cmd.FolderFlag, ctx = flags.NewFolderFlag(ctx)
+	cmd.FolderFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.name, "name", "", "Name of the VM")
+	f.BoolVar(&cmd.template, "template", false, "Mark VM as template")
+}
+
+func (cmd *register) Process(ctx context.Context) error {
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.ResourcePoolFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.FolderFlag.Process(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cmd *register) Usage() string {
+	return "VMX"
+}
+
+func (cmd *register) Description() string {
+	return `Add an existing VM to the inventory.
+
+VMX is a path to the vm config file, relative to DATASTORE.
+
+Examples:
+  govc vm.register path/name.vmx
+  govc vm.register -template -host $host path/name.vmx`
+}
+
+func (cmd *register) Run(ctx context.Context, f *flag.FlagSet) error {
+	if len(f.Args()) != 1 {
+		return flag.ErrHelp
+	}
+
+	pool, err := cmd.ResourcePoolIfSpecified()
+	if err != nil {
+		return err
+	}
+
+	host, err := cmd.HostSystemFlag.HostSystemIfSpecified()
+	if err != nil {
+		return err
+	}
+
+	if cmd.template {
+		if pool != nil || host == nil {
+			return flag.ErrHelp
+		}
+	} else if pool == nil {
+		if host != nil {
+			pool, err = host.ResourcePool(ctx)
+			if err != nil {
+				return err
+			}
+		} else {
+			// neither -host nor -pool were specified, so use the default pool (ESX)
+			pool, err = cmd.ResourcePool()
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	folder, err := cmd.FolderFlag.Folder()
+	if err != nil {
+		return err
+	}
+
+	path, err := cmd.DatastorePath(f.Arg(0))
+	if err != nil {
+		return err
+	}
+
+	task, err := folder.RegisterVM(ctx, path, cmd.name, cmd.template, pool, host)
+	if err != nil {
+		return err
+	}
+
+	return task.Wait(ctx)
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/snapshot/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/snapshot/create.go
@@ -1,0 +1,86 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshot
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type create struct {
+	*flags.VirtualMachineFlag
+
+	description string
+	memory      bool
+	quiesce     bool
+}
+
+func init() {
+	cli.Register("snapshot.create", &create{})
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.memory, "m", true, "Include memory state")
+	f.BoolVar(&cmd.quiesce, "q", false, "Quiesce guest file system")
+	f.StringVar(&cmd.description, "d", "", "Snapshot description")
+}
+
+func (cmd *create) Usage() string {
+	return "NAME"
+}
+
+func (cmd *create) Description() string {
+	return `Create snapshot of VM with NAME.
+
+Examples:
+  govc snapshot.create -vm my-vm happy-vm-state`
+}
+
+func (cmd *create) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	task, err := vm.CreateSnapshot(ctx, f.Arg(0), cmd.description, cmd.memory, cmd.quiesce)
+	if err != nil {
+		return err
+	}
+
+	return task.Wait(ctx)
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/snapshot/remove.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/snapshot/remove.go
@@ -1,0 +1,94 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshot
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type remove struct {
+	*flags.VirtualMachineFlag
+
+	recursive   bool
+	consolidate bool
+}
+
+func init() {
+	cli.Register("snapshot.remove", &remove{})
+}
+
+func (cmd *remove) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.recursive, "r", false, "Remove snapshot children")
+	f.BoolVar(&cmd.consolidate, "c", true, "Consolidate disks")
+}
+
+func (cmd *remove) Usage() string {
+	return "NAME"
+}
+
+func (cmd *remove) Description() string {
+	return `Remove snapshot of VM with given NAME.
+
+NAME can be the snapshot name, tree path, moid or '*' to remove all snapshots.
+
+Examples:
+  govc snapshot.remove -vm my-vm happy-vm-state`
+}
+
+func (cmd *remove) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	var task *object.Task
+
+	if f.Arg(0) == "*" {
+		task, err = vm.RemoveAllSnapshot(ctx, &cmd.consolidate)
+	} else {
+		task, err = vm.RemoveSnapshot(ctx, f.Arg(0), cmd.recursive, &cmd.consolidate)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return task.Wait(ctx)
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/snapshot/revert.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/snapshot/revert.go
@@ -1,0 +1,93 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshot
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+)
+
+type revert struct {
+	*flags.VirtualMachineFlag
+
+	suppressPowerOn bool
+}
+
+func init() {
+	cli.Register("snapshot.revert", &revert{})
+}
+
+func (cmd *revert) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.suppressPowerOn, "s", false, "Suppress power on")
+}
+
+func (cmd *revert) Usage() string {
+	return "[NAME]"
+}
+
+func (cmd *revert) Description() string {
+	return `Revert to snapshot of VM with given NAME.
+
+If NAME is not provided, revert to the current snapshot.
+Otherwise, NAME can be the snapshot name, tree path or moid.
+
+Examples:
+  govc snapshot.revert -vm my-vm happy-vm-state`
+}
+
+func (cmd *revert) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *revert) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() > 1 {
+		return flag.ErrHelp
+	}
+
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	var task *object.Task
+
+	if f.NArg() == 1 {
+		task, err = vm.RevertToSnapshot(ctx, f.Arg(0), cmd.suppressPowerOn)
+	} else {
+		task, err = vm.RevertToCurrentSnapshot(ctx, cmd.suppressPowerOn)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return task.Wait(ctx)
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/snapshot/tree.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/snapshot/tree.go
@@ -1,0 +1,168 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshot
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type tree struct {
+	*flags.VirtualMachineFlag
+
+	current     bool
+	currentName bool
+	date        bool
+	description bool
+	fullPath    bool
+	id          bool
+
+	info *types.VirtualMachineSnapshotInfo
+}
+
+func init() {
+	cli.Register("snapshot.tree", &tree{})
+}
+
+func (cmd *tree) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.current, "c", true, "Print the current snapshot")
+	f.BoolVar(&cmd.currentName, "C", false,
+		"Print the current snapshot name only")
+	f.BoolVar(&cmd.date, "D", false, "Print the snapshot creation date")
+	f.BoolVar(&cmd.description, "d", false,
+		"Print the snapshot description")
+	f.BoolVar(&cmd.fullPath, "f", false,
+		"Print the full path prefix for snapshot")
+	f.BoolVar(&cmd.id, "i", false, "Print the snapshot id")
+}
+
+func (cmd *tree) Description() string {
+	return `List VM snapshots in a tree-like format.
+
+The command will exit 0 with no output if VM does not have any snapshots.
+
+Examples:
+  govc snapshot.tree -vm my-vm
+  govc snapshot.tree -vm my-vm -D -i -d`
+}
+
+func (cmd *tree) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *tree) write(level int, parent string, st []types.VirtualMachineSnapshotTree) {
+	for _, s := range st {
+		sname := s.Name
+
+		if cmd.fullPath && parent != "" {
+			sname = path.Join(parent, sname)
+		}
+
+		var names []string
+
+		if !cmd.currentName {
+			names = append(names, sname)
+		}
+
+		if s.Snapshot == *cmd.info.CurrentSnapshot {
+			if cmd.current {
+				names = append(names, ".")
+			} else if cmd.currentName {
+				fmt.Println(sname)
+				return
+			}
+		}
+
+		for _, name := range names {
+			var attr []string
+			var meta string
+
+			if cmd.id {
+				attr = append(attr, s.Snapshot.Value)
+			}
+
+			if cmd.date {
+				attr = append(attr, s.CreateTime.Format("Jan 2 15:04"))
+			}
+
+			if len(attr) > 0 {
+				meta = fmt.Sprintf("[%s]  ", strings.Join(attr, " "))
+			}
+
+			if cmd.description {
+				fmt.Printf("%s%s%s - %4s\n",
+					strings.Repeat(" ", level), meta, name,
+					s.Description)
+			} else {
+				fmt.Printf("%s%s%s\n",
+					strings.Repeat(" ", level), meta, name)
+			}
+		}
+
+		cmd.write(level+2, sname, s.ChildSnapshotList)
+	}
+}
+
+func (cmd *tree) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 0 {
+		return flag.ErrHelp
+	}
+
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	var o mo.VirtualMachine
+
+	err = vm.Properties(ctx, vm.Reference(), []string{"snapshot"}, &o)
+	if err != nil {
+		return err
+	}
+
+	if o.Snapshot == nil {
+		return nil
+	}
+
+	if o.Snapshot.CurrentSnapshot == nil || cmd.currentName {
+		cmd.current = false
+	}
+
+	cmd.info = o.Snapshot
+
+	cmd.write(0, "", o.Snapshot.RootSnapshotList)
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/unregister.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/unregister.go
@@ -1,0 +1,76 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vm
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type unregister struct {
+	*flags.ClientFlag
+	*flags.SearchFlag
+}
+
+func init() {
+	cli.Register("vm.unregister", &unregister{})
+}
+
+func (cmd *unregister) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.SearchFlag, ctx = flags.NewSearchFlag(ctx, flags.SearchVirtualMachines)
+	cmd.SearchFlag.Register(ctx, f)
+}
+
+func (cmd *unregister) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.SearchFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *unregister) Usage() string {
+	return "VM..."
+}
+
+func (cmd *unregister) Description() string {
+	return `Remove VM from inventory without removing any of the VM files on disk.`
+}
+
+func (cmd *unregister) Run(ctx context.Context, f *flag.FlagSet) error {
+	vms, err := cmd.VirtualMachines(f.Args())
+	if err != nil {
+		return err
+	}
+
+	for _, vm := range vms {
+		err := vm.Unregister(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/upgrade.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/upgrade.go
@@ -1,0 +1,80 @@
+package vm
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/task"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type upgrade struct {
+	*flags.VirtualMachineFlag
+	version int
+}
+
+func init() {
+	cli.Register("vm.upgrade", &upgrade{})
+}
+
+func isAlreadyUpgraded(err error) bool {
+	if fault, ok := err.(task.Error); ok {
+		_, ok = fault.Fault().(*types.AlreadyUpgraded)
+		return ok
+	}
+
+	return false
+}
+
+func (cmd *upgrade) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.IntVar(&cmd.version, "version", 0, "Target vm hardware version, by default -- latest available")
+}
+
+func (cmd *upgrade) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *upgrade) Description() string {
+	return `Upgrade VMs to latest hardware version
+
+Examples:
+  govc vm.upgrade -vm $vm_name
+  govc vm.upgrade -version=$version -vm $vm_name
+  govc vm.upgrade -version=$version -vm.uuid $vm_uuid`
+}
+
+func (cmd *upgrade) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	var version = ""
+	if cmd.version != 0 {
+		version = fmt.Sprintf("vmx-%02d", cmd.version)
+	}
+
+	task, err := vm.UpgradeVM(ctx, version)
+	if err != nil {
+		return err
+	}
+	err = task.Wait(ctx)
+	if err != nil {
+		if isAlreadyUpgraded(err) {
+			fmt.Println(err.Error())
+		} else {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/vnc.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/vnc.go
@@ -1,0 +1,504 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vm
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type intRange struct {
+	low, high int
+}
+
+var intRangeRegexp = regexp.MustCompile("^([0-9]+)-([0-9]+)$")
+
+func (i *intRange) Set(s string) error {
+	m := intRangeRegexp.FindStringSubmatch(s)
+	if m == nil {
+		return fmt.Errorf("invalid range: %s", s)
+	}
+
+	low, err := strconv.Atoi(m[1])
+	if err != nil {
+		return fmt.Errorf("couldn't convert to integer: %v", err)
+	}
+
+	high, err := strconv.Atoi(m[2])
+	if err != nil {
+		return fmt.Errorf("couldn't convert to integer: %v", err)
+	}
+
+	if low > high {
+		return fmt.Errorf("invalid range: low > high")
+	}
+
+	i.low = low
+	i.high = high
+	return nil
+}
+
+func (i *intRange) String() string {
+	return fmt.Sprintf("%d-%d", i.low, i.high)
+}
+
+type vnc struct {
+	*flags.SearchFlag
+
+	Enable    bool
+	Disable   bool
+	Port      int
+	PortRange intRange
+	Password  string
+}
+
+func init() {
+	cmd := &vnc{}
+	err := cmd.PortRange.Set("5900-5999")
+	if err != nil {
+		fmt.Printf("Error setting port range %v", err)
+	}
+	cli.Register("vm.vnc", cmd)
+}
+
+func (cmd *vnc) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.SearchFlag, ctx = flags.NewSearchFlag(ctx, flags.SearchVirtualMachines)
+	cmd.SearchFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.Enable, "enable", false, "Enable VNC")
+	f.BoolVar(&cmd.Disable, "disable", false, "Disable VNC")
+	f.IntVar(&cmd.Port, "port", -1, "VNC port (-1 for auto-select)")
+	f.Var(&cmd.PortRange, "port-range", "VNC port auto-select range")
+	f.StringVar(&cmd.Password, "password", "", "VNC password")
+}
+
+func (cmd *vnc) Process(ctx context.Context) error {
+	if err := cmd.SearchFlag.Process(ctx); err != nil {
+		return err
+	}
+	// Either may be true or none may be true.
+	if cmd.Enable && cmd.Disable {
+		return flag.ErrHelp
+	}
+
+	return nil
+}
+
+func (cmd *vnc) Usage() string {
+	return "VM..."
+}
+
+func (cmd *vnc) Description() string {
+	return `Enable or disable VNC for VM.
+
+Port numbers are automatically chosen if not specified.
+
+If neither -enable or -disable is specified, the current state is returned.
+
+Examples:
+  govc vm.vnc -enable -password 1234 $vm | awk '{print $2}' | xargs open`
+}
+
+func (cmd *vnc) Run(ctx context.Context, f *flag.FlagSet) error {
+	vms, err := cmd.loadVMs(f.Args())
+	if err != nil {
+		return err
+	}
+
+	// Actuate settings in VMs
+	for _, vm := range vms {
+		switch {
+		case cmd.Enable:
+			err = vm.enable(cmd.Port, cmd.Password)
+			if err != nil {
+				return err
+			}
+		case cmd.Disable:
+			err = vm.disable()
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// Reconfigure VMs to reflect updates
+	for _, vm := range vms {
+		err = vm.reconfigure()
+		if err != nil {
+			return err
+		}
+	}
+
+	return cmd.WriteResult(vncResult(vms))
+}
+
+func (cmd *vnc) loadVMs(args []string) ([]*vncVM, error) {
+	c, err := cmd.Client()
+	if err != nil {
+		return nil, err
+	}
+
+	vms, err := cmd.VirtualMachines(args)
+	if err != nil {
+		return nil, err
+	}
+
+	var vncVMs []*vncVM
+	for _, vm := range vms {
+		v, err := newVNCVM(c, vm)
+		if err != nil {
+			return nil, err
+		}
+		vncVMs = append(vncVMs, v)
+	}
+
+	// Assign vncHosts to vncVMs
+	hosts := make(map[string]*vncHost)
+	for _, vm := range vncVMs {
+		if h, ok := hosts[vm.hostReference().Value]; ok {
+			vm.host = h
+			continue
+		}
+
+		hs := object.NewHostSystem(c, vm.hostReference())
+		h, err := newVNCHost(c, hs, cmd.PortRange.low, cmd.PortRange.high)
+		if err != nil {
+			return nil, err
+		}
+
+		hosts[vm.hostReference().Value] = h
+		vm.host = h
+	}
+
+	return vncVMs, nil
+}
+
+type vncVM struct {
+	c    *vim25.Client
+	vm   *object.VirtualMachine
+	mvm  mo.VirtualMachine
+	host *vncHost
+
+	curOptions vncOptions
+	newOptions vncOptions
+}
+
+func newVNCVM(c *vim25.Client, vm *object.VirtualMachine) (*vncVM, error) {
+	v := &vncVM{
+		c:  c,
+		vm: vm,
+	}
+
+	virtualMachineProperties := []string{
+		"name",
+		"config.extraConfig",
+		"runtime.host",
+	}
+
+	pc := property.DefaultCollector(c)
+	ctx := context.TODO()
+	err := pc.RetrieveOne(ctx, vm.Reference(), virtualMachineProperties, &v.mvm)
+	if err != nil {
+		return nil, err
+	}
+
+	v.curOptions = vncOptionsFromExtraConfig(v.mvm.Config.ExtraConfig)
+	v.newOptions = vncOptionsFromExtraConfig(v.mvm.Config.ExtraConfig)
+
+	return v, nil
+}
+
+func (v *vncVM) hostReference() types.ManagedObjectReference {
+	return *v.mvm.Runtime.Host
+}
+
+func (v *vncVM) enable(port int, password string) error {
+	v.newOptions["enabled"] = "true"
+	v.newOptions["port"] = fmt.Sprintf("%d", port)
+	v.newOptions["password"] = password
+
+	// Find port if auto-select
+	if port == -1 {
+		// Reuse port if If VM already has a port, reuse it.
+		// Otherwise, find unused VNC port on host.
+		if p, ok := v.curOptions["port"]; ok && p != "" {
+			v.newOptions["port"] = p
+		} else {
+			port, err := v.host.popUnusedPort()
+			if err != nil {
+				return err
+			}
+			v.newOptions["port"] = fmt.Sprintf("%d", port)
+		}
+	}
+	return nil
+}
+
+func (v *vncVM) disable() error {
+	v.newOptions["enabled"] = "false"
+	v.newOptions["port"] = ""
+	v.newOptions["password"] = ""
+	return nil
+}
+
+func (v *vncVM) reconfigure() error {
+	if reflect.DeepEqual(v.curOptions, v.newOptions) {
+		// No changes to settings
+		return nil
+	}
+
+	spec := types.VirtualMachineConfigSpec{
+		ExtraConfig: v.newOptions.ToExtraConfig(),
+	}
+
+	ctx := context.TODO()
+	task, err := v.vm.Reconfigure(ctx, spec)
+	if err != nil {
+		return err
+	}
+
+	return task.Wait(ctx)
+}
+
+func (v *vncVM) uri() (string, error) {
+	ip, err := v.host.managementIP()
+	if err != nil {
+		return "", err
+	}
+
+	uri := fmt.Sprintf("vnc://:%s@%s:%s",
+		v.newOptions["password"],
+		ip,
+		v.newOptions["port"])
+
+	return uri, nil
+}
+
+func (v *vncVM) write(w io.Writer) error {
+	if strings.EqualFold(v.newOptions["enabled"], "true") {
+		uri, err := v.uri()
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%s: %s\n", v.mvm.Name, uri)
+	} else {
+		fmt.Printf("%s: disabled\n", v.mvm.Name)
+	}
+	return nil
+}
+
+type vncHost struct {
+	c     *vim25.Client
+	host  *object.HostSystem
+	ports map[int]struct{}
+	ip    string // This field is populated by `managementIP`
+}
+
+func newVNCHost(c *vim25.Client, host *object.HostSystem, low, high int) (*vncHost, error) {
+	ports := make(map[int]struct{})
+	for i := low; i <= high; i++ {
+		ports[i] = struct{}{}
+	}
+
+	used, err := loadUsedPorts(c, host.Reference())
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove used ports from range
+	for _, u := range used {
+		delete(ports, u)
+	}
+
+	h := &vncHost{
+		c:     c,
+		host:  host,
+		ports: ports,
+	}
+
+	return h, nil
+}
+
+func loadUsedPorts(c *vim25.Client, host types.ManagedObjectReference) ([]int, error) {
+	ctx := context.TODO()
+	ospec := types.ObjectSpec{
+		Obj: host,
+		SelectSet: []types.BaseSelectionSpec{
+			&types.TraversalSpec{
+				Type: "HostSystem",
+				Path: "vm",
+				Skip: types.NewBool(false),
+			},
+		},
+		Skip: types.NewBool(false),
+	}
+
+	pspec := types.PropertySpec{
+		Type:    "VirtualMachine",
+		PathSet: []string{"config.extraConfig"},
+	}
+
+	req := types.RetrieveProperties{
+		This: c.ServiceContent.PropertyCollector,
+		SpecSet: []types.PropertyFilterSpec{
+			{
+				ObjectSet: []types.ObjectSpec{ospec},
+				PropSet:   []types.PropertySpec{pspec},
+			},
+		},
+	}
+
+	var vms []mo.VirtualMachine
+	err := mo.RetrievePropertiesForRequest(ctx, c, req, &vms)
+	if err != nil {
+		return nil, err
+	}
+
+	var ports []int
+	for _, vm := range vms {
+		if vm.Config == nil || vm.Config.ExtraConfig == nil {
+			continue
+		}
+
+		options := vncOptionsFromExtraConfig(vm.Config.ExtraConfig)
+		if ps, ok := options["port"]; ok && ps != "" {
+			pi, err := strconv.Atoi(ps)
+			if err == nil {
+				ports = append(ports, pi)
+			}
+		}
+	}
+
+	return ports, nil
+}
+
+func (h *vncHost) popUnusedPort() (int, error) {
+	if len(h.ports) == 0 {
+		return 0, fmt.Errorf("no unused ports in range")
+	}
+
+	// Return first port we get when iterating
+	var port int
+	for port = range h.ports {
+		break
+	}
+	delete(h.ports, port)
+	return port, nil
+}
+
+func (h *vncHost) managementIP() (string, error) {
+	ctx := context.TODO()
+	if h.ip != "" {
+		return h.ip, nil
+	}
+
+	ips, err := h.host.ManagementIPs(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	if len(ips) > 0 {
+		h.ip = ips[0].String()
+	} else {
+		h.ip = "<unknown>"
+	}
+
+	return h.ip, nil
+}
+
+type vncResult []*vncVM
+
+func (vms vncResult) MarshalJSON() ([]byte, error) {
+	out := make(map[string]string)
+	for _, vm := range vms {
+		uri, err := vm.uri()
+		if err != nil {
+			return nil, err
+		}
+		out[vm.mvm.Name] = uri
+	}
+	return json.Marshal(out)
+}
+
+func (vms vncResult) Write(w io.Writer) error {
+	for _, vm := range vms {
+		err := vm.write(w)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type vncOptions map[string]string
+
+var vncPrefix = "RemoteDisplay.vnc."
+
+func vncOptionsFromExtraConfig(ov []types.BaseOptionValue) vncOptions {
+	vo := make(vncOptions)
+	for _, b := range ov {
+		o := b.GetOptionValue()
+		if strings.HasPrefix(o.Key, vncPrefix) {
+			key := o.Key[len(vncPrefix):]
+			if key != "key" {
+				vo[key] = o.Value.(string)
+			}
+		}
+	}
+	return vo
+}
+
+func (vo vncOptions) ToExtraConfig() []types.BaseOptionValue {
+	ov := make([]types.BaseOptionValue, 0)
+	for k, v := range vo {
+		key := vncPrefix + k
+		value := v
+
+		o := types.OptionValue{
+			Key:   key,
+			Value: &value, // Pass pointer to avoid omitempty
+		}
+
+		ov = append(ov, &o)
+	}
+
+	// Don't know how to deal with the key option, set it to be empty...
+	o := types.OptionValue{
+		Key:   vncPrefix + "key",
+		Value: new(string), // Pass pointer to avoid omitempty
+	}
+
+	ov = append(ov, &o)
+
+	return ov
+}

--- a/vendor/github.com/vmware/govmomi/guest/auth_manager.go
+++ b/vendor/github.com/vmware/govmomi/guest/auth_manager.go
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type AuthManager struct {
+	types.ManagedObjectReference
+
+	vm types.ManagedObjectReference
+
+	c *vim25.Client
+}
+
+func (m AuthManager) Reference() types.ManagedObjectReference {
+	return m.ManagedObjectReference
+}
+
+func (m AuthManager) AcquireCredentials(ctx context.Context, requestedAuth types.BaseGuestAuthentication, sessionID int64) (types.BaseGuestAuthentication, error) {
+	req := types.AcquireCredentialsInGuest{
+		This:          m.Reference(),
+		Vm:            m.vm,
+		RequestedAuth: requestedAuth,
+		SessionID:     sessionID,
+	}
+
+	res, err := methods.AcquireCredentialsInGuest(ctx, m.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (m AuthManager) ReleaseCredentials(ctx context.Context, auth types.BaseGuestAuthentication) error {
+	req := types.ReleaseCredentialsInGuest{
+		This: m.Reference(),
+		Vm:   m.vm,
+		Auth: auth,
+	}
+
+	_, err := methods.ReleaseCredentialsInGuest(ctx, m.c, &req)
+
+	return err
+}
+
+func (m AuthManager) ValidateCredentials(ctx context.Context, auth types.BaseGuestAuthentication) error {
+	req := types.ValidateCredentialsInGuest{
+		This: m.Reference(),
+		Vm:   m.vm,
+		Auth: auth,
+	}
+
+	_, err := methods.ValidateCredentialsInGuest(ctx, m.c, &req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/guest/file_manager.go
+++ b/vendor/github.com/vmware/govmomi/guest/file_manager.go
@@ -1,0 +1,294 @@
+/*
+Copyright (c) 2015-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"context"
+	"net"
+	"net/url"
+	"sync"
+
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type FileManager struct {
+	types.ManagedObjectReference
+
+	vm types.ManagedObjectReference
+
+	c *vim25.Client
+
+	mu    *sync.Mutex
+	hosts map[string]string
+}
+
+func (m FileManager) Reference() types.ManagedObjectReference {
+	return m.ManagedObjectReference
+}
+
+func (m FileManager) ChangeFileAttributes(ctx context.Context, auth types.BaseGuestAuthentication, guestFilePath string, fileAttributes types.BaseGuestFileAttributes) error {
+	req := types.ChangeFileAttributesInGuest{
+		This:           m.Reference(),
+		Vm:             m.vm,
+		Auth:           auth,
+		GuestFilePath:  guestFilePath,
+		FileAttributes: fileAttributes,
+	}
+
+	_, err := methods.ChangeFileAttributesInGuest(ctx, m.c, &req)
+	return err
+}
+
+func (m FileManager) CreateTemporaryDirectory(ctx context.Context, auth types.BaseGuestAuthentication, prefix, suffix string, path string) (string, error) {
+	req := types.CreateTemporaryDirectoryInGuest{
+		This:          m.Reference(),
+		Vm:            m.vm,
+		Auth:          auth,
+		Prefix:        prefix,
+		Suffix:        suffix,
+		DirectoryPath: path,
+	}
+
+	res, err := methods.CreateTemporaryDirectoryInGuest(ctx, m.c, &req)
+	if err != nil {
+		return "", err
+	}
+
+	return res.Returnval, nil
+}
+
+func (m FileManager) CreateTemporaryFile(ctx context.Context, auth types.BaseGuestAuthentication, prefix, suffix string, path string) (string, error) {
+	req := types.CreateTemporaryFileInGuest{
+		This:          m.Reference(),
+		Vm:            m.vm,
+		Auth:          auth,
+		Prefix:        prefix,
+		Suffix:        suffix,
+		DirectoryPath: path,
+	}
+
+	res, err := methods.CreateTemporaryFileInGuest(ctx, m.c, &req)
+	if err != nil {
+		return "", err
+	}
+
+	return res.Returnval, nil
+}
+
+func (m FileManager) DeleteDirectory(ctx context.Context, auth types.BaseGuestAuthentication, directoryPath string, recursive bool) error {
+	req := types.DeleteDirectoryInGuest{
+		This:          m.Reference(),
+		Vm:            m.vm,
+		Auth:          auth,
+		DirectoryPath: directoryPath,
+		Recursive:     recursive,
+	}
+
+	_, err := methods.DeleteDirectoryInGuest(ctx, m.c, &req)
+	return err
+}
+
+func (m FileManager) DeleteFile(ctx context.Context, auth types.BaseGuestAuthentication, filePath string) error {
+	req := types.DeleteFileInGuest{
+		This:     m.Reference(),
+		Vm:       m.vm,
+		Auth:     auth,
+		FilePath: filePath,
+	}
+
+	_, err := methods.DeleteFileInGuest(ctx, m.c, &req)
+	return err
+}
+
+// TransferURL rewrites the url with a valid hostname and adds the host's thumbprint.
+// The InitiateFileTransfer{From,To}Guest methods return a URL with the host set to "*" when connected directly to ESX,
+// but return the address of VM's runtime host when connected to vCenter.
+func (m FileManager) TransferURL(ctx context.Context, u string) (*url.URL, error) {
+	turl, err := url.Parse(u)
+	if err != nil {
+		return nil, err
+	}
+
+	if turl.Hostname() == "*" {
+		turl.Host = m.c.URL().Host // Also use Client's port, to support port forwarding
+	}
+
+	if !m.c.IsVC() {
+		return turl, nil // we already connected to the ESX host and have its thumbprint
+	}
+
+	name := turl.Hostname()
+	port := turl.Port()
+
+	m.mu.Lock()
+	mname, ok := m.hosts[name]
+	m.mu.Unlock()
+
+	if ok {
+		turl.Host = net.JoinHostPort(mname, port)
+		return turl, nil
+	}
+
+	c := property.DefaultCollector(m.c)
+
+	var vm mo.VirtualMachine
+	err = c.RetrieveOne(ctx, m.vm, []string{"runtime.host"}, &vm)
+	if err != nil {
+		return nil, err
+	}
+
+	if vm.Runtime.Host == nil {
+		return turl, nil // won't matter if the VM was powered off since the call to InitiateFileTransfer will fail
+	}
+
+	props := []string{"summary.config.sslThumbprint", "config.virtualNicManagerInfo.netConfig"}
+
+	var host mo.HostSystem
+	err = c.RetrieveOne(ctx, *vm.Runtime.Host, props, &host)
+	if err != nil {
+		return nil, err
+	}
+
+	// prefer an ESX management IP, as the hostname used when adding to VC may not be valid for this client
+	// See also object.HostSystem.ManagementIPs which we can't use here due to import cycle
+	for _, nc := range host.Config.VirtualNicManagerInfo.NetConfig {
+		if nc.NicType != string(types.HostVirtualNicManagerNicTypeManagement) {
+			continue
+		}
+		for ix := range nc.CandidateVnic {
+			for _, selectedVnicKey := range nc.SelectedVnic {
+				if nc.CandidateVnic[ix].Key != selectedVnicKey {
+					continue
+				}
+				ip := net.ParseIP(nc.CandidateVnic[ix].Spec.Ip.IpAddress)
+				if ip != nil {
+					mname = ip.String()
+					m.mu.Lock()
+					m.hosts[name] = mname
+					m.mu.Unlock()
+
+					name = mname
+					break
+				}
+			}
+		}
+	}
+
+	turl.Host = net.JoinHostPort(name, port)
+
+	m.c.SetThumbprint(turl.Host, host.Summary.Config.SslThumbprint)
+
+	return turl, nil
+}
+
+func (m FileManager) InitiateFileTransferFromGuest(ctx context.Context, auth types.BaseGuestAuthentication, guestFilePath string) (*types.FileTransferInformation, error) {
+	req := types.InitiateFileTransferFromGuest{
+		This:          m.Reference(),
+		Vm:            m.vm,
+		Auth:          auth,
+		GuestFilePath: guestFilePath,
+	}
+
+	res, err := methods.InitiateFileTransferFromGuest(ctx, m.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Returnval, nil
+}
+
+func (m FileManager) InitiateFileTransferToGuest(ctx context.Context, auth types.BaseGuestAuthentication, guestFilePath string, fileAttributes types.BaseGuestFileAttributes, fileSize int64, overwrite bool) (string, error) {
+	req := types.InitiateFileTransferToGuest{
+		This:           m.Reference(),
+		Vm:             m.vm,
+		Auth:           auth,
+		GuestFilePath:  guestFilePath,
+		FileAttributes: fileAttributes,
+		FileSize:       fileSize,
+		Overwrite:      overwrite,
+	}
+
+	res, err := methods.InitiateFileTransferToGuest(ctx, m.c, &req)
+	if err != nil {
+		return "", err
+	}
+
+	return res.Returnval, nil
+}
+
+func (m FileManager) ListFiles(ctx context.Context, auth types.BaseGuestAuthentication, filePath string, index int32, maxResults int32, matchPattern string) (*types.GuestListFileInfo, error) {
+	req := types.ListFilesInGuest{
+		This:         m.Reference(),
+		Vm:           m.vm,
+		Auth:         auth,
+		FilePath:     filePath,
+		Index:        index,
+		MaxResults:   maxResults,
+		MatchPattern: matchPattern,
+	}
+
+	res, err := methods.ListFilesInGuest(ctx, m.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Returnval, nil
+}
+
+func (m FileManager) MakeDirectory(ctx context.Context, auth types.BaseGuestAuthentication, directoryPath string, createParentDirectories bool) error {
+	req := types.MakeDirectoryInGuest{
+		This:                    m.Reference(),
+		Vm:                      m.vm,
+		Auth:                    auth,
+		DirectoryPath:           directoryPath,
+		CreateParentDirectories: createParentDirectories,
+	}
+
+	_, err := methods.MakeDirectoryInGuest(ctx, m.c, &req)
+	return err
+}
+
+func (m FileManager) MoveDirectory(ctx context.Context, auth types.BaseGuestAuthentication, srcDirectoryPath string, dstDirectoryPath string) error {
+	req := types.MoveDirectoryInGuest{
+		This:             m.Reference(),
+		Vm:               m.vm,
+		Auth:             auth,
+		SrcDirectoryPath: srcDirectoryPath,
+		DstDirectoryPath: dstDirectoryPath,
+	}
+
+	_, err := methods.MoveDirectoryInGuest(ctx, m.c, &req)
+	return err
+}
+
+func (m FileManager) MoveFile(ctx context.Context, auth types.BaseGuestAuthentication, srcFilePath string, dstFilePath string, overwrite bool) error {
+	req := types.MoveFileInGuest{
+		This:        m.Reference(),
+		Vm:          m.vm,
+		Auth:        auth,
+		SrcFilePath: srcFilePath,
+		DstFilePath: dstFilePath,
+		Overwrite:   overwrite,
+	}
+
+	_, err := methods.MoveFileInGuest(ctx, m.c, &req)
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/guest/operations_manager.go
+++ b/vendor/github.com/vmware/govmomi/guest/operations_manager.go
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"context"
+	"sync"
+
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type OperationsManager struct {
+	c  *vim25.Client
+	vm types.ManagedObjectReference
+}
+
+func NewOperationsManager(c *vim25.Client, vm types.ManagedObjectReference) *OperationsManager {
+	return &OperationsManager{c, vm}
+}
+
+func (m OperationsManager) retrieveOne(ctx context.Context, p string, dst *mo.GuestOperationsManager) error {
+	pc := property.DefaultCollector(m.c)
+	return pc.RetrieveOne(ctx, *m.c.ServiceContent.GuestOperationsManager, []string{p}, dst)
+}
+
+func (m OperationsManager) AuthManager(ctx context.Context) (*AuthManager, error) {
+	var g mo.GuestOperationsManager
+
+	err := m.retrieveOne(ctx, "authManager", &g)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AuthManager{*g.AuthManager, m.vm, m.c}, nil
+}
+
+func (m OperationsManager) FileManager(ctx context.Context) (*FileManager, error) {
+	var g mo.GuestOperationsManager
+
+	err := m.retrieveOne(ctx, "fileManager", &g)
+	if err != nil {
+		return nil, err
+	}
+
+	return &FileManager{
+		ManagedObjectReference: *g.FileManager,
+		vm:                     m.vm,
+		c:                      m.c,
+		mu:                     new(sync.Mutex),
+		hosts:                  make(map[string]string),
+	}, nil
+}
+
+func (m OperationsManager) ProcessManager(ctx context.Context) (*ProcessManager, error) {
+	var g mo.GuestOperationsManager
+
+	err := m.retrieveOne(ctx, "processManager", &g)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ProcessManager{*g.ProcessManager, m.vm, m.c}, nil
+}

--- a/vendor/github.com/vmware/govmomi/guest/process_manager.go
+++ b/vendor/github.com/vmware/govmomi/guest/process_manager.go
@@ -1,0 +1,101 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ProcessManager struct {
+	types.ManagedObjectReference
+
+	vm types.ManagedObjectReference
+
+	c *vim25.Client
+}
+
+func (m ProcessManager) Client() *vim25.Client {
+	return m.c
+}
+
+func (m ProcessManager) Reference() types.ManagedObjectReference {
+	return m.ManagedObjectReference
+}
+
+func (m ProcessManager) ListProcesses(ctx context.Context, auth types.BaseGuestAuthentication, pids []int64) ([]types.GuestProcessInfo, error) {
+	req := types.ListProcessesInGuest{
+		This: m.Reference(),
+		Vm:   m.vm,
+		Auth: auth,
+		Pids: pids,
+	}
+
+	res, err := methods.ListProcessesInGuest(ctx, m.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, err
+}
+
+func (m ProcessManager) ReadEnvironmentVariable(ctx context.Context, auth types.BaseGuestAuthentication, names []string) ([]string, error) {
+	req := types.ReadEnvironmentVariableInGuest{
+		This:  m.Reference(),
+		Vm:    m.vm,
+		Auth:  auth,
+		Names: names,
+	}
+
+	res, err := methods.ReadEnvironmentVariableInGuest(ctx, m.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, err
+}
+
+func (m ProcessManager) StartProgram(ctx context.Context, auth types.BaseGuestAuthentication, spec types.BaseGuestProgramSpec) (int64, error) {
+	req := types.StartProgramInGuest{
+		This: m.Reference(),
+		Vm:   m.vm,
+		Auth: auth,
+		Spec: spec,
+	}
+
+	res, err := methods.StartProgramInGuest(ctx, m.c, &req)
+	if err != nil {
+		return 0, err
+	}
+
+	return res.Returnval, err
+}
+
+func (m ProcessManager) TerminateProcess(ctx context.Context, auth types.BaseGuestAuthentication, pid int64) error {
+	req := types.TerminateProcessInGuest{
+		This: m.Reference(),
+		Vm:   m.vm,
+		Auth: auth,
+		Pid:  pid,
+	}
+
+	_, err := methods.TerminateProcessInGuest(ctx, m.c, &req)
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/guest/toolbox/client.go
+++ b/vendor/github.com/vmware/govmomi/guest/toolbox/client.go
@@ -1,0 +1,302 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package toolbox
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/vmware/govmomi/guest"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// Client attempts to expose guest.OperationsManager as idiomatic Go interfaces
+type Client struct {
+	ProcessManager *guest.ProcessManager
+	FileManager    *guest.FileManager
+	Authentication types.BaseGuestAuthentication
+	GuestFamily    types.VirtualMachineGuestOsFamily
+}
+
+func (c *Client) rm(ctx context.Context, path string) {
+	err := c.FileManager.DeleteFile(ctx, c.Authentication, path)
+	if err != nil {
+		log.Printf("rm %q: %s", path, err)
+	}
+}
+
+func (c *Client) mktemp(ctx context.Context) (string, error) {
+	return c.FileManager.CreateTemporaryFile(ctx, c.Authentication, "govmomi-", "", "")
+}
+
+type exitError struct {
+	error
+	exitCode int
+}
+
+func (e *exitError) ExitCode() int {
+	return e.exitCode
+}
+
+// Run implements exec.Cmd.Run over vmx guest RPC against standard vmware-tools or toolbox.
+func (c *Client) Run(ctx context.Context, cmd *exec.Cmd) error {
+	if cmd.Stdin != nil {
+		dst, err := c.mktemp(ctx)
+		if err != nil {
+			return err
+		}
+
+		defer c.rm(ctx, dst)
+
+		var buf bytes.Buffer
+		size, err := io.Copy(&buf, cmd.Stdin)
+		if err != nil {
+			return err
+		}
+
+		p := soap.DefaultUpload
+		p.ContentLength = size
+		attr := new(types.GuestPosixFileAttributes)
+
+		err = c.Upload(ctx, &buf, dst, p, attr, true)
+		if err != nil {
+			return err
+		}
+
+		cmd.Args = append(cmd.Args, "<", dst)
+	}
+
+	output := []struct {
+		io.Writer
+		fd   string
+		path string
+	}{
+		{cmd.Stdout, "1", ""},
+		{cmd.Stderr, "2", ""},
+	}
+
+	for i, out := range output {
+		if out.Writer == nil {
+			continue
+		}
+
+		dst, err := c.mktemp(ctx)
+		if err != nil {
+			return err
+		}
+
+		defer c.rm(ctx, dst)
+
+		cmd.Args = append(cmd.Args, out.fd+">", dst)
+		output[i].path = dst
+	}
+
+	path := cmd.Path
+	args := cmd.Args
+
+	switch c.GuestFamily {
+	case types.VirtualMachineGuestOsFamilyWindowsGuest:
+		// Using 'cmd.exe /c' is required on Windows for i/o redirection
+		path = "c:\\Windows\\System32\\cmd.exe"
+		args = append([]string{"/c", cmd.Path}, args...)
+	default:
+		if !strings.ContainsAny(cmd.Path, "/") {
+			// vmware-tools requires an absolute ProgramPath
+			// Default to 'bash -c' as a convenience
+			path = "/bin/bash"
+			arg := "'" + strings.Join(append([]string{cmd.Path}, args...), " ") + "'"
+			args = []string{"-c", arg}
+		}
+	}
+
+	spec := types.GuestProgramSpec{
+		ProgramPath:      path,
+		Arguments:        strings.Join(args, " "),
+		EnvVariables:     cmd.Env,
+		WorkingDirectory: cmd.Dir,
+	}
+
+	pid, err := c.ProcessManager.StartProgram(ctx, c.Authentication, &spec)
+	if err != nil {
+		return err
+	}
+
+	rc := 0
+	for {
+		procs, err := c.ProcessManager.ListProcesses(ctx, c.Authentication, []int64{pid})
+		if err != nil {
+			return err
+		}
+
+		p := procs[0]
+		if p.EndTime == nil {
+			<-time.After(time.Second / 2)
+			continue
+		}
+
+		rc = int(p.ExitCode)
+
+		break
+	}
+
+	for _, out := range output {
+		if out.Writer == nil {
+			continue
+		}
+
+		f, _, err := c.Download(ctx, out.path)
+		if err != nil {
+			return err
+		}
+
+		_, err = io.Copy(out.Writer, f)
+		_ = f.Close()
+		if err != nil {
+			return err
+		}
+	}
+
+	if rc != 0 {
+		return &exitError{fmt.Errorf("%s: exit %d", cmd.Path, rc), rc}
+	}
+
+	return nil
+}
+
+// archiveReader wraps an io.ReadCloser to support streaming download
+// of a guest directory, stops reading once it sees the stream trailer.
+// This is only useful when guest tools is the Go toolbox.
+// The trailer is required since TransferFromGuest requires a Content-Length,
+// which toolbox doesn't know ahead of time as the gzip'd tarball never touches the disk.
+// We opted to wrap this here for now rather than guest.FileManager so
+// DownloadFile can be also be used as-is to handle this use case.
+type archiveReader struct {
+	io.ReadCloser
+}
+
+var (
+	gzipHeader    = []byte{0x1f, 0x8b, 0x08} // rfc1952 {ID1, ID2, CM}
+	gzipHeaderLen = len(gzipHeader)
+)
+
+func (r *archiveReader) Read(buf []byte) (int, error) {
+	nr, err := r.ReadCloser.Read(buf)
+
+	// Stop reading if the last N bytes are the gzipTrailer
+	if nr >= gzipHeaderLen {
+		if bytes.Equal(buf[nr-gzipHeaderLen:nr], gzipHeader) {
+			nr -= gzipHeaderLen
+			err = io.EOF
+		}
+	}
+
+	return nr, err
+}
+
+func isDir(src string) bool {
+	u, err := url.Parse(src)
+	if err != nil {
+		return false
+	}
+
+	return strings.HasSuffix(u.Path, "/")
+}
+
+// Download initiates a file transfer from the guest
+func (c *Client) Download(ctx context.Context, src string) (io.ReadCloser, int64, error) {
+	vc := c.ProcessManager.Client()
+
+	info, err := c.FileManager.InitiateFileTransferFromGuest(ctx, c.Authentication, src)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	u, err := c.FileManager.TransferURL(ctx, info.Url)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	p := soap.DefaultDownload
+
+	f, n, err := vc.Download(ctx, u, &p)
+	if err != nil {
+		return nil, n, err
+	}
+
+	if strings.HasPrefix(src, "/archive:/") || isDir(src) {
+		f = &archiveReader{ReadCloser: f} // look for the gzip trailer
+	}
+
+	return f, n, nil
+}
+
+// Upload transfers a file to the guest
+func (c *Client) Upload(ctx context.Context, src io.Reader, dst string, p soap.Upload, attr types.BaseGuestFileAttributes, force bool) error {
+	vc := c.ProcessManager.Client()
+
+	var err error
+
+	if p.ContentLength == 0 { // Content-Length is required
+		switch r := src.(type) {
+		case *bytes.Buffer:
+			p.ContentLength = int64(r.Len())
+		case *bytes.Reader:
+			p.ContentLength = int64(r.Len())
+		case *strings.Reader:
+			p.ContentLength = int64(r.Len())
+		case *os.File:
+			info, serr := r.Stat()
+			if serr != nil {
+				return serr
+			}
+
+			p.ContentLength = info.Size()
+		}
+
+		if p.ContentLength == 0 { // os.File for example could be a device (stdin)
+			buf := new(bytes.Buffer)
+
+			p.ContentLength, err = io.Copy(buf, src)
+			if err != nil {
+				return err
+			}
+
+			src = buf
+		}
+	}
+
+	url, err := c.FileManager.InitiateFileTransferToGuest(ctx, c.Authentication, dst, attr, p.ContentLength, force)
+	if err != nil {
+		return err
+	}
+
+	u, err := c.FileManager.TransferURL(ctx, url)
+	if err != nil {
+		return err
+	}
+
+	return vc.Client.Upload(ctx, src, u, &p)
+}

--- a/vendor/github.com/vmware/govmomi/internal/methods.go
+++ b/vendor/github.com/vmware/govmomi/internal/methods.go
@@ -1,0 +1,123 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+type RetrieveDynamicTypeManagerBody struct {
+	Req    *RetrieveDynamicTypeManagerRequest  `xml:"urn:vim25 RetrieveDynamicTypeManager"`
+	Res    *RetrieveDynamicTypeManagerResponse `xml:"urn:vim25 RetrieveDynamicTypeManagerResponse"`
+	Fault_ *soap.Fault
+}
+
+func (b *RetrieveDynamicTypeManagerBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RetrieveDynamicTypeManager(ctx context.Context, r soap.RoundTripper, req *RetrieveDynamicTypeManagerRequest) (*RetrieveDynamicTypeManagerResponse, error) {
+	var reqBody, resBody RetrieveDynamicTypeManagerBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RetrieveManagedMethodExecuterBody struct {
+	Req    *RetrieveManagedMethodExecuterRequest  `xml:"urn:vim25 RetrieveManagedMethodExecuter"`
+	Res    *RetrieveManagedMethodExecuterResponse `xml:"urn:vim25 RetrieveManagedMethodExecuterResponse"`
+	Fault_ *soap.Fault
+}
+
+func (b *RetrieveManagedMethodExecuterBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RetrieveManagedMethodExecuter(ctx context.Context, r soap.RoundTripper, req *RetrieveManagedMethodExecuterRequest) (*RetrieveManagedMethodExecuterResponse, error) {
+	var reqBody, resBody RetrieveManagedMethodExecuterBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type DynamicTypeMgrQueryMoInstancesBody struct {
+	Req    *DynamicTypeMgrQueryMoInstancesRequest  `xml:"urn:vim25 DynamicTypeMgrQueryMoInstances"`
+	Res    *DynamicTypeMgrQueryMoInstancesResponse `xml:"urn:vim25 DynamicTypeMgrQueryMoInstancesResponse"`
+	Fault_ *soap.Fault
+}
+
+func (b *DynamicTypeMgrQueryMoInstancesBody) Fault() *soap.Fault { return b.Fault_ }
+
+func DynamicTypeMgrQueryMoInstances(ctx context.Context, r soap.RoundTripper, req *DynamicTypeMgrQueryMoInstancesRequest) (*DynamicTypeMgrQueryMoInstancesResponse, error) {
+	var reqBody, resBody DynamicTypeMgrQueryMoInstancesBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type DynamicTypeMgrQueryTypeInfoBody struct {
+	Req    *DynamicTypeMgrQueryTypeInfoRequest  `xml:"urn:vim25 DynamicTypeMgrQueryTypeInfo"`
+	Res    *DynamicTypeMgrQueryTypeInfoResponse `xml:"urn:vim25 DynamicTypeMgrQueryTypeInfoResponse"`
+	Fault_ *soap.Fault
+}
+
+func (b *DynamicTypeMgrQueryTypeInfoBody) Fault() *soap.Fault { return b.Fault_ }
+
+func DynamicTypeMgrQueryTypeInfo(ctx context.Context, r soap.RoundTripper, req *DynamicTypeMgrQueryTypeInfoRequest) (*DynamicTypeMgrQueryTypeInfoResponse, error) {
+	var reqBody, resBody DynamicTypeMgrQueryTypeInfoBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type ExecuteSoapBody struct {
+	Req    *ExecuteSoapRequest  `xml:"urn:vim25 ExecuteSoap"`
+	Res    *ExecuteSoapResponse `xml:"urn:vim25 ExecuteSoapResponse"`
+	Fault_ *soap.Fault
+}
+
+func (b *ExecuteSoapBody) Fault() *soap.Fault { return b.Fault_ }
+
+func ExecuteSoap(ctx context.Context, r soap.RoundTripper, req *ExecuteSoapRequest) (*ExecuteSoapResponse, error) {
+	var reqBody, resBody ExecuteSoapBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}

--- a/vendor/github.com/vmware/govmomi/internal/types.go
+++ b/vendor/github.com/vmware/govmomi/internal/types.go
@@ -1,0 +1,270 @@
+/*
+Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"reflect"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type DynamicTypeMgrQueryMoInstancesRequest struct {
+	This       types.ManagedObjectReference `xml:"_this"`
+	FilterSpec BaseDynamicTypeMgrFilterSpec `xml:"filterSpec,omitempty,typeattr"`
+}
+
+type DynamicTypeMgrQueryMoInstancesResponse struct {
+	Returnval []DynamicTypeMgrMoInstance `xml:"urn:vim25 returnval"`
+}
+
+type DynamicTypeEnumTypeInfo struct {
+	types.DynamicData
+
+	Name       string                     `xml:"name"`
+	WsdlName   string                     `xml:"wsdlName"`
+	Version    string                     `xml:"version"`
+	Value      []string                   `xml:"value,omitempty"`
+	Annotation []DynamicTypeMgrAnnotation `xml:"annotation,omitempty"`
+}
+
+func init() {
+	types.Add("DynamicTypeEnumTypeInfo", reflect.TypeOf((*DynamicTypeEnumTypeInfo)(nil)).Elem())
+}
+
+type DynamicTypeMgrAllTypeInfoRequest struct {
+	types.DynamicData
+
+	ManagedTypeInfo []DynamicTypeMgrManagedTypeInfo `xml:"managedTypeInfo,omitempty"`
+	EnumTypeInfo    []DynamicTypeEnumTypeInfo       `xml:"enumTypeInfo,omitempty"`
+	DataTypeInfo    []DynamicTypeMgrDataTypeInfo    `xml:"dataTypeInfo,omitempty"`
+}
+
+func init() {
+	types.Add("DynamicTypeMgrAllTypeInfo", reflect.TypeOf((*DynamicTypeMgrAllTypeInfoRequest)(nil)).Elem())
+}
+
+type DynamicTypeMgrAnnotation struct {
+	types.DynamicData
+
+	Name      string   `xml:"name"`
+	Parameter []string `xml:"parameter,omitempty"`
+}
+
+func init() {
+	types.Add("DynamicTypeMgrAnnotation", reflect.TypeOf((*DynamicTypeMgrAnnotation)(nil)).Elem())
+}
+
+type DynamicTypeMgrDataTypeInfo struct {
+	types.DynamicData
+
+	Name       string                           `xml:"name"`
+	WsdlName   string                           `xml:"wsdlName"`
+	Version    string                           `xml:"version"`
+	Base       []string                         `xml:"base,omitempty"`
+	Property   []DynamicTypeMgrPropertyTypeInfo `xml:"property,omitempty"`
+	Annotation []DynamicTypeMgrAnnotation       `xml:"annotation,omitempty"`
+}
+
+func init() {
+	types.Add("DynamicTypeMgrDataTypeInfo", reflect.TypeOf((*DynamicTypeMgrDataTypeInfo)(nil)).Elem())
+}
+
+func (b *DynamicTypeMgrFilterSpec) GetDynamicTypeMgrFilterSpec() *DynamicTypeMgrFilterSpec { return b }
+
+type BaseDynamicTypeMgrFilterSpec interface {
+	GetDynamicTypeMgrFilterSpec() *DynamicTypeMgrFilterSpec
+}
+
+type DynamicTypeMgrFilterSpec struct {
+	types.DynamicData
+}
+
+func init() {
+	types.Add("DynamicTypeMgrFilterSpec", reflect.TypeOf((*DynamicTypeMgrFilterSpec)(nil)).Elem())
+}
+
+type DynamicTypeMgrManagedTypeInfo struct {
+	types.DynamicData
+
+	Name       string                           `xml:"name"`
+	WsdlName   string                           `xml:"wsdlName"`
+	Version    string                           `xml:"version"`
+	Base       []string                         `xml:"base,omitempty"`
+	Property   []DynamicTypeMgrPropertyTypeInfo `xml:"property,omitempty"`
+	Method     []DynamicTypeMgrMethodTypeInfo   `xml:"method,omitempty"`
+	Annotation []DynamicTypeMgrAnnotation       `xml:"annotation,omitempty"`
+}
+
+func init() {
+	types.Add("DynamicTypeMgrManagedTypeInfo", reflect.TypeOf((*DynamicTypeMgrManagedTypeInfo)(nil)).Elem())
+}
+
+type DynamicTypeMgrMethodTypeInfo struct {
+	types.DynamicData
+
+	Name           string                        `xml:"name"`
+	WsdlName       string                        `xml:"wsdlName"`
+	Version        string                        `xml:"version"`
+	ParamTypeInfo  []DynamicTypeMgrParamTypeInfo `xml:"paramTypeInfo,omitempty"`
+	ReturnTypeInfo *DynamicTypeMgrParamTypeInfo  `xml:"returnTypeInfo,omitempty"`
+	Fault          []string                      `xml:"fault,omitempty"`
+	PrivId         string                        `xml:"privId,omitempty"`
+	Annotation     []DynamicTypeMgrAnnotation    `xml:"annotation,omitempty"`
+}
+
+func init() {
+	types.Add("DynamicTypeMgrMethodTypeInfo", reflect.TypeOf((*DynamicTypeMgrMethodTypeInfo)(nil)).Elem())
+}
+
+type DynamicTypeMgrMoFilterSpec struct {
+	DynamicTypeMgrFilterSpec
+
+	Id         string `xml:"id,omitempty"`
+	TypeSubstr string `xml:"typeSubstr,omitempty"`
+}
+
+func init() {
+	types.Add("DynamicTypeMgrMoFilterSpec", reflect.TypeOf((*DynamicTypeMgrMoFilterSpec)(nil)).Elem())
+}
+
+type DynamicTypeMgrMoInstance struct {
+	types.DynamicData
+
+	Id     string `xml:"id"`
+	MoType string `xml:"moType"`
+}
+
+func init() {
+	types.Add("DynamicTypeMgrMoInstance", reflect.TypeOf((*DynamicTypeMgrMoInstance)(nil)).Elem())
+}
+
+type DynamicTypeMgrParamTypeInfo struct {
+	types.DynamicData
+
+	Name       string                     `xml:"name"`
+	Version    string                     `xml:"version"`
+	Type       string                     `xml:"type"`
+	PrivId     string                     `xml:"privId,omitempty"`
+	Annotation []DynamicTypeMgrAnnotation `xml:"annotation,omitempty"`
+}
+
+func init() {
+	types.Add("DynamicTypeMgrParamTypeInfo", reflect.TypeOf((*DynamicTypeMgrParamTypeInfo)(nil)).Elem())
+}
+
+type DynamicTypeMgrPropertyTypeInfo struct {
+	types.DynamicData
+
+	Name        string                     `xml:"name"`
+	Version     string                     `xml:"version"`
+	Type        string                     `xml:"type"`
+	PrivId      string                     `xml:"privId,omitempty"`
+	MsgIdFormat string                     `xml:"msgIdFormat,omitempty"`
+	Annotation  []DynamicTypeMgrAnnotation `xml:"annotation,omitempty"`
+}
+
+type DynamicTypeMgrQueryTypeInfoRequest struct {
+	This       types.ManagedObjectReference `xml:"_this"`
+	FilterSpec BaseDynamicTypeMgrFilterSpec `xml:"filterSpec,omitempty,typeattr"`
+}
+
+type DynamicTypeMgrQueryTypeInfoResponse struct {
+	Returnval DynamicTypeMgrAllTypeInfoRequest `xml:"urn:vim25 returnval"`
+}
+
+func init() {
+	types.Add("DynamicTypeMgrPropertyTypeInfo", reflect.TypeOf((*DynamicTypeMgrPropertyTypeInfo)(nil)).Elem())
+}
+
+type DynamicTypeMgrTypeFilterSpec struct {
+	DynamicTypeMgrFilterSpec
+
+	TypeSubstr string `xml:"typeSubstr,omitempty"`
+}
+
+func init() {
+	types.Add("DynamicTypeMgrTypeFilterSpec", reflect.TypeOf((*DynamicTypeMgrTypeFilterSpec)(nil)).Elem())
+}
+
+type ReflectManagedMethodExecuterSoapArgument struct {
+	types.DynamicData
+
+	Name string `xml:"name"`
+	Val  string `xml:"val"`
+}
+
+func init() {
+	types.Add("ReflectManagedMethodExecuterSoapArgument", reflect.TypeOf((*ReflectManagedMethodExecuterSoapArgument)(nil)).Elem())
+}
+
+type ReflectManagedMethodExecuterSoapFault struct {
+	types.DynamicData
+
+	FaultMsg    string `xml:"faultMsg"`
+	FaultDetail string `xml:"faultDetail,omitempty"`
+}
+
+func init() {
+	types.Add("ReflectManagedMethodExecuterSoapFault", reflect.TypeOf((*ReflectManagedMethodExecuterSoapFault)(nil)).Elem())
+}
+
+type ReflectManagedMethodExecuterSoapResult struct {
+	types.DynamicData
+
+	Response string                                 `xml:"response,omitempty"`
+	Fault    *ReflectManagedMethodExecuterSoapFault `xml:"fault,omitempty"`
+}
+
+type RetrieveDynamicTypeManagerRequest struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+type RetrieveDynamicTypeManagerResponse struct {
+	Returnval *InternalDynamicTypeManager `xml:"urn:vim25 returnval"`
+}
+
+type RetrieveManagedMethodExecuterRequest struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("RetrieveManagedMethodExecuter", reflect.TypeOf((*RetrieveManagedMethodExecuterRequest)(nil)).Elem())
+}
+
+type RetrieveManagedMethodExecuterResponse struct {
+	Returnval *ReflectManagedMethodExecuter `xml:"urn:vim25 returnval"`
+}
+
+type InternalDynamicTypeManager struct {
+	types.ManagedObjectReference
+}
+
+type ReflectManagedMethodExecuter struct {
+	types.ManagedObjectReference
+}
+
+type ExecuteSoapRequest struct {
+	This     types.ManagedObjectReference               `xml:"_this"`
+	Moid     string                                     `xml:"moid"`
+	Version  string                                     `xml:"version"`
+	Method   string                                     `xml:"method"`
+	Argument []ReflectManagedMethodExecuterSoapArgument `xml:"argument,omitempty"`
+}
+
+type ExecuteSoapResponse struct {
+	Returnval *ReflectManagedMethodExecuterSoapResult `xml:"urn:vim25 returnval"`
+}

--- a/vendor/github.com/vmware/govmomi/license/assignment_manager.go
+++ b/vendor/github.com/vmware/govmomi/license/assignment_manager.go
@@ -1,0 +1,70 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package license
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type AssignmentManager struct {
+	object.Common
+}
+
+func (m AssignmentManager) QueryAssigned(ctx context.Context, id string) ([]types.LicenseAssignmentManagerLicenseAssignment, error) {
+	req := types.QueryAssignedLicenses{
+		This:     m.Reference(),
+		EntityId: id,
+	}
+
+	res, err := methods.QueryAssignedLicenses(ctx, m.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (m AssignmentManager) Remove(ctx context.Context, id string) error {
+	req := types.RemoveAssignedLicense{
+		This:     m.Reference(),
+		EntityId: id,
+	}
+
+	_, err := methods.RemoveAssignedLicense(ctx, m.Client(), &req)
+
+	return err
+}
+
+func (m AssignmentManager) Update(ctx context.Context, id string, key string, name string) (*types.LicenseManagerLicenseInfo, error) {
+	req := types.UpdateAssignedLicense{
+		This:              m.Reference(),
+		Entity:            id,
+		LicenseKey:        key,
+		EntityDisplayName: name,
+	}
+
+	res, err := methods.UpdateAssignedLicense(ctx, m.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Returnval, nil
+}

--- a/vendor/github.com/vmware/govmomi/license/manager.go
+++ b/vendor/github.com/vmware/govmomi/license/manager.go
@@ -1,0 +1,195 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package license
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type Manager struct {
+	object.Common
+}
+
+func NewManager(c *vim25.Client) *Manager {
+	m := Manager{
+		object.NewCommon(c, *c.ServiceContent.LicenseManager),
+	}
+
+	return &m
+}
+
+func mapToKeyValueSlice(m map[string]string) []types.KeyValue {
+	var r []types.KeyValue
+	for k, v := range m {
+		r = append(r, types.KeyValue{Key: k, Value: v})
+	}
+	return r
+}
+
+func (m Manager) Add(ctx context.Context, key string, labels map[string]string) (types.LicenseManagerLicenseInfo, error) {
+	req := types.AddLicense{
+		This:       m.Reference(),
+		LicenseKey: key,
+		Labels:     mapToKeyValueSlice(labels),
+	}
+
+	res, err := methods.AddLicense(ctx, m.Client(), &req)
+	if err != nil {
+		return types.LicenseManagerLicenseInfo{}, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (m Manager) Decode(ctx context.Context, key string) (types.LicenseManagerLicenseInfo, error) {
+	req := types.DecodeLicense{
+		This:       m.Reference(),
+		LicenseKey: key,
+	}
+
+	res, err := methods.DecodeLicense(ctx, m.Client(), &req)
+	if err != nil {
+		return types.LicenseManagerLicenseInfo{}, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (m Manager) Remove(ctx context.Context, key string) error {
+	req := types.RemoveLicense{
+		This:       m.Reference(),
+		LicenseKey: key,
+	}
+
+	_, err := methods.RemoveLicense(ctx, m.Client(), &req)
+	return err
+}
+
+func (m Manager) Update(ctx context.Context, key string, labels map[string]string) (types.LicenseManagerLicenseInfo, error) {
+	req := types.UpdateLicense{
+		This:       m.Reference(),
+		LicenseKey: key,
+		Labels:     mapToKeyValueSlice(labels),
+	}
+
+	res, err := methods.UpdateLicense(ctx, m.Client(), &req)
+	if err != nil {
+		return types.LicenseManagerLicenseInfo{}, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (m Manager) List(ctx context.Context) (InfoList, error) {
+	var mlm mo.LicenseManager
+
+	err := m.Properties(ctx, m.Reference(), []string{"licenses"}, &mlm)
+	if err != nil {
+		return nil, err
+	}
+
+	return InfoList(mlm.Licenses), nil
+}
+
+func (m Manager) AssignmentManager(ctx context.Context) (*AssignmentManager, error) {
+	var mlm mo.LicenseManager
+
+	err := m.Properties(ctx, m.Reference(), []string{"licenseAssignmentManager"}, &mlm)
+	if err != nil {
+		return nil, err
+	}
+
+	if mlm.LicenseAssignmentManager == nil {
+		return nil, object.ErrNotSupported
+	}
+
+	am := AssignmentManager{
+		object.NewCommon(m.Client(), *mlm.LicenseAssignmentManager),
+	}
+
+	return &am, nil
+}
+
+type licenseFeature struct {
+	name  string
+	level int
+}
+
+func parseLicenseFeature(feature string) *licenseFeature {
+	lf := new(licenseFeature)
+
+	f := strings.Split(feature, ":")
+
+	lf.name = f[0]
+
+	if len(f) > 1 {
+		var err error
+		lf.level, err = strconv.Atoi(f[1])
+		if err != nil {
+			lf.name = feature
+		}
+	}
+
+	return lf
+}
+
+func HasFeature(license types.LicenseManagerLicenseInfo, key string) bool {
+	feature := parseLicenseFeature(key)
+
+	for _, p := range license.Properties {
+		if p.Key != "feature" {
+			continue
+		}
+
+		kv, ok := p.Value.(types.KeyValue)
+
+		if !ok {
+			continue
+		}
+
+		lf := parseLicenseFeature(kv.Key)
+
+		if lf.name == feature.name && lf.level >= feature.level {
+			return true
+		}
+	}
+
+	return false
+}
+
+// InfoList provides helper methods for []types.LicenseManagerLicenseInfo
+type InfoList []types.LicenseManagerLicenseInfo
+
+func (l InfoList) WithFeature(key string) InfoList {
+	var result InfoList
+
+	for _, license := range l {
+		if HasFeature(license, key) {
+			result = append(result, license)
+		}
+	}
+
+	return result
+}

--- a/vendor/github.com/vmware/govmomi/performance/manager.go
+++ b/vendor/github.com/vmware/govmomi/performance/manager.go
@@ -1,0 +1,410 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package performance
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// Manager wraps mo.PerformanceManager.
+type Manager struct {
+	object.Common
+
+	Sort bool
+
+	pm struct {
+		sync.Mutex
+		*mo.PerformanceManager
+	}
+
+	infoByName struct {
+		sync.Mutex
+		m map[string]*types.PerfCounterInfo
+	}
+
+	infoByKey struct {
+		sync.Mutex
+		m map[int32]*types.PerfCounterInfo
+	}
+}
+
+// NewManager creates a new Manager instance.
+func NewManager(client *vim25.Client) *Manager {
+	m := Manager{
+		Common: object.NewCommon(client, *client.ServiceContent.PerfManager),
+	}
+
+	m.pm.PerformanceManager = new(mo.PerformanceManager)
+
+	return &m
+}
+
+// IntervalList wraps []types.PerfInterval.
+type IntervalList []types.PerfInterval
+
+// Enabled returns a map with Level as the key and enabled PerfInterval.Name(s) as the value.
+func (l IntervalList) Enabled() map[int32][]string {
+	enabled := make(map[int32][]string)
+
+	for level := int32(0); level <= 4; level++ {
+		var names []string
+
+		for _, interval := range l {
+			if interval.Enabled && interval.Level >= level {
+				names = append(names, interval.Name)
+			}
+		}
+
+		enabled[level] = names
+	}
+
+	return enabled
+}
+
+// HistoricalInterval gets the PerformanceManager.HistoricalInterval property and wraps as an IntervalList.
+func (m *Manager) HistoricalInterval(ctx context.Context) (IntervalList, error) {
+	var pm mo.PerformanceManager
+
+	err := m.Properties(ctx, m.Reference(), []string{"historicalInterval"}, &pm)
+	if err != nil {
+		return nil, err
+	}
+
+	return IntervalList(pm.HistoricalInterval), nil
+}
+
+// CounterInfo gets the PerformanceManager.PerfCounter property.
+// The property value is only collected once, subsequent calls return the cached value.
+func (m *Manager) CounterInfo(ctx context.Context) ([]types.PerfCounterInfo, error) {
+	m.pm.Lock()
+	defer m.pm.Unlock()
+
+	if len(m.pm.PerfCounter) == 0 {
+		err := m.Properties(ctx, m.Reference(), []string{"perfCounter"}, m.pm.PerformanceManager)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return m.pm.PerfCounter, nil
+}
+
+// CounterInfoByName converts the PerformanceManager.PerfCounter property to a map,
+// where key is types.PerfCounterInfo.Name().
+func (m *Manager) CounterInfoByName(ctx context.Context) (map[string]*types.PerfCounterInfo, error) {
+	m.infoByName.Lock()
+	defer m.infoByName.Unlock()
+
+	if m.infoByName.m != nil {
+		return m.infoByName.m, nil
+	}
+
+	info, err := m.CounterInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	m.infoByName.m = make(map[string]*types.PerfCounterInfo)
+
+	for i := range info {
+		c := &info[i]
+
+		m.infoByName.m[c.Name()] = c
+	}
+
+	return m.infoByName.m, nil
+}
+
+// CounterInfoByKey converts the PerformanceManager.PerfCounter property to a map,
+// where key is types.PerfCounterInfo.Key.
+func (m *Manager) CounterInfoByKey(ctx context.Context) (map[int32]*types.PerfCounterInfo, error) {
+	m.infoByKey.Lock()
+	defer m.infoByKey.Unlock()
+
+	if m.infoByKey.m != nil {
+		return m.infoByKey.m, nil
+	}
+
+	info, err := m.CounterInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	m.infoByKey.m = make(map[int32]*types.PerfCounterInfo)
+
+	for i := range info {
+		c := &info[i]
+
+		m.infoByKey.m[c.Key] = c
+	}
+
+	return m.infoByKey.m, nil
+}
+
+// ProviderSummary wraps the QueryPerfProviderSummary method, caching the value based on entity.Type.
+func (m *Manager) ProviderSummary(ctx context.Context, entity types.ManagedObjectReference) (*types.PerfProviderSummary, error) {
+	req := types.QueryPerfProviderSummary{
+		This:   m.Reference(),
+		Entity: entity,
+	}
+
+	res, err := methods.QueryPerfProviderSummary(ctx, m.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Returnval, nil
+}
+
+type groupPerfCounterInfo struct {
+	info map[int32]*types.PerfCounterInfo
+	ids  []types.PerfMetricId
+}
+
+func (d groupPerfCounterInfo) Len() int {
+	return len(d.ids)
+}
+
+func (d groupPerfCounterInfo) Less(i, j int) bool {
+	ci := d.ids[i].CounterId
+	cj := d.ids[j].CounterId
+	gi := d.info[ci].GroupInfo.GetElementDescription()
+	gj := d.info[cj].GroupInfo.GetElementDescription()
+
+	return gi.Key < gj.Key
+}
+
+func (d groupPerfCounterInfo) Swap(i, j int) {
+	d.ids[i], d.ids[j] = d.ids[j], d.ids[i]
+}
+
+// MetricList wraps []types.PerfMetricId
+type MetricList []types.PerfMetricId
+
+// ByKey converts MetricList to map, where key is types.PerfMetricId.CounterId / types.PerfCounterInfo.Key
+func (l MetricList) ByKey() map[int32][]*types.PerfMetricId {
+	ids := make(map[int32][]*types.PerfMetricId, len(l))
+
+	for i := range l {
+		id := &l[i]
+		ids[id.CounterId] = append(ids[id.CounterId], id)
+	}
+
+	return ids
+}
+
+// AvailableMetric wraps the QueryAvailablePerfMetric method.
+// The MetricList is sorted by PerfCounterInfo.GroupInfo.Key if Manager.Sort == true.
+func (m *Manager) AvailableMetric(ctx context.Context, entity types.ManagedObjectReference, interval int32) (MetricList, error) {
+	req := types.QueryAvailablePerfMetric{
+		This:       m.Reference(),
+		Entity:     entity.Reference(),
+		IntervalId: interval,
+	}
+
+	res, err := methods.QueryAvailablePerfMetric(ctx, m.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	if m.Sort {
+		info, err := m.CounterInfoByKey(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		sort.Sort(groupPerfCounterInfo{info, res.Returnval})
+	}
+
+	return MetricList(res.Returnval), nil
+}
+
+// Query wraps the QueryPerf method.
+func (m *Manager) Query(ctx context.Context, spec []types.PerfQuerySpec) ([]types.BasePerfEntityMetricBase, error) {
+	req := types.QueryPerf{
+		This:      m.Reference(),
+		QuerySpec: spec,
+	}
+
+	res, err := methods.QueryPerf(ctx, m.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+// SampleByName uses the spec param as a template, constructing a []types.PerfQuerySpec for the given metrics and entities
+// and invoking the Query method.
+// The spec template can specify instances using the MetricId.Instance field, by default all instances are collected.
+// The spec template MaxSample defaults to 1.
+// If the spec template IntervalId is a historical interval and StartTime is not specified,
+// the StartTime is set to the current time - (IntervalId * MaxSample).
+func (m *Manager) SampleByName(ctx context.Context, spec types.PerfQuerySpec, metrics []string, entity []types.ManagedObjectReference) ([]types.BasePerfEntityMetricBase, error) {
+	info, err := m.CounterInfoByName(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var ids []types.PerfMetricId
+
+	instances := spec.MetricId
+	if len(instances) == 0 {
+		// Default to all instances
+		instances = []types.PerfMetricId{{Instance: "*"}}
+	}
+
+	for _, name := range metrics {
+		counter, ok := info[name]
+		if !ok {
+			return nil, fmt.Errorf("counter %q not found", name)
+		}
+
+		for _, i := range instances {
+			ids = append(ids, types.PerfMetricId{CounterId: counter.Key, Instance: i.Instance})
+		}
+	}
+
+	spec.MetricId = ids
+
+	if spec.MaxSample == 0 {
+		spec.MaxSample = 1
+	}
+
+	if spec.IntervalId >= 60 && spec.StartTime == nil {
+		// Need a StartTime to make use of history
+		now, err := methods.GetCurrentTime(ctx, m.Client())
+		if err != nil {
+			return nil, err
+		}
+
+		// Go back in time
+		x := spec.IntervalId * -1 * spec.MaxSample
+		t := now.Add(time.Duration(x) * time.Second)
+		spec.StartTime = &t
+	}
+
+	var query []types.PerfQuerySpec
+
+	for _, e := range entity {
+		spec.Entity = e.Reference()
+		query = append(query, spec)
+	}
+
+	return m.Query(ctx, query)
+}
+
+// MetricSeries contains the same data as types.PerfMetricIntSeries, but with the CounterId converted to Name.
+type MetricSeries struct {
+	Name     string
+	unit     string
+	Instance string
+	Value    []int64
+}
+
+func (s *MetricSeries) Format(val int64) string {
+	switch types.PerformanceManagerUnit(s.unit) {
+	case types.PerformanceManagerUnitPercent:
+		return strconv.FormatFloat(float64(val)/100.0, 'f', 2, 64)
+	default:
+		return strconv.FormatInt(val, 10)
+	}
+}
+
+// ValueCSV converts the Value field to a CSV string
+func (s *MetricSeries) ValueCSV() string {
+	vals := make([]string, len(s.Value))
+
+	for i := range s.Value {
+		vals[i] = s.Format(s.Value[i])
+	}
+
+	return strings.Join(vals, ",")
+}
+
+// EntityMetric contains the same data as types.PerfEntityMetric, but with MetricSeries type for the Value field.
+type EntityMetric struct {
+	Entity types.ManagedObjectReference
+
+	SampleInfo []types.PerfSampleInfo
+	Value      []MetricSeries
+}
+
+// SampleInfoCSV converts the SampleInfo field to a CSV string
+func (m *EntityMetric) SampleInfoCSV() string {
+	vals := make([]string, len(m.SampleInfo)*2)
+
+	i := 0
+
+	for _, s := range m.SampleInfo {
+		vals[i] = s.Timestamp.Format(time.RFC3339)
+		i++
+		vals[i] = strconv.Itoa(int(s.Interval))
+		i++
+	}
+
+	return strings.Join(vals, ",")
+}
+
+// ToMetricSeries converts []BasePerfEntityMetricBase to []EntityMetric
+func (m *Manager) ToMetricSeries(ctx context.Context, series []types.BasePerfEntityMetricBase) ([]EntityMetric, error) {
+	counters, err := m.CounterInfoByKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []EntityMetric
+
+	for i := range series {
+		var values []MetricSeries
+		s, ok := series[i].(*types.PerfEntityMetric)
+		if !ok {
+			panic(fmt.Errorf("expected type %T, got: %T", s, series[i]))
+		}
+
+		for j := range s.Value {
+			v := s.Value[j].(*types.PerfMetricIntSeries)
+
+			values = append(values, MetricSeries{
+				Name:     counters[v.Id.CounterId].Name(),
+				unit:     counters[v.Id.CounterId].UnitInfo.GetElementDescription().Key,
+				Instance: v.Id.Instance,
+				Value:    v.Value,
+			})
+		}
+
+		result = append(result, EntityMetric{
+			Entity:     s.Entity,
+			SampleInfo: s.SampleInfo,
+			Value:      values,
+		})
+	}
+
+	return result, nil
+}

--- a/vendor/github.com/vmware/govmomi/ssoadmin/client.go
+++ b/vendor/github.com/vmware/govmomi/ssoadmin/client.go
@@ -1,0 +1,425 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ssoadmin
+
+import (
+	"context"
+	"path"
+	"reflect"
+	"strings"
+
+	"github.com/vmware/govmomi/lookup"
+	ltypes "github.com/vmware/govmomi/lookup/types"
+	"github.com/vmware/govmomi/ssoadmin/methods"
+	"github.com/vmware/govmomi/ssoadmin/types"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+	vim "github.com/vmware/govmomi/vim25/types"
+)
+
+const (
+	Namespace = "sso"
+	Version   = "version2"
+	Path      = "/sso-adminserver" + vim25.Path
+)
+
+var (
+	ServiceInstance = vim.ManagedObjectReference{
+		Type:  "SsoAdminServiceInstance",
+		Value: "SsoAdminServiceInstance",
+	}
+)
+
+type Client struct {
+	*soap.Client
+
+	ServiceContent types.AdminServiceContent
+	GroupCheck     types.GroupcheckServiceContent
+	Domain         string
+	Limit          int32
+}
+
+func init() {
+	// Fault types are not in the ssoadmin.wsdl
+	vim.Add("SsoFaultNotAuthenticated", reflect.TypeOf((*vim.NotAuthenticated)(nil)).Elem())
+	vim.Add("SsoFaultNoPermission", reflect.TypeOf((*vim.NoPermission)(nil)).Elem())
+	vim.Add("SsoFaultInvalidCredentials", reflect.TypeOf((*vim.InvalidLogin)(nil)).Elem())
+	vim.Add("SsoAdminFaultDuplicateSolutionCertificateFaultFault", reflect.TypeOf((*vim.InvalidArgument)(nil)).Elem())
+}
+
+func NewClient(ctx context.Context, c *vim25.Client) (*Client, error) {
+	filter := &ltypes.LookupServiceRegistrationFilter{
+		ServiceType: &ltypes.LookupServiceRegistrationServiceType{
+			Product: "com.vmware.cis",
+			Type:    "cs.identity",
+		},
+		EndpointType: &ltypes.LookupServiceRegistrationEndpointType{
+			Protocol: "vmomi",
+			Type:     "com.vmware.cis.cs.identity.admin",
+		},
+	}
+
+	url := lookup.EndpointURL(ctx, c, Path, filter)
+	sc := c.Client.NewServiceClient(url, Namespace)
+	sc.Version = Version
+
+	admin := &Client{
+		Client: sc,
+		Domain: "vsphere.local", // Default
+		Limit:  100,
+	}
+	if url != Path {
+		admin.Domain = path.Base(url)
+	}
+
+	{
+		req := types.SsoAdminServiceInstance{
+			This: ServiceInstance,
+		}
+
+		res, err := methods.SsoAdminServiceInstance(ctx, sc, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		admin.ServiceContent = res.Returnval
+	}
+
+	{
+		req := types.SsoGroupcheckServiceInstance{
+			This: vim.ManagedObjectReference{
+				Type: "SsoGroupcheckServiceInstance", Value: "ServiceInstance",
+			},
+		}
+
+		res, err := methods.SsoGroupcheckServiceInstance(ctx, sc, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		admin.GroupCheck = res.Returnval
+	}
+
+	return admin, nil
+}
+
+func (c *Client) parseID(name string) types.PrincipalId {
+	p := strings.SplitN(name, "@", 2)
+	id := types.PrincipalId{Name: p[0]}
+	if len(p) == 2 {
+		id.Domain = p[1]
+	} else {
+		id.Domain = c.Domain
+	}
+	return id
+}
+
+func (c *Client) CreateSolutionUser(ctx context.Context, name string, details types.AdminSolutionDetails) error {
+	req := types.CreateLocalSolutionUser{
+		This:        c.ServiceContent.PrincipalManagementService,
+		UserName:    name,
+		UserDetails: details,
+	}
+
+	_, err := methods.CreateLocalSolutionUser(ctx, c, &req)
+	return err
+}
+
+func (c *Client) UpdateSolutionUser(ctx context.Context, name string, details types.AdminSolutionDetails) error {
+	req := types.UpdateLocalSolutionUserDetails{
+		This:        c.ServiceContent.PrincipalManagementService,
+		UserName:    name,
+		UserDetails: details,
+	}
+
+	_, err := methods.UpdateLocalSolutionUserDetails(ctx, c, &req)
+	return err
+}
+
+func (c *Client) DeletePrincipal(ctx context.Context, name string) error {
+	req := types.DeleteLocalPrincipal{
+		This:          c.ServiceContent.PrincipalManagementService,
+		PrincipalName: name,
+	}
+
+	_, err := methods.DeleteLocalPrincipal(ctx, c, &req)
+	return err
+}
+
+func (c *Client) AddUsersToGroup(ctx context.Context, groupName string, userIDs ...types.PrincipalId) error {
+	req := types.AddUsersToLocalGroup{
+		This:      c.ServiceContent.PrincipalManagementService,
+		GroupName: groupName,
+		UserIds:   userIDs,
+	}
+
+	_, err := methods.AddUsersToLocalGroup(ctx, c, &req)
+	return err
+}
+
+func (c *Client) RemoveUsersFromGroup(ctx context.Context, groupName string, userIDs ...types.PrincipalId) error {
+	req := types.RemovePrincipalsFromLocalGroup{
+		This:          c.ServiceContent.PrincipalManagementService,
+		GroupName:     groupName,
+		PrincipalsIds: userIDs,
+	}
+
+	_, err := methods.RemovePrincipalsFromLocalGroup(ctx, c, &req)
+	return err
+}
+
+func (c *Client) CreateGroup(ctx context.Context, name string, details types.AdminGroupDetails) error {
+	req := types.CreateLocalGroup{
+		This:         c.ServiceContent.PrincipalManagementService,
+		GroupName:    name,
+		GroupDetails: details,
+	}
+
+	_, err := methods.CreateLocalGroup(ctx, c, &req)
+	return err
+}
+
+func (c *Client) UpdateGroup(ctx context.Context, name string, details types.AdminGroupDetails) error {
+	req := types.UpdateLocalGroupDetails{
+		This:         c.ServiceContent.PrincipalManagementService,
+		GroupName:    name,
+		GroupDetails: details,
+	}
+
+	_, err := methods.UpdateLocalGroupDetails(ctx, c, &req)
+	return err
+}
+
+func (c *Client) CreatePersonUser(ctx context.Context, name string, details types.AdminPersonDetails, password string) error {
+	req := types.CreateLocalPersonUser{
+		This:        c.ServiceContent.PrincipalManagementService,
+		UserName:    name,
+		UserDetails: details,
+		Password:    password,
+	}
+
+	_, err := methods.CreateLocalPersonUser(ctx, c, &req)
+	return err
+}
+
+func (c *Client) UpdatePersonUser(ctx context.Context, name string, details types.AdminPersonDetails) error {
+	req := types.UpdateLocalPersonUserDetails{
+		This:        c.ServiceContent.PrincipalManagementService,
+		UserName:    name,
+		UserDetails: details,
+	}
+
+	_, err := methods.UpdateLocalPersonUserDetails(ctx, c, &req)
+	return err
+}
+
+func (c *Client) ResetPersonPassword(ctx context.Context, name string, password string) error {
+	req := types.ResetLocalPersonUserPassword{
+		This:        c.ServiceContent.PrincipalManagementService,
+		UserName:    name,
+		NewPassword: password,
+	}
+
+	_, err := methods.ResetLocalPersonUserPassword(ctx, c, &req)
+	return err
+}
+
+func (c *Client) FindSolutionUser(ctx context.Context, name string) (*types.AdminSolutionUser, error) {
+	req := types.FindSolutionUser{
+		This:     c.ServiceContent.PrincipalDiscoveryService,
+		UserName: name,
+	}
+
+	res, err := methods.FindSolutionUser(ctx, c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (c *Client) FindPersonUser(ctx context.Context, name string) (*types.AdminPersonUser, error) {
+	req := types.FindPersonUser{
+		This:   c.ServiceContent.PrincipalDiscoveryService,
+		UserId: c.parseID(name),
+	}
+
+	res, err := methods.FindPersonUser(ctx, c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (c *Client) FindUser(ctx context.Context, name string) (*types.AdminUser, error) {
+	req := types.FindUser{
+		This:   c.ServiceContent.PrincipalDiscoveryService,
+		UserId: c.parseID(name),
+	}
+
+	res, err := methods.FindUser(ctx, c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (c *Client) FindSolutionUsers(ctx context.Context, search string) ([]types.AdminSolutionUser, error) {
+	req := types.FindSolutionUsers{
+		This:         c.ServiceContent.PrincipalDiscoveryService,
+		SearchString: search,
+		Limit:        c.Limit,
+	}
+
+	res, err := methods.FindSolutionUsers(ctx, c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (c *Client) FindPersonUsers(ctx context.Context, search string) ([]types.AdminPersonUser, error) {
+	req := types.FindPersonUsers{
+		This: c.ServiceContent.PrincipalDiscoveryService,
+		Criteria: types.AdminPrincipalDiscoveryServiceSearchCriteria{
+			Domain:       c.Domain,
+			SearchString: search,
+		},
+		Limit: c.Limit,
+	}
+
+	res, err := methods.FindPersonUsers(ctx, c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (c *Client) FindGroup(ctx context.Context, name string) (*types.AdminGroup, error) {
+	req := types.FindGroup{
+		This:    c.ServiceContent.PrincipalDiscoveryService,
+		GroupId: c.parseID(name),
+	}
+
+	res, err := methods.FindGroup(ctx, c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (c *Client) FindGroups(ctx context.Context, search string) ([]types.AdminGroup, error) {
+	req := types.FindGroups{
+		This: c.ServiceContent.PrincipalDiscoveryService,
+		Criteria: types.AdminPrincipalDiscoveryServiceSearchCriteria{
+			Domain:       c.Domain,
+			SearchString: search,
+		},
+		Limit: c.Limit,
+	}
+
+	res, err := methods.FindGroups(ctx, c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (c *Client) FindParentGroups(ctx context.Context, id types.PrincipalId, groups ...types.PrincipalId) ([]types.PrincipalId, error) {
+	if len(groups) == 0 {
+		req := types.FindAllParentGroups{
+			This:   c.GroupCheck.GroupCheckService,
+			UserId: id,
+		}
+		res, err := methods.FindAllParentGroups(ctx, c, &req)
+		if err != nil {
+			return nil, err
+		}
+		return res.Returnval, nil
+	}
+
+	return nil, nil
+}
+
+func (c *Client) Login(ctx context.Context) error {
+	req := types.Login{
+		This: c.ServiceContent.SessionManager,
+	}
+
+	_, err := methods.Login(ctx, c, &req)
+	return err
+}
+
+func (c *Client) Logout(ctx context.Context) error {
+	req := types.Logout{
+		This: c.ServiceContent.SessionManager,
+	}
+
+	_, err := methods.Logout(ctx, c, &req)
+	return err
+}
+
+func (c *Client) SetRole(ctx context.Context, id types.PrincipalId, role string) (bool, error) {
+	req := types.SetRole{
+		This:   c.ServiceContent.RoleManagementService,
+		UserId: id,
+		Role:   role,
+	}
+
+	res, err := methods.SetRole(ctx, c, &req)
+	if err != nil {
+		return false, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (c *Client) GrantWSTrustRole(ctx context.Context, id types.PrincipalId, role string) (bool, error) {
+	req := types.GrantWSTrustRole{
+		This:   c.ServiceContent.RoleManagementService,
+		UserId: id,
+		Role:   role,
+	}
+
+	res, err := methods.GrantWSTrustRole(ctx, c, &req)
+	if err != nil {
+		return false, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (c *Client) RevokeWSTrustRole(ctx context.Context, id types.PrincipalId, role string) (bool, error) {
+	req := types.RevokeWSTrustRole{
+		This:   c.ServiceContent.RoleManagementService,
+		UserId: id,
+		Role:   role,
+	}
+
+	res, err := methods.RevokeWSTrustRole(ctx, c, &req)
+	if err != nil {
+		return false, err
+	}
+
+	return res.Returnval, nil
+}

--- a/vendor/github.com/vmware/govmomi/ssoadmin/methods/methods.go
+++ b/vendor/github.com/vmware/govmomi/ssoadmin/methods/methods.go
@@ -1,0 +1,1744 @@
+/*
+Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package methods
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/ssoadmin/types"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+type AddCertificateBody struct {
+	Req    *types.AddCertificate         `xml:"urn:sso AddCertificate,omitempty"`
+	Res    *types.AddCertificateResponse `xml:"urn:sso AddCertificateResponse,omitempty"`
+	Fault_ *soap.Fault                   `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *AddCertificateBody) Fault() *soap.Fault { return b.Fault_ }
+
+func AddCertificate(ctx context.Context, r soap.RoundTripper, req *types.AddCertificate) (*types.AddCertificateResponse, error) {
+	var reqBody, resBody AddCertificateBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type AddExternalDomainBody struct {
+	Req    *types.AddExternalDomain         `xml:"urn:sso AddExternalDomain,omitempty"`
+	Res    *types.AddExternalDomainResponse `xml:"urn:sso AddExternalDomainResponse,omitempty"`
+	Fault_ *soap.Fault                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *AddExternalDomainBody) Fault() *soap.Fault { return b.Fault_ }
+
+func AddExternalDomain(ctx context.Context, r soap.RoundTripper, req *types.AddExternalDomain) (*types.AddExternalDomainResponse, error) {
+	var reqBody, resBody AddExternalDomainBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type AddGroupToLocalGroupBody struct {
+	Req    *types.AddGroupToLocalGroup         `xml:"urn:sso AddGroupToLocalGroup,omitempty"`
+	Res    *types.AddGroupToLocalGroupResponse `xml:"urn:sso AddGroupToLocalGroupResponse,omitempty"`
+	Fault_ *soap.Fault                         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *AddGroupToLocalGroupBody) Fault() *soap.Fault { return b.Fault_ }
+
+func AddGroupToLocalGroup(ctx context.Context, r soap.RoundTripper, req *types.AddGroupToLocalGroup) (*types.AddGroupToLocalGroupResponse, error) {
+	var reqBody, resBody AddGroupToLocalGroupBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type AddGroupsToLocalGroupBody struct {
+	Req    *types.AddGroupsToLocalGroup         `xml:"urn:sso AddGroupsToLocalGroup,omitempty"`
+	Res    *types.AddGroupsToLocalGroupResponse `xml:"urn:sso AddGroupsToLocalGroupResponse,omitempty"`
+	Fault_ *soap.Fault                          `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *AddGroupsToLocalGroupBody) Fault() *soap.Fault { return b.Fault_ }
+
+func AddGroupsToLocalGroup(ctx context.Context, r soap.RoundTripper, req *types.AddGroupsToLocalGroup) (*types.AddGroupsToLocalGroupResponse, error) {
+	var reqBody, resBody AddGroupsToLocalGroupBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type AddUserToLocalGroupBody struct {
+	Req    *types.AddUserToLocalGroup         `xml:"urn:sso AddUserToLocalGroup,omitempty"`
+	Res    *types.AddUserToLocalGroupResponse `xml:"urn:sso AddUserToLocalGroupResponse,omitempty"`
+	Fault_ *soap.Fault                        `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *AddUserToLocalGroupBody) Fault() *soap.Fault { return b.Fault_ }
+
+func AddUserToLocalGroup(ctx context.Context, r soap.RoundTripper, req *types.AddUserToLocalGroup) (*types.AddUserToLocalGroupResponse, error) {
+	var reqBody, resBody AddUserToLocalGroupBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type AddUsersToLocalGroupBody struct {
+	Req    *types.AddUsersToLocalGroup         `xml:"urn:sso AddUsersToLocalGroup,omitempty"`
+	Res    *types.AddUsersToLocalGroupResponse `xml:"urn:sso AddUsersToLocalGroupResponse,omitempty"`
+	Fault_ *soap.Fault                         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *AddUsersToLocalGroupBody) Fault() *soap.Fault { return b.Fault_ }
+
+func AddUsersToLocalGroup(ctx context.Context, r soap.RoundTripper, req *types.AddUsersToLocalGroup) (*types.AddUsersToLocalGroupResponse, error) {
+	var reqBody, resBody AddUsersToLocalGroupBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type CreateLocalGroupBody struct {
+	Req    *types.CreateLocalGroup         `xml:"urn:sso CreateLocalGroup,omitempty"`
+	Res    *types.CreateLocalGroupResponse `xml:"urn:sso CreateLocalGroupResponse,omitempty"`
+	Fault_ *soap.Fault                     `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CreateLocalGroupBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CreateLocalGroup(ctx context.Context, r soap.RoundTripper, req *types.CreateLocalGroup) (*types.CreateLocalGroupResponse, error) {
+	var reqBody, resBody CreateLocalGroupBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type CreateLocalPersonUserBody struct {
+	Req    *types.CreateLocalPersonUser         `xml:"urn:sso CreateLocalPersonUser,omitempty"`
+	Res    *types.CreateLocalPersonUserResponse `xml:"urn:sso CreateLocalPersonUserResponse,omitempty"`
+	Fault_ *soap.Fault                          `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CreateLocalPersonUserBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CreateLocalPersonUser(ctx context.Context, r soap.RoundTripper, req *types.CreateLocalPersonUser) (*types.CreateLocalPersonUserResponse, error) {
+	var reqBody, resBody CreateLocalPersonUserBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type CreateLocalSolutionUserBody struct {
+	Req    *types.CreateLocalSolutionUser         `xml:"urn:sso CreateLocalSolutionUser,omitempty"`
+	Res    *types.CreateLocalSolutionUserResponse `xml:"urn:sso CreateLocalSolutionUserResponse,omitempty"`
+	Fault_ *soap.Fault                            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CreateLocalSolutionUserBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CreateLocalSolutionUser(ctx context.Context, r soap.RoundTripper, req *types.CreateLocalSolutionUser) (*types.CreateLocalSolutionUserResponse, error) {
+	var reqBody, resBody CreateLocalSolutionUserBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type DeleteCertificateBody struct {
+	Req    *types.DeleteCertificate         `xml:"urn:sso DeleteCertificate,omitempty"`
+	Res    *types.DeleteCertificateResponse `xml:"urn:sso DeleteCertificateResponse,omitempty"`
+	Fault_ *soap.Fault                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *DeleteCertificateBody) Fault() *soap.Fault { return b.Fault_ }
+
+func DeleteCertificate(ctx context.Context, r soap.RoundTripper, req *types.DeleteCertificate) (*types.DeleteCertificateResponse, error) {
+	var reqBody, resBody DeleteCertificateBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type DeleteDomainBody struct {
+	Req    *types.DeleteDomain         `xml:"urn:sso DeleteDomain,omitempty"`
+	Res    *types.DeleteDomainResponse `xml:"urn:sso DeleteDomainResponse,omitempty"`
+	Fault_ *soap.Fault                 `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *DeleteDomainBody) Fault() *soap.Fault { return b.Fault_ }
+
+func DeleteDomain(ctx context.Context, r soap.RoundTripper, req *types.DeleteDomain) (*types.DeleteDomainResponse, error) {
+	var reqBody, resBody DeleteDomainBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type DeleteLocalPrincipalBody struct {
+	Req    *types.DeleteLocalPrincipal         `xml:"urn:sso DeleteLocalPrincipal,omitempty"`
+	Res    *types.DeleteLocalPrincipalResponse `xml:"urn:sso DeleteLocalPrincipalResponse,omitempty"`
+	Fault_ *soap.Fault                         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *DeleteLocalPrincipalBody) Fault() *soap.Fault { return b.Fault_ }
+
+func DeleteLocalPrincipal(ctx context.Context, r soap.RoundTripper, req *types.DeleteLocalPrincipal) (*types.DeleteLocalPrincipalResponse, error) {
+	var reqBody, resBody DeleteLocalPrincipalBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type DisableUserAccountBody struct {
+	Req    *types.DisableUserAccount         `xml:"urn:sso DisableUserAccount,omitempty"`
+	Res    *types.DisableUserAccountResponse `xml:"urn:sso DisableUserAccountResponse,omitempty"`
+	Fault_ *soap.Fault                       `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *DisableUserAccountBody) Fault() *soap.Fault { return b.Fault_ }
+
+func DisableUserAccount(ctx context.Context, r soap.RoundTripper, req *types.DisableUserAccount) (*types.DisableUserAccountResponse, error) {
+	var reqBody, resBody DisableUserAccountBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type EnableUserAccountBody struct {
+	Req    *types.EnableUserAccount         `xml:"urn:sso EnableUserAccount,omitempty"`
+	Res    *types.EnableUserAccountResponse `xml:"urn:sso EnableUserAccountResponse,omitempty"`
+	Fault_ *soap.Fault                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *EnableUserAccountBody) Fault() *soap.Fault { return b.Fault_ }
+
+func EnableUserAccount(ctx context.Context, r soap.RoundTripper, req *types.EnableUserAccount) (*types.EnableUserAccountResponse, error) {
+	var reqBody, resBody EnableUserAccountBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type FindBody struct {
+	Req    *types.Find         `xml:"urn:sso Find,omitempty"`
+	Res    *types.FindResponse `xml:"urn:sso FindResponse,omitempty"`
+	Fault_ *soap.Fault         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FindBody) Fault() *soap.Fault { return b.Fault_ }
+
+func Find(ctx context.Context, r soap.RoundTripper, req *types.Find) (*types.FindResponse, error) {
+	var reqBody, resBody FindBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type FindAllParentGroupsBody struct {
+	Req    *types.FindAllParentGroups         `xml:"urn:sso FindAllParentGroups,omitempty"`
+	Res    *types.FindAllParentGroupsResponse `xml:"urn:sso FindAllParentGroupsResponse,omitempty"`
+	Fault_ *soap.Fault                        `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FindAllParentGroupsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func FindAllParentGroups(ctx context.Context, r soap.RoundTripper, req *types.FindAllParentGroups) (*types.FindAllParentGroupsResponse, error) {
+	var reqBody, resBody FindAllParentGroupsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type FindCertificateBody struct {
+	Req    *types.FindCertificate         `xml:"urn:sso FindCertificate,omitempty"`
+	Res    *types.FindCertificateResponse `xml:"urn:sso FindCertificateResponse,omitempty"`
+	Fault_ *soap.Fault                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FindCertificateBody) Fault() *soap.Fault { return b.Fault_ }
+
+func FindCertificate(ctx context.Context, r soap.RoundTripper, req *types.FindCertificate) (*types.FindCertificateResponse, error) {
+	var reqBody, resBody FindCertificateBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type FindDirectParentGroupsBody struct {
+	Req    *types.FindDirectParentGroups         `xml:"urn:sso FindDirectParentGroups,omitempty"`
+	Res    *types.FindDirectParentGroupsResponse `xml:"urn:sso FindDirectParentGroupsResponse,omitempty"`
+	Fault_ *soap.Fault                           `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FindDirectParentGroupsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func FindDirectParentGroups(ctx context.Context, r soap.RoundTripper, req *types.FindDirectParentGroups) (*types.FindDirectParentGroupsResponse, error) {
+	var reqBody, resBody FindDirectParentGroupsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type FindDisabledPersonUsersBody struct {
+	Req    *types.FindDisabledPersonUsers         `xml:"urn:sso FindDisabledPersonUsers,omitempty"`
+	Res    *types.FindDisabledPersonUsersResponse `xml:"urn:sso FindDisabledPersonUsersResponse,omitempty"`
+	Fault_ *soap.Fault                            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FindDisabledPersonUsersBody) Fault() *soap.Fault { return b.Fault_ }
+
+func FindDisabledPersonUsers(ctx context.Context, r soap.RoundTripper, req *types.FindDisabledPersonUsers) (*types.FindDisabledPersonUsersResponse, error) {
+	var reqBody, resBody FindDisabledPersonUsersBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type FindDisabledSolutionUsersBody struct {
+	Req    *types.FindDisabledSolutionUsers         `xml:"urn:sso FindDisabledSolutionUsers,omitempty"`
+	Res    *types.FindDisabledSolutionUsersResponse `xml:"urn:sso FindDisabledSolutionUsersResponse,omitempty"`
+	Fault_ *soap.Fault                              `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FindDisabledSolutionUsersBody) Fault() *soap.Fault { return b.Fault_ }
+
+func FindDisabledSolutionUsers(ctx context.Context, r soap.RoundTripper, req *types.FindDisabledSolutionUsers) (*types.FindDisabledSolutionUsersResponse, error) {
+	var reqBody, resBody FindDisabledSolutionUsersBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type FindExternalDomainBody struct {
+	Req    *types.FindExternalDomain         `xml:"urn:sso FindExternalDomain,omitempty"`
+	Res    *types.FindExternalDomainResponse `xml:"urn:sso FindExternalDomainResponse,omitempty"`
+	Fault_ *soap.Fault                       `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FindExternalDomainBody) Fault() *soap.Fault { return b.Fault_ }
+
+func FindExternalDomain(ctx context.Context, r soap.RoundTripper, req *types.FindExternalDomain) (*types.FindExternalDomainResponse, error) {
+	var reqBody, resBody FindExternalDomainBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type FindGroupBody struct {
+	Req    *types.FindGroup         `xml:"urn:sso FindGroup,omitempty"`
+	Res    *types.FindGroupResponse `xml:"urn:sso FindGroupResponse,omitempty"`
+	Fault_ *soap.Fault              `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FindGroupBody) Fault() *soap.Fault { return b.Fault_ }
+
+func FindGroup(ctx context.Context, r soap.RoundTripper, req *types.FindGroup) (*types.FindGroupResponse, error) {
+	var reqBody, resBody FindGroupBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type FindGroupsBody struct {
+	Req    *types.FindGroups         `xml:"urn:sso FindGroups,omitempty"`
+	Res    *types.FindGroupsResponse `xml:"urn:sso FindGroupsResponse,omitempty"`
+	Fault_ *soap.Fault               `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FindGroupsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func FindGroups(ctx context.Context, r soap.RoundTripper, req *types.FindGroups) (*types.FindGroupsResponse, error) {
+	var reqBody, resBody FindGroupsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type FindGroupsInGroupBody struct {
+	Req    *types.FindGroupsInGroup         `xml:"urn:sso FindGroupsInGroup,omitempty"`
+	Res    *types.FindGroupsInGroupResponse `xml:"urn:sso FindGroupsInGroupResponse,omitempty"`
+	Fault_ *soap.Fault                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FindGroupsInGroupBody) Fault() *soap.Fault { return b.Fault_ }
+
+func FindGroupsInGroup(ctx context.Context, r soap.RoundTripper, req *types.FindGroupsInGroup) (*types.FindGroupsInGroupResponse, error) {
+	var reqBody, resBody FindGroupsInGroupBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type FindLockedUsersBody struct {
+	Req    *types.FindLockedUsers         `xml:"urn:sso FindLockedUsers,omitempty"`
+	Res    *types.FindLockedUsersResponse `xml:"urn:sso FindLockedUsersResponse,omitempty"`
+	Fault_ *soap.Fault                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FindLockedUsersBody) Fault() *soap.Fault { return b.Fault_ }
+
+func FindLockedUsers(ctx context.Context, r soap.RoundTripper, req *types.FindLockedUsers) (*types.FindLockedUsersResponse, error) {
+	var reqBody, resBody FindLockedUsersBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type FindNestedParentGroupsBody struct {
+	Req    *types.FindNestedParentGroups         `xml:"urn:sso FindNestedParentGroups,omitempty"`
+	Res    *types.FindNestedParentGroupsResponse `xml:"urn:sso FindNestedParentGroupsResponse,omitempty"`
+	Fault_ *soap.Fault                           `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FindNestedParentGroupsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func FindNestedParentGroups(ctx context.Context, r soap.RoundTripper, req *types.FindNestedParentGroups) (*types.FindNestedParentGroupsResponse, error) {
+	var reqBody, resBody FindNestedParentGroupsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type FindParentGroupsBody struct {
+	Req    *types.FindParentGroups         `xml:"urn:sso FindParentGroups,omitempty"`
+	Res    *types.FindParentGroupsResponse `xml:"urn:sso FindParentGroupsResponse,omitempty"`
+	Fault_ *soap.Fault                     `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FindParentGroupsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func FindParentGroups(ctx context.Context, r soap.RoundTripper, req *types.FindParentGroups) (*types.FindParentGroupsResponse, error) {
+	var reqBody, resBody FindParentGroupsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type FindPersonUserBody struct {
+	Req    *types.FindPersonUser         `xml:"urn:sso FindPersonUser,omitempty"`
+	Res    *types.FindPersonUserResponse `xml:"urn:sso FindPersonUserResponse,omitempty"`
+	Fault_ *soap.Fault                   `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FindPersonUserBody) Fault() *soap.Fault { return b.Fault_ }
+
+func FindPersonUser(ctx context.Context, r soap.RoundTripper, req *types.FindPersonUser) (*types.FindPersonUserResponse, error) {
+	var reqBody, resBody FindPersonUserBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type FindPersonUsersBody struct {
+	Req    *types.FindPersonUsers         `xml:"urn:sso FindPersonUsers,omitempty"`
+	Res    *types.FindPersonUsersResponse `xml:"urn:sso FindPersonUsersResponse,omitempty"`
+	Fault_ *soap.Fault                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FindPersonUsersBody) Fault() *soap.Fault { return b.Fault_ }
+
+func FindPersonUsers(ctx context.Context, r soap.RoundTripper, req *types.FindPersonUsers) (*types.FindPersonUsersResponse, error) {
+	var reqBody, resBody FindPersonUsersBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type FindPersonUsersInGroupBody struct {
+	Req    *types.FindPersonUsersInGroup         `xml:"urn:sso FindPersonUsersInGroup,omitempty"`
+	Res    *types.FindPersonUsersInGroupResponse `xml:"urn:sso FindPersonUsersInGroupResponse,omitempty"`
+	Fault_ *soap.Fault                           `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FindPersonUsersInGroupBody) Fault() *soap.Fault { return b.Fault_ }
+
+func FindPersonUsersInGroup(ctx context.Context, r soap.RoundTripper, req *types.FindPersonUsersInGroup) (*types.FindPersonUsersInGroupResponse, error) {
+	var reqBody, resBody FindPersonUsersInGroupBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type FindSolutionUserBody struct {
+	Req    *types.FindSolutionUser         `xml:"urn:sso FindSolutionUser,omitempty"`
+	Res    *types.FindSolutionUserResponse `xml:"urn:sso FindSolutionUserResponse,omitempty"`
+	Fault_ *soap.Fault                     `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FindSolutionUserBody) Fault() *soap.Fault { return b.Fault_ }
+
+func FindSolutionUser(ctx context.Context, r soap.RoundTripper, req *types.FindSolutionUser) (*types.FindSolutionUserResponse, error) {
+	var reqBody, resBody FindSolutionUserBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type FindSolutionUsersBody struct {
+	Req    *types.FindSolutionUsers         `xml:"urn:sso FindSolutionUsers,omitempty"`
+	Res    *types.FindSolutionUsersResponse `xml:"urn:sso FindSolutionUsersResponse,omitempty"`
+	Fault_ *soap.Fault                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FindSolutionUsersBody) Fault() *soap.Fault { return b.Fault_ }
+
+func FindSolutionUsers(ctx context.Context, r soap.RoundTripper, req *types.FindSolutionUsers) (*types.FindSolutionUsersResponse, error) {
+	var reqBody, resBody FindSolutionUsersBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type FindSolutionUsersInGroupBody struct {
+	Req    *types.FindSolutionUsersInGroup         `xml:"urn:sso FindSolutionUsersInGroup,omitempty"`
+	Res    *types.FindSolutionUsersInGroupResponse `xml:"urn:sso FindSolutionUsersInGroupResponse,omitempty"`
+	Fault_ *soap.Fault                             `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FindSolutionUsersInGroupBody) Fault() *soap.Fault { return b.Fault_ }
+
+func FindSolutionUsersInGroup(ctx context.Context, r soap.RoundTripper, req *types.FindSolutionUsersInGroup) (*types.FindSolutionUsersInGroupResponse, error) {
+	var reqBody, resBody FindSolutionUsersInGroupBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type FindUserBody struct {
+	Req    *types.FindUser         `xml:"urn:sso FindUser,omitempty"`
+	Res    *types.FindUserResponse `xml:"urn:sso FindUserResponse,omitempty"`
+	Fault_ *soap.Fault             `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FindUserBody) Fault() *soap.Fault { return b.Fault_ }
+
+func FindUser(ctx context.Context, r soap.RoundTripper, req *types.FindUser) (*types.FindUserResponse, error) {
+	var reqBody, resBody FindUserBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type FindUsersBody struct {
+	Req    *types.FindUsers         `xml:"urn:sso FindUsers,omitempty"`
+	Res    *types.FindUsersResponse `xml:"urn:sso FindUsersResponse,omitempty"`
+	Fault_ *soap.Fault              `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FindUsersBody) Fault() *soap.Fault { return b.Fault_ }
+
+func FindUsers(ctx context.Context, r soap.RoundTripper, req *types.FindUsers) (*types.FindUsersResponse, error) {
+	var reqBody, resBody FindUsersBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type FindUsersInGroupBody struct {
+	Req    *types.FindUsersInGroup         `xml:"urn:sso FindUsersInGroup,omitempty"`
+	Res    *types.FindUsersInGroupResponse `xml:"urn:sso FindUsersInGroupResponse,omitempty"`
+	Fault_ *soap.Fault                     `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FindUsersInGroupBody) Fault() *soap.Fault { return b.Fault_ }
+
+func FindUsersInGroup(ctx context.Context, r soap.RoundTripper, req *types.FindUsersInGroup) (*types.FindUsersInGroupResponse, error) {
+	var reqBody, resBody FindUsersInGroupBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type GetAllCertificatesBody struct {
+	Req    *types.GetAllCertificates         `xml:"urn:sso GetAllCertificates,omitempty"`
+	Res    *types.GetAllCertificatesResponse `xml:"urn:sso GetAllCertificatesResponse,omitempty"`
+	Fault_ *soap.Fault                       `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GetAllCertificatesBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GetAllCertificates(ctx context.Context, r soap.RoundTripper, req *types.GetAllCertificates) (*types.GetAllCertificatesResponse, error) {
+	var reqBody, resBody GetAllCertificatesBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type GetClockToleranceBody struct {
+	Req    *types.GetClockTolerance         `xml:"urn:sso GetClockTolerance,omitempty"`
+	Res    *types.GetClockToleranceResponse `xml:"urn:sso GetClockToleranceResponse,omitempty"`
+	Fault_ *soap.Fault                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GetClockToleranceBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GetClockTolerance(ctx context.Context, r soap.RoundTripper, req *types.GetClockTolerance) (*types.GetClockToleranceResponse, error) {
+	var reqBody, resBody GetClockToleranceBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type GetDelegationCountBody struct {
+	Req    *types.GetDelegationCount         `xml:"urn:sso GetDelegationCount,omitempty"`
+	Res    *types.GetDelegationCountResponse `xml:"urn:sso GetDelegationCountResponse,omitempty"`
+	Fault_ *soap.Fault                       `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GetDelegationCountBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GetDelegationCount(ctx context.Context, r soap.RoundTripper, req *types.GetDelegationCount) (*types.GetDelegationCountResponse, error) {
+	var reqBody, resBody GetDelegationCountBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type GetDomainsBody struct {
+	Req    *types.GetDomains         `xml:"urn:sso GetDomains,omitempty"`
+	Res    *types.GetDomainsResponse `xml:"urn:sso GetDomainsResponse,omitempty"`
+	Fault_ *soap.Fault               `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GetDomainsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GetDomains(ctx context.Context, r soap.RoundTripper, req *types.GetDomains) (*types.GetDomainsResponse, error) {
+	var reqBody, resBody GetDomainsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type GetIssuersCertificatesBody struct {
+	Req    *types.GetIssuersCertificates         `xml:"urn:sso GetIssuersCertificates,omitempty"`
+	Res    *types.GetIssuersCertificatesResponse `xml:"urn:sso GetIssuersCertificatesResponse,omitempty"`
+	Fault_ *soap.Fault                           `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GetIssuersCertificatesBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GetIssuersCertificates(ctx context.Context, r soap.RoundTripper, req *types.GetIssuersCertificates) (*types.GetIssuersCertificatesResponse, error) {
+	var reqBody, resBody GetIssuersCertificatesBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type GetKnownCertificateChainsBody struct {
+	Req    *types.GetKnownCertificateChains         `xml:"urn:sso GetKnownCertificateChains,omitempty"`
+	Res    *types.GetKnownCertificateChainsResponse `xml:"urn:sso GetKnownCertificateChainsResponse,omitempty"`
+	Fault_ *soap.Fault                              `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GetKnownCertificateChainsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GetKnownCertificateChains(ctx context.Context, r soap.RoundTripper, req *types.GetKnownCertificateChains) (*types.GetKnownCertificateChainsResponse, error) {
+	var reqBody, resBody GetKnownCertificateChainsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type GetLocalPasswordPolicyBody struct {
+	Req    *types.GetLocalPasswordPolicy         `xml:"urn:sso GetLocalPasswordPolicy,omitempty"`
+	Res    *types.GetLocalPasswordPolicyResponse `xml:"urn:sso GetLocalPasswordPolicyResponse,omitempty"`
+	Fault_ *soap.Fault                           `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GetLocalPasswordPolicyBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GetLocalPasswordPolicy(ctx context.Context, r soap.RoundTripper, req *types.GetLocalPasswordPolicy) (*types.GetLocalPasswordPolicyResponse, error) {
+	var reqBody, resBody GetLocalPasswordPolicyBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type GetLockoutPolicyBody struct {
+	Req    *types.GetLockoutPolicy         `xml:"urn:sso GetLockoutPolicy,omitempty"`
+	Res    *types.GetLockoutPolicyResponse `xml:"urn:sso GetLockoutPolicyResponse,omitempty"`
+	Fault_ *soap.Fault                     `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GetLockoutPolicyBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GetLockoutPolicy(ctx context.Context, r soap.RoundTripper, req *types.GetLockoutPolicy) (*types.GetLockoutPolicyResponse, error) {
+	var reqBody, resBody GetLockoutPolicyBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type GetMaximumBearerTokenLifetimeBody struct {
+	Req    *types.GetMaximumBearerTokenLifetime         `xml:"urn:sso GetMaximumBearerTokenLifetime,omitempty"`
+	Res    *types.GetMaximumBearerTokenLifetimeResponse `xml:"urn:sso GetMaximumBearerTokenLifetimeResponse,omitempty"`
+	Fault_ *soap.Fault                                  `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GetMaximumBearerTokenLifetimeBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GetMaximumBearerTokenLifetime(ctx context.Context, r soap.RoundTripper, req *types.GetMaximumBearerTokenLifetime) (*types.GetMaximumBearerTokenLifetimeResponse, error) {
+	var reqBody, resBody GetMaximumBearerTokenLifetimeBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type GetMaximumHoKTokenLifetimeBody struct {
+	Req    *types.GetMaximumHoKTokenLifetime         `xml:"urn:sso GetMaximumHoKTokenLifetime,omitempty"`
+	Res    *types.GetMaximumHoKTokenLifetimeResponse `xml:"urn:sso GetMaximumHoKTokenLifetimeResponse,omitempty"`
+	Fault_ *soap.Fault                               `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GetMaximumHoKTokenLifetimeBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GetMaximumHoKTokenLifetime(ctx context.Context, r soap.RoundTripper, req *types.GetMaximumHoKTokenLifetime) (*types.GetMaximumHoKTokenLifetimeResponse, error) {
+	var reqBody, resBody GetMaximumHoKTokenLifetimeBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type GetPasswordExpirationConfigurationBody struct {
+	Req    *types.GetPasswordExpirationConfiguration         `xml:"urn:sso GetPasswordExpirationConfiguration,omitempty"`
+	Res    *types.GetPasswordExpirationConfigurationResponse `xml:"urn:sso GetPasswordExpirationConfigurationResponse,omitempty"`
+	Fault_ *soap.Fault                                       `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GetPasswordExpirationConfigurationBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GetPasswordExpirationConfiguration(ctx context.Context, r soap.RoundTripper, req *types.GetPasswordExpirationConfiguration) (*types.GetPasswordExpirationConfigurationResponse, error) {
+	var reqBody, resBody GetPasswordExpirationConfigurationBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type GetRenewCountBody struct {
+	Req    *types.GetRenewCount         `xml:"urn:sso GetRenewCount,omitempty"`
+	Res    *types.GetRenewCountResponse `xml:"urn:sso GetRenewCountResponse,omitempty"`
+	Fault_ *soap.Fault                  `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GetRenewCountBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GetRenewCount(ctx context.Context, r soap.RoundTripper, req *types.GetRenewCount) (*types.GetRenewCountResponse, error) {
+	var reqBody, resBody GetRenewCountBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type GetSmtpConfigurationBody struct {
+	Req    *types.GetSmtpConfiguration         `xml:"urn:sso GetSmtpConfiguration,omitempty"`
+	Res    *types.GetSmtpConfigurationResponse `xml:"urn:sso GetSmtpConfigurationResponse,omitempty"`
+	Fault_ *soap.Fault                         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GetSmtpConfigurationBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GetSmtpConfiguration(ctx context.Context, r soap.RoundTripper, req *types.GetSmtpConfiguration) (*types.GetSmtpConfigurationResponse, error) {
+	var reqBody, resBody GetSmtpConfigurationBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type GetSslCertificateManagerBody struct {
+	Req    *types.GetSslCertificateManager         `xml:"urn:sso GetSslCertificateManager,omitempty"`
+	Res    *types.GetSslCertificateManagerResponse `xml:"urn:sso GetSslCertificateManagerResponse,omitempty"`
+	Fault_ *soap.Fault                             `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GetSslCertificateManagerBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GetSslCertificateManager(ctx context.Context, r soap.RoundTripper, req *types.GetSslCertificateManager) (*types.GetSslCertificateManagerResponse, error) {
+	var reqBody, resBody GetSslCertificateManagerBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type GetSystemDomainNameBody struct {
+	Req    *types.GetSystemDomainName         `xml:"urn:sso GetSystemDomainName,omitempty"`
+	Res    *types.GetSystemDomainNameResponse `xml:"urn:sso GetSystemDomainNameResponse,omitempty"`
+	Fault_ *soap.Fault                        `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GetSystemDomainNameBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GetSystemDomainName(ctx context.Context, r soap.RoundTripper, req *types.GetSystemDomainName) (*types.GetSystemDomainNameResponse, error) {
+	var reqBody, resBody GetSystemDomainNameBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type GetTrustedCertificatesBody struct {
+	Req    *types.GetTrustedCertificates         `xml:"urn:sso GetTrustedCertificates,omitempty"`
+	Res    *types.GetTrustedCertificatesResponse `xml:"urn:sso GetTrustedCertificatesResponse,omitempty"`
+	Fault_ *soap.Fault                           `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GetTrustedCertificatesBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GetTrustedCertificates(ctx context.Context, r soap.RoundTripper, req *types.GetTrustedCertificates) (*types.GetTrustedCertificatesResponse, error) {
+	var reqBody, resBody GetTrustedCertificatesBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type HasAdministratorRoleBody struct {
+	Req    *types.HasAdministratorRole         `xml:"urn:sso HasAdministratorRole,omitempty"`
+	Res    *types.HasAdministratorRoleResponse `xml:"urn:sso HasAdministratorRoleResponse,omitempty"`
+	Fault_ *soap.Fault                         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *HasAdministratorRoleBody) Fault() *soap.Fault { return b.Fault_ }
+
+func HasAdministratorRole(ctx context.Context, r soap.RoundTripper, req *types.HasAdministratorRole) (*types.HasAdministratorRoleResponse, error) {
+	var reqBody, resBody HasAdministratorRoleBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type HasRegularUserRoleBody struct {
+	Req    *types.HasRegularUserRole         `xml:"urn:sso HasRegularUserRole,omitempty"`
+	Res    *types.HasRegularUserRoleResponse `xml:"urn:sso HasRegularUserRoleResponse,omitempty"`
+	Fault_ *soap.Fault                       `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *HasRegularUserRoleBody) Fault() *soap.Fault { return b.Fault_ }
+
+func HasRegularUserRole(ctx context.Context, r soap.RoundTripper, req *types.HasRegularUserRole) (*types.HasRegularUserRoleResponse, error) {
+	var reqBody, resBody HasRegularUserRoleBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type IsMemberOfGroupBody struct {
+	Req    *types.IsMemberOfGroup         `xml:"urn:sso IsMemberOfGroup,omitempty"`
+	Res    *types.IsMemberOfGroupResponse `xml:"urn:sso IsMemberOfGroupResponse,omitempty"`
+	Fault_ *soap.Fault                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *IsMemberOfGroupBody) Fault() *soap.Fault { return b.Fault_ }
+
+func IsMemberOfGroup(ctx context.Context, r soap.RoundTripper, req *types.IsMemberOfGroup) (*types.IsMemberOfGroupResponse, error) {
+	var reqBody, resBody IsMemberOfGroupBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type LoginBody struct {
+	Req    *types.Login         `xml:"urn:sso Login,omitempty"`
+	Res    *types.LoginResponse `xml:"urn:sso LoginResponse,omitempty"`
+	Fault_ *soap.Fault          `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *LoginBody) Fault() *soap.Fault { return b.Fault_ }
+
+func Login(ctx context.Context, r soap.RoundTripper, req *types.Login) (*types.LoginResponse, error) {
+	var reqBody, resBody LoginBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type LogoutBody struct {
+	Req    *types.Logout         `xml:"urn:sso Logout,omitempty"`
+	Res    *types.LogoutResponse `xml:"urn:sso LogoutResponse,omitempty"`
+	Fault_ *soap.Fault           `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *LogoutBody) Fault() *soap.Fault { return b.Fault_ }
+
+func Logout(ctx context.Context, r soap.RoundTripper, req *types.Logout) (*types.LogoutResponse, error) {
+	var reqBody, resBody LogoutBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type ProbeConnectivityBody struct {
+	Req    *types.ProbeConnectivity         `xml:"urn:sso ProbeConnectivity,omitempty"`
+	Res    *types.ProbeConnectivityResponse `xml:"urn:sso ProbeConnectivityResponse,omitempty"`
+	Fault_ *soap.Fault                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *ProbeConnectivityBody) Fault() *soap.Fault { return b.Fault_ }
+
+func ProbeConnectivity(ctx context.Context, r soap.RoundTripper, req *types.ProbeConnectivity) (*types.ProbeConnectivityResponse, error) {
+	var reqBody, resBody ProbeConnectivityBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RemoveFromLocalGroupBody struct {
+	Req    *types.RemoveFromLocalGroup         `xml:"urn:sso RemoveFromLocalGroup,omitempty"`
+	Res    *types.RemoveFromLocalGroupResponse `xml:"urn:sso RemoveFromLocalGroupResponse,omitempty"`
+	Fault_ *soap.Fault                         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RemoveFromLocalGroupBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RemoveFromLocalGroup(ctx context.Context, r soap.RoundTripper, req *types.RemoveFromLocalGroup) (*types.RemoveFromLocalGroupResponse, error) {
+	var reqBody, resBody RemoveFromLocalGroupBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RemovePrincipalsFromLocalGroupBody struct {
+	Req    *types.RemovePrincipalsFromLocalGroup         `xml:"urn:sso RemovePrincipalsFromLocalGroup,omitempty"`
+	Res    *types.RemovePrincipalsFromLocalGroupResponse `xml:"urn:sso RemovePrincipalsFromLocalGroupResponse,omitempty"`
+	Fault_ *soap.Fault                                   `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RemovePrincipalsFromLocalGroupBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RemovePrincipalsFromLocalGroup(ctx context.Context, r soap.RoundTripper, req *types.RemovePrincipalsFromLocalGroup) (*types.RemovePrincipalsFromLocalGroupResponse, error) {
+	var reqBody, resBody RemovePrincipalsFromLocalGroupBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type ResetLocalPersonUserPasswordBody struct {
+	Req    *types.ResetLocalPersonUserPassword         `xml:"urn:sso ResetLocalPersonUserPassword,omitempty"`
+	Res    *types.ResetLocalPersonUserPasswordResponse `xml:"urn:sso ResetLocalPersonUserPasswordResponse,omitempty"`
+	Fault_ *soap.Fault                                 `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *ResetLocalPersonUserPasswordBody) Fault() *soap.Fault { return b.Fault_ }
+
+func ResetLocalPersonUserPassword(ctx context.Context, r soap.RoundTripper, req *types.ResetLocalPersonUserPassword) (*types.ResetLocalPersonUserPasswordResponse, error) {
+	var reqBody, resBody ResetLocalPersonUserPasswordBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type ResetLocalUserPasswordBody struct {
+	Req    *types.ResetLocalUserPassword         `xml:"urn:sso ResetLocalUserPassword,omitempty"`
+	Res    *types.ResetLocalUserPasswordResponse `xml:"urn:sso ResetLocalUserPasswordResponse,omitempty"`
+	Fault_ *soap.Fault                           `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *ResetLocalUserPasswordBody) Fault() *soap.Fault { return b.Fault_ }
+
+func ResetLocalUserPassword(ctx context.Context, r soap.RoundTripper, req *types.ResetLocalUserPassword) (*types.ResetLocalUserPasswordResponse, error) {
+	var reqBody, resBody ResetLocalUserPasswordBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type ResetSelfLocalPersonUserPasswordBody struct {
+	Req    *types.ResetSelfLocalPersonUserPassword         `xml:"urn:sso ResetSelfLocalPersonUserPassword,omitempty"`
+	Res    *types.ResetSelfLocalPersonUserPasswordResponse `xml:"urn:sso ResetSelfLocalPersonUserPasswordResponse,omitempty"`
+	Fault_ *soap.Fault                                     `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *ResetSelfLocalPersonUserPasswordBody) Fault() *soap.Fault { return b.Fault_ }
+
+func ResetSelfLocalPersonUserPassword(ctx context.Context, r soap.RoundTripper, req *types.ResetSelfLocalPersonUserPassword) (*types.ResetSelfLocalPersonUserPasswordResponse, error) {
+	var reqBody, resBody ResetSelfLocalPersonUserPasswordBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type SendMailBody struct {
+	Req    *types.SendMail         `xml:"urn:sso SendMail,omitempty"`
+	Res    *types.SendMailResponse `xml:"urn:sso SendMailResponse,omitempty"`
+	Fault_ *soap.Fault             `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *SendMailBody) Fault() *soap.Fault { return b.Fault_ }
+
+func SendMail(ctx context.Context, r soap.RoundTripper, req *types.SendMail) (*types.SendMailResponse, error) {
+	var reqBody, resBody SendMailBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type SetClockToleranceBody struct {
+	Req    *types.SetClockTolerance         `xml:"urn:sso SetClockTolerance,omitempty"`
+	Res    *types.SetClockToleranceResponse `xml:"urn:sso SetClockToleranceResponse,omitempty"`
+	Fault_ *soap.Fault                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *SetClockToleranceBody) Fault() *soap.Fault { return b.Fault_ }
+
+func SetClockTolerance(ctx context.Context, r soap.RoundTripper, req *types.SetClockTolerance) (*types.SetClockToleranceResponse, error) {
+	var reqBody, resBody SetClockToleranceBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type SetDelegationCountBody struct {
+	Req    *types.SetDelegationCount         `xml:"urn:sso SetDelegationCount,omitempty"`
+	Res    *types.SetDelegationCountResponse `xml:"urn:sso SetDelegationCountResponse,omitempty"`
+	Fault_ *soap.Fault                       `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *SetDelegationCountBody) Fault() *soap.Fault { return b.Fault_ }
+
+func SetDelegationCount(ctx context.Context, r soap.RoundTripper, req *types.SetDelegationCount) (*types.SetDelegationCountResponse, error) {
+	var reqBody, resBody SetDelegationCountBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type SetMaximumBearerTokenLifetimeBody struct {
+	Req    *types.SetMaximumBearerTokenLifetime         `xml:"urn:sso SetMaximumBearerTokenLifetime,omitempty"`
+	Res    *types.SetMaximumBearerTokenLifetimeResponse `xml:"urn:sso SetMaximumBearerTokenLifetimeResponse,omitempty"`
+	Fault_ *soap.Fault                                  `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *SetMaximumBearerTokenLifetimeBody) Fault() *soap.Fault { return b.Fault_ }
+
+func SetMaximumBearerTokenLifetime(ctx context.Context, r soap.RoundTripper, req *types.SetMaximumBearerTokenLifetime) (*types.SetMaximumBearerTokenLifetimeResponse, error) {
+	var reqBody, resBody SetMaximumBearerTokenLifetimeBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type SetMaximumHoKTokenLifetimeBody struct {
+	Req    *types.SetMaximumHoKTokenLifetime         `xml:"urn:sso SetMaximumHoKTokenLifetime,omitempty"`
+	Res    *types.SetMaximumHoKTokenLifetimeResponse `xml:"urn:sso SetMaximumHoKTokenLifetimeResponse,omitempty"`
+	Fault_ *soap.Fault                               `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *SetMaximumHoKTokenLifetimeBody) Fault() *soap.Fault { return b.Fault_ }
+
+func SetMaximumHoKTokenLifetime(ctx context.Context, r soap.RoundTripper, req *types.SetMaximumHoKTokenLifetime) (*types.SetMaximumHoKTokenLifetimeResponse, error) {
+	var reqBody, resBody SetMaximumHoKTokenLifetimeBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type SetNewSignerIdentityBody struct {
+	Req    *types.SetNewSignerIdentity         `xml:"urn:sso SetNewSignerIdentity,omitempty"`
+	Res    *types.SetNewSignerIdentityResponse `xml:"urn:sso SetNewSignerIdentityResponse,omitempty"`
+	Fault_ *soap.Fault                         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *SetNewSignerIdentityBody) Fault() *soap.Fault { return b.Fault_ }
+
+func SetNewSignerIdentity(ctx context.Context, r soap.RoundTripper, req *types.SetNewSignerIdentity) (*types.SetNewSignerIdentityResponse, error) {
+	var reqBody, resBody SetNewSignerIdentityBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type SetRenewCountBody struct {
+	Req    *types.SetRenewCount         `xml:"urn:sso SetRenewCount,omitempty"`
+	Res    *types.SetRenewCountResponse `xml:"urn:sso SetRenewCountResponse,omitempty"`
+	Fault_ *soap.Fault                  `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *SetRenewCountBody) Fault() *soap.Fault { return b.Fault_ }
+
+func SetRenewCount(ctx context.Context, r soap.RoundTripper, req *types.SetRenewCount) (*types.SetRenewCountResponse, error) {
+	var reqBody, resBody SetRenewCountBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type SetRoleBody struct {
+	Req    *types.SetRole         `xml:"urn:sso SetRole,omitempty"`
+	Res    *types.SetRoleResponse `xml:"urn:sso SetRoleResponse,omitempty"`
+	Fault_ *soap.Fault            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *SetRoleBody) Fault() *soap.Fault { return b.Fault_ }
+
+func SetRole(ctx context.Context, r soap.RoundTripper, req *types.SetRole) (*types.SetRoleResponse, error) {
+	var reqBody, resBody SetRoleBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type SetSignerIdentityBody struct {
+	Req    *types.SetSignerIdentity         `xml:"urn:sso SetSignerIdentity,omitempty"`
+	Res    *types.SetSignerIdentityResponse `xml:"urn:sso SetSignerIdentityResponse,omitempty"`
+	Fault_ *soap.Fault                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *SetSignerIdentityBody) Fault() *soap.Fault { return b.Fault_ }
+
+func SetSignerIdentity(ctx context.Context, r soap.RoundTripper, req *types.SetSignerIdentity) (*types.SetSignerIdentityResponse, error) {
+	var reqBody, resBody SetSignerIdentityBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type SsoAdminServiceInstanceBody struct {
+	Req    *types.SsoAdminServiceInstance         `xml:"urn:sso SsoAdminServiceInstance,omitempty"`
+	Res    *types.SsoAdminServiceInstanceResponse `xml:"urn:sso SsoAdminServiceInstanceResponse,omitempty"`
+	Fault_ *soap.Fault                            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *SsoAdminServiceInstanceBody) Fault() *soap.Fault { return b.Fault_ }
+
+func SsoAdminServiceInstance(ctx context.Context, r soap.RoundTripper, req *types.SsoAdminServiceInstance) (*types.SsoAdminServiceInstanceResponse, error) {
+	var reqBody, resBody SsoAdminServiceInstanceBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type SsoGroupcheckServiceInstanceBody struct {
+	Req    *types.SsoGroupcheckServiceInstance         `xml:"urn:sso SsoGroupcheckServiceInstance,omitempty"`
+	Res    *types.SsoGroupcheckServiceInstanceResponse `xml:"urn:sso SsoGroupcheckServiceInstanceResponse,omitempty"`
+	Fault_ *soap.Fault                                 `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *SsoGroupcheckServiceInstanceBody) Fault() *soap.Fault { return b.Fault_ }
+
+func SsoGroupcheckServiceInstance(ctx context.Context, r soap.RoundTripper, req *types.SsoGroupcheckServiceInstance) (*types.SsoGroupcheckServiceInstanceResponse, error) {
+	var reqBody, resBody SsoGroupcheckServiceInstanceBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type UnlockUserAccountBody struct {
+	Req    *types.UnlockUserAccount         `xml:"urn:sso UnlockUserAccount,omitempty"`
+	Res    *types.UnlockUserAccountResponse `xml:"urn:sso UnlockUserAccountResponse,omitempty"`
+	Fault_ *soap.Fault                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UnlockUserAccountBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UnlockUserAccount(ctx context.Context, r soap.RoundTripper, req *types.UnlockUserAccount) (*types.UnlockUserAccountResponse, error) {
+	var reqBody, resBody UnlockUserAccountBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type UpdateExternalDomainAuthnTypeBody struct {
+	Req    *types.UpdateExternalDomainAuthnType         `xml:"urn:sso UpdateExternalDomainAuthnType,omitempty"`
+	Res    *types.UpdateExternalDomainAuthnTypeResponse `xml:"urn:sso UpdateExternalDomainAuthnTypeResponse,omitempty"`
+	Fault_ *soap.Fault                                  `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdateExternalDomainAuthnTypeBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdateExternalDomainAuthnType(ctx context.Context, r soap.RoundTripper, req *types.UpdateExternalDomainAuthnType) (*types.UpdateExternalDomainAuthnTypeResponse, error) {
+	var reqBody, resBody UpdateExternalDomainAuthnTypeBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type UpdateExternalDomainDetailsBody struct {
+	Req    *types.UpdateExternalDomainDetails         `xml:"urn:sso UpdateExternalDomainDetails,omitempty"`
+	Res    *types.UpdateExternalDomainDetailsResponse `xml:"urn:sso UpdateExternalDomainDetailsResponse,omitempty"`
+	Fault_ *soap.Fault                                `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdateExternalDomainDetailsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdateExternalDomainDetails(ctx context.Context, r soap.RoundTripper, req *types.UpdateExternalDomainDetails) (*types.UpdateExternalDomainDetailsResponse, error) {
+	var reqBody, resBody UpdateExternalDomainDetailsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type UpdateLocalGroupDetailsBody struct {
+	Req    *types.UpdateLocalGroupDetails         `xml:"urn:sso UpdateLocalGroupDetails,omitempty"`
+	Res    *types.UpdateLocalGroupDetailsResponse `xml:"urn:sso UpdateLocalGroupDetailsResponse,omitempty"`
+	Fault_ *soap.Fault                            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdateLocalGroupDetailsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdateLocalGroupDetails(ctx context.Context, r soap.RoundTripper, req *types.UpdateLocalGroupDetails) (*types.UpdateLocalGroupDetailsResponse, error) {
+	var reqBody, resBody UpdateLocalGroupDetailsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type UpdateLocalPasswordPolicyBody struct {
+	Req    *types.UpdateLocalPasswordPolicy         `xml:"urn:sso UpdateLocalPasswordPolicy,omitempty"`
+	Res    *types.UpdateLocalPasswordPolicyResponse `xml:"urn:sso UpdateLocalPasswordPolicyResponse,omitempty"`
+	Fault_ *soap.Fault                              `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdateLocalPasswordPolicyBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdateLocalPasswordPolicy(ctx context.Context, r soap.RoundTripper, req *types.UpdateLocalPasswordPolicy) (*types.UpdateLocalPasswordPolicyResponse, error) {
+	var reqBody, resBody UpdateLocalPasswordPolicyBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type UpdateLocalPersonUserDetailsBody struct {
+	Req    *types.UpdateLocalPersonUserDetails         `xml:"urn:sso UpdateLocalPersonUserDetails,omitempty"`
+	Res    *types.UpdateLocalPersonUserDetailsResponse `xml:"urn:sso UpdateLocalPersonUserDetailsResponse,omitempty"`
+	Fault_ *soap.Fault                                 `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdateLocalPersonUserDetailsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdateLocalPersonUserDetails(ctx context.Context, r soap.RoundTripper, req *types.UpdateLocalPersonUserDetails) (*types.UpdateLocalPersonUserDetailsResponse, error) {
+	var reqBody, resBody UpdateLocalPersonUserDetailsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type UpdateLocalSolutionUserDetailsBody struct {
+	Req    *types.UpdateLocalSolutionUserDetails         `xml:"urn:sso UpdateLocalSolutionUserDetails,omitempty"`
+	Res    *types.UpdateLocalSolutionUserDetailsResponse `xml:"urn:sso UpdateLocalSolutionUserDetailsResponse,omitempty"`
+	Fault_ *soap.Fault                                   `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdateLocalSolutionUserDetailsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdateLocalSolutionUserDetails(ctx context.Context, r soap.RoundTripper, req *types.UpdateLocalSolutionUserDetails) (*types.UpdateLocalSolutionUserDetailsResponse, error) {
+	var reqBody, resBody UpdateLocalSolutionUserDetailsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type UpdateLockoutPolicyBody struct {
+	Req    *types.UpdateLockoutPolicy         `xml:"urn:sso UpdateLockoutPolicy,omitempty"`
+	Res    *types.UpdateLockoutPolicyResponse `xml:"urn:sso UpdateLockoutPolicyResponse,omitempty"`
+	Fault_ *soap.Fault                        `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdateLockoutPolicyBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdateLockoutPolicy(ctx context.Context, r soap.RoundTripper, req *types.UpdateLockoutPolicy) (*types.UpdateLockoutPolicyResponse, error) {
+	var reqBody, resBody UpdateLockoutPolicyBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type UpdatePasswordExpirationConfigurationBody struct {
+	Req    *types.UpdatePasswordExpirationConfiguration         `xml:"urn:sso UpdatePasswordExpirationConfiguration,omitempty"`
+	Res    *types.UpdatePasswordExpirationConfigurationResponse `xml:"urn:sso UpdatePasswordExpirationConfigurationResponse,omitempty"`
+	Fault_ *soap.Fault                                          `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdatePasswordExpirationConfigurationBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdatePasswordExpirationConfiguration(ctx context.Context, r soap.RoundTripper, req *types.UpdatePasswordExpirationConfiguration) (*types.UpdatePasswordExpirationConfigurationResponse, error) {
+	var reqBody, resBody UpdatePasswordExpirationConfigurationBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type UpdateSelfLocalPersonUserDetailsBody struct {
+	Req    *types.UpdateSelfLocalPersonUserDetails         `xml:"urn:sso UpdateSelfLocalPersonUserDetails,omitempty"`
+	Res    *types.UpdateSelfLocalPersonUserDetailsResponse `xml:"urn:sso UpdateSelfLocalPersonUserDetailsResponse,omitempty"`
+	Fault_ *soap.Fault                                     `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdateSelfLocalPersonUserDetailsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdateSelfLocalPersonUserDetails(ctx context.Context, r soap.RoundTripper, req *types.UpdateSelfLocalPersonUserDetails) (*types.UpdateSelfLocalPersonUserDetailsResponse, error) {
+	var reqBody, resBody UpdateSelfLocalPersonUserDetailsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type UpdateSelfLocalSolutionUserDetailsBody struct {
+	Req    *types.UpdateSelfLocalSolutionUserDetails         `xml:"urn:sso UpdateSelfLocalSolutionUserDetails,omitempty"`
+	Res    *types.UpdateSelfLocalSolutionUserDetailsResponse `xml:"urn:sso UpdateSelfLocalSolutionUserDetailsResponse,omitempty"`
+	Fault_ *soap.Fault                                       `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdateSelfLocalSolutionUserDetailsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdateSelfLocalSolutionUserDetails(ctx context.Context, r soap.RoundTripper, req *types.UpdateSelfLocalSolutionUserDetails) (*types.UpdateSelfLocalSolutionUserDetailsResponse, error) {
+	var reqBody, resBody UpdateSelfLocalSolutionUserDetailsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type UpdateSmtpConfigurationBody struct {
+	Req    *types.UpdateSmtpConfiguration         `xml:"urn:sso UpdateSmtpConfiguration,omitempty"`
+	Res    *types.UpdateSmtpConfigurationResponse `xml:"urn:sso UpdateSmtpConfigurationResponse,omitempty"`
+	Fault_ *soap.Fault                            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdateSmtpConfigurationBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdateSmtpConfiguration(ctx context.Context, r soap.RoundTripper, req *types.UpdateSmtpConfiguration) (*types.UpdateSmtpConfigurationResponse, error) {
+	var reqBody, resBody UpdateSmtpConfigurationBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}

--- a/vendor/github.com/vmware/govmomi/ssoadmin/methods/role.go
+++ b/vendor/github.com/vmware/govmomi/ssoadmin/methods/role.go
@@ -1,0 +1,76 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package methods
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/ssoadmin/types"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/xml"
+)
+
+// Methods here are not included in the wsdl
+
+type GrantWSTrustRoleBody struct {
+	Req    *types.GrantWSTrustRole         `xml:"urn:sso GrantWSTrustRole,omitempty"`
+	Res    *types.GrantWSTrustRoleResponse `xml:"urn:sso GrantWSTrustRoleResponse,omitempty"`
+	Fault_ *soap.Fault                     `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GrantWSTrustRoleBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GrantWSTrustRole(ctx context.Context, r soap.RoundTripper, req *types.GrantWSTrustRole) (*types.GrantWSTrustRoleResponse, error) {
+	var reqBody, resBody GrantWSTrustRoleBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RevokeWSTrustRoleBody struct {
+	Req    *types.RevokeWSTrustRole         `xml:"urn:sso RevokeWSTrustRole,omitempty"`
+	Res    *types.RevokeWSTrustRoleResponse `xml:"urn:sso RevokeWSTrustRoleResponse,omitempty"`
+	Fault_ *soap.Fault                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RevokeWSTrustRoleBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RevokeWSTrustRole(ctx context.Context, r soap.RoundTripper, req *types.RevokeWSTrustRole) (*types.RevokeWSTrustRoleResponse, error) {
+	var reqBody, resBody RevokeWSTrustRoleBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+// C14N returns the canonicalized form of LoginBody.Req, for use by sts.Signer
+func (b *LoginBody) C14N() string {
+	req, err := xml.Marshal(b.Req)
+	if err != nil {
+		panic(err)
+	}
+	return string(req)
+}

--- a/vendor/github.com/vmware/govmomi/ssoadmin/types/role.go
+++ b/vendor/github.com/vmware/govmomi/ssoadmin/types/role.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"reflect"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// Types here are not included in the wsdl
+
+const (
+	RoleActAsUser     = "ActAsUser"
+	RoleRegularUser   = "RegularUser"
+	RoleAdministrator = "Administrator"
+)
+
+type GrantWSTrustRole GrantWSTrustRoleRequestType
+
+func init() {
+	types.Add("sso:GrantWSTrustRole", reflect.TypeOf((*GrantWSTrustRole)(nil)).Elem())
+}
+
+type GrantWSTrustRoleRequestType struct {
+	This   types.ManagedObjectReference `xml:"_this"`
+	UserId PrincipalId                  `xml:"userId"`
+	Role   string                       `xml:"role"`
+}
+
+func init() {
+	types.Add("sso:GrantWSTrustRoleRequestType", reflect.TypeOf((*GrantWSTrustRoleRequestType)(nil)).Elem())
+}
+
+type GrantWSTrustRoleResponse struct {
+	Returnval bool `xml:"returnval"`
+}
+
+type RevokeWSTrustRole RevokeWSTrustRoleRequestType
+
+func init() {
+	types.Add("sso:RevokeWSTrustRole", reflect.TypeOf((*RevokeWSTrustRole)(nil)).Elem())
+}
+
+type RevokeWSTrustRoleRequestType struct {
+	This   types.ManagedObjectReference `xml:"_this"`
+	UserId PrincipalId                  `xml:"userId"`
+	Role   string                       `xml:"role"`
+}
+
+func init() {
+	types.Add("sso:RevokeWSTrustRoleRequestType", reflect.TypeOf((*RevokeWSTrustRoleRequestType)(nil)).Elem())
+}
+
+type RevokeWSTrustRoleResponse struct {
+	Returnval bool `xml:"returnval"`
+}

--- a/vendor/github.com/vmware/govmomi/ssoadmin/types/types.go
+++ b/vendor/github.com/vmware/govmomi/ssoadmin/types/types.go
@@ -1,0 +1,1985 @@
+/*
+Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"net/url"
+	"reflect"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type AddCertificate AddCertificateRequestType
+
+func init() {
+	types.Add("sso:AddCertificate", reflect.TypeOf((*AddCertificate)(nil)).Elem())
+}
+
+type AddCertificateRequestType struct {
+	This        types.ManagedObjectReference `xml:"_this"`
+	Certificate string                       `xml:"certificate"`
+}
+
+func init() {
+	types.Add("sso:AddCertificateRequestType", reflect.TypeOf((*AddCertificateRequestType)(nil)).Elem())
+}
+
+type AddCertificateResponse struct {
+	Returnval bool `xml:"returnval"`
+}
+
+type AddExternalDomain AddExternalDomainRequestType
+
+func init() {
+	types.Add("sso:AddExternalDomain", reflect.TypeOf((*AddExternalDomain)(nil)).Elem())
+}
+
+type AddExternalDomainRequestType struct {
+	This               types.ManagedObjectReference                           `xml:"_this"`
+	ServerType         string                                                 `xml:"serverType"`
+	DomainName         string                                                 `xml:"domainName"`
+	DomainAlias        string                                                 `xml:"domainAlias,omitempty"`
+	Details            AdminExternalDomainDetails                             `xml:"details"`
+	AuthenticationType string                                                 `xml:"authenticationType"`
+	AuthnCredentials   *AdminDomainManagementServiceAuthenticationCredentails `xml:"authnCredentials,omitempty"`
+}
+
+func init() {
+	types.Add("sso:AddExternalDomainRequestType", reflect.TypeOf((*AddExternalDomainRequestType)(nil)).Elem())
+}
+
+type AddExternalDomainResponse struct {
+}
+
+type AddGroupToLocalGroup AddGroupToLocalGroupRequestType
+
+func init() {
+	types.Add("sso:AddGroupToLocalGroup", reflect.TypeOf((*AddGroupToLocalGroup)(nil)).Elem())
+}
+
+type AddGroupToLocalGroupRequestType struct {
+	This      types.ManagedObjectReference `xml:"_this"`
+	GroupId   PrincipalId                  `xml:"groupId"`
+	GroupName string                       `xml:"groupName"`
+}
+
+func init() {
+	types.Add("sso:AddGroupToLocalGroupRequestType", reflect.TypeOf((*AddGroupToLocalGroupRequestType)(nil)).Elem())
+}
+
+type AddGroupToLocalGroupResponse struct {
+	Returnval bool `xml:"returnval"`
+}
+
+type AddGroupsToLocalGroup AddGroupsToLocalGroupRequestType
+
+func init() {
+	types.Add("sso:AddGroupsToLocalGroup", reflect.TypeOf((*AddGroupsToLocalGroup)(nil)).Elem())
+}
+
+type AddGroupsToLocalGroupRequestType struct {
+	This      types.ManagedObjectReference `xml:"_this"`
+	GroupIds  []PrincipalId                `xml:"groupIds"`
+	GroupName string                       `xml:"groupName"`
+}
+
+func init() {
+	types.Add("sso:AddGroupsToLocalGroupRequestType", reflect.TypeOf((*AddGroupsToLocalGroupRequestType)(nil)).Elem())
+}
+
+type AddGroupsToLocalGroupResponse struct {
+	Returnval []bool `xml:"returnval"`
+}
+
+type AddUserToLocalGroup AddUserToLocalGroupRequestType
+
+func init() {
+	types.Add("sso:AddUserToLocalGroup", reflect.TypeOf((*AddUserToLocalGroup)(nil)).Elem())
+}
+
+type AddUserToLocalGroupRequestType struct {
+	This      types.ManagedObjectReference `xml:"_this"`
+	UserId    PrincipalId                  `xml:"userId"`
+	GroupName string                       `xml:"groupName"`
+}
+
+func init() {
+	types.Add("sso:AddUserToLocalGroupRequestType", reflect.TypeOf((*AddUserToLocalGroupRequestType)(nil)).Elem())
+}
+
+type AddUserToLocalGroupResponse struct {
+	Returnval bool `xml:"returnval"`
+}
+
+type AddUsersToLocalGroup AddUsersToLocalGroupRequestType
+
+func init() {
+	types.Add("sso:AddUsersToLocalGroup", reflect.TypeOf((*AddUsersToLocalGroup)(nil)).Elem())
+}
+
+type AddUsersToLocalGroupRequestType struct {
+	This      types.ManagedObjectReference `xml:"_this"`
+	UserIds   []PrincipalId                `xml:"userIds"`
+	GroupName string                       `xml:"groupName"`
+}
+
+func init() {
+	types.Add("sso:AddUsersToLocalGroupRequestType", reflect.TypeOf((*AddUsersToLocalGroupRequestType)(nil)).Elem())
+}
+
+type AddUsersToLocalGroupResponse struct {
+	Returnval []bool `xml:"returnval"`
+}
+
+type AdminConfigurationManagementServiceCertificateChain struct {
+	types.DynamicData
+
+	Certificates []string `xml:"certificates"`
+}
+
+func init() {
+	types.Add("sso:AdminConfigurationManagementServiceCertificateChain", reflect.TypeOf((*AdminConfigurationManagementServiceCertificateChain)(nil)).Elem())
+}
+
+type AdminDomainManagementServiceAuthenticationCredentails struct {
+	types.DynamicData
+
+	Username string `xml:"username"`
+	Password string `xml:"password"`
+}
+
+func init() {
+	types.Add("sso:AdminDomainManagementServiceAuthenticationCredentails", reflect.TypeOf((*AdminDomainManagementServiceAuthenticationCredentails)(nil)).Elem())
+}
+
+type AdminDomains struct {
+	types.DynamicData
+
+	ExternalDomains  []AdminExternalDomain `xml:"externalDomains"`
+	SystemDomainName string                `xml:"systemDomainName"`
+}
+
+func init() {
+	types.Add("sso:AdminDomains", reflect.TypeOf((*AdminDomains)(nil)).Elem())
+}
+
+type AdminExternalDomain struct {
+	types.DynamicData
+
+	Type                  string                                   `xml:"type"`
+	Name                  string                                   `xml:"name"`
+	Alias                 string                                   `xml:"alias,omitempty"`
+	Details               AdminExternalDomainDetails               `xml:"details"`
+	AuthenticationDetails AdminExternalDomainAuthenticationDetails `xml:"authenticationDetails"`
+}
+
+func init() {
+	types.Add("sso:AdminExternalDomain", reflect.TypeOf((*AdminExternalDomain)(nil)).Elem())
+}
+
+type AdminExternalDomainAuthenticationDetails struct {
+	types.DynamicData
+
+	AuthenticationType string `xml:"authenticationType"`
+	Username           string `xml:"username,omitempty"`
+}
+
+func init() {
+	types.Add("sso:AdminExternalDomainAuthenticationDetails", reflect.TypeOf((*AdminExternalDomainAuthenticationDetails)(nil)).Elem())
+}
+
+type AdminExternalDomainDetails struct {
+	types.DynamicData
+
+	FriendlyName         string  `xml:"friendlyName"`
+	UserBaseDn           string  `xml:"userBaseDn"`
+	GroupBaseDn          string  `xml:"groupBaseDn"`
+	PrimaryUrl           url.URL `xml:"primaryUrl"`
+	FailoverUrl          url.URL `xml:"failoverUrl,omitempty"`
+	SearchTimeoutSeconds int32   `xml:"searchTimeoutSeconds"`
+}
+
+func init() {
+	types.Add("sso:AdminExternalDomainDetails", reflect.TypeOf((*AdminExternalDomainDetails)(nil)).Elem())
+}
+
+type AdminGroup struct {
+	types.DynamicData
+
+	Id      PrincipalId       `xml:"id"`
+	Alias   *PrincipalId      `xml:"alias,omitempty"`
+	Details AdminGroupDetails `xml:"details"`
+}
+
+func init() {
+	types.Add("sso:AdminGroup", reflect.TypeOf((*AdminGroup)(nil)).Elem())
+}
+
+type AdminGroupDetails struct {
+	types.DynamicData
+
+	Description string `xml:"description,omitempty"`
+}
+
+func init() {
+	types.Add("sso:AdminGroupDetails", reflect.TypeOf((*AdminGroupDetails)(nil)).Elem())
+}
+
+type AdminLockoutPolicy struct {
+	types.DynamicData
+
+	Description              string `xml:"description"`
+	MaxFailedAttempts        int32  `xml:"maxFailedAttempts"`
+	FailedAttemptIntervalSec int64  `xml:"failedAttemptIntervalSec"`
+	AutoUnlockIntervalSec    int64  `xml:"autoUnlockIntervalSec"`
+}
+
+func init() {
+	types.Add("sso:AdminLockoutPolicy", reflect.TypeOf((*AdminLockoutPolicy)(nil)).Elem())
+}
+
+type AdminMailContent struct {
+	types.DynamicData
+
+	From    string `xml:"from"`
+	To      string `xml:"to"`
+	Subject string `xml:"subject"`
+	Content string `xml:"content"`
+}
+
+func init() {
+	types.Add("sso:AdminMailContent", reflect.TypeOf((*AdminMailContent)(nil)).Elem())
+}
+
+type AdminPasswordExpirationConfig struct {
+	types.DynamicData
+
+	EmailNotificationEnabled bool    `xml:"emailNotificationEnabled"`
+	EmailFrom                string  `xml:"emailFrom,omitempty"`
+	EmailSubject             string  `xml:"emailSubject,omitempty"`
+	NotificationDays         []int32 `xml:"notificationDays,omitempty"`
+}
+
+func init() {
+	types.Add("sso:AdminPasswordExpirationConfig", reflect.TypeOf((*AdminPasswordExpirationConfig)(nil)).Elem())
+}
+
+type AdminPasswordFormat struct {
+	types.DynamicData
+
+	LengthRestriction              AdminPasswordFormatLengthRestriction     `xml:"lengthRestriction"`
+	AlphabeticRestriction          AdminPasswordFormatAlphabeticRestriction `xml:"alphabeticRestriction"`
+	MinNumericCount                int32                                    `xml:"minNumericCount"`
+	MinSpecialCharCount            int32                                    `xml:"minSpecialCharCount"`
+	MaxIdenticalAdjacentCharacters int32                                    `xml:"maxIdenticalAdjacentCharacters"`
+}
+
+func init() {
+	types.Add("sso:AdminPasswordFormat", reflect.TypeOf((*AdminPasswordFormat)(nil)).Elem())
+}
+
+type AdminPasswordFormatAlphabeticRestriction struct {
+	types.DynamicData
+
+	MinAlphabeticCount int32 `xml:"minAlphabeticCount"`
+	MinUppercaseCount  int32 `xml:"minUppercaseCount"`
+	MinLowercaseCount  int32 `xml:"minLowercaseCount"`
+}
+
+func init() {
+	types.Add("sso:AdminPasswordFormatAlphabeticRestriction", reflect.TypeOf((*AdminPasswordFormatAlphabeticRestriction)(nil)).Elem())
+}
+
+type AdminPasswordFormatLengthRestriction struct {
+	types.DynamicData
+
+	MinLength int32 `xml:"minLength"`
+	MaxLength int32 `xml:"maxLength"`
+}
+
+func init() {
+	types.Add("sso:AdminPasswordFormatLengthRestriction", reflect.TypeOf((*AdminPasswordFormatLengthRestriction)(nil)).Elem())
+}
+
+type AdminPasswordPolicy struct {
+	types.DynamicData
+
+	Description                      string              `xml:"description"`
+	ProhibitedPreviousPasswordsCount int32               `xml:"prohibitedPreviousPasswordsCount"`
+	PasswordFormat                   AdminPasswordFormat `xml:"passwordFormat"`
+	PasswordLifetimeDays             int32               `xml:"passwordLifetimeDays,omitempty"`
+}
+
+func init() {
+	types.Add("sso:AdminPasswordPolicy", reflect.TypeOf((*AdminPasswordPolicy)(nil)).Elem())
+}
+
+type AdminPersonDetails struct {
+	types.DynamicData
+
+	Description  string `xml:"description,omitempty"`
+	EmailAddress string `xml:"emailAddress,omitempty"`
+	FirstName    string `xml:"firstName,omitempty"`
+	LastName     string `xml:"lastName,omitempty"`
+}
+
+func init() {
+	types.Add("sso:AdminPersonDetails", reflect.TypeOf((*AdminPersonDetails)(nil)).Elem())
+}
+
+type AdminPersonUser struct {
+	types.DynamicData
+
+	Id       PrincipalId        `xml:"id"`
+	Alias    *PrincipalId       `xml:"alias,omitempty"`
+	Details  AdminPersonDetails `xml:"details"`
+	Disabled bool               `xml:"disabled"`
+	Locked   bool               `xml:"locked"`
+}
+
+func init() {
+	types.Add("sso:AdminPersonUser", reflect.TypeOf((*AdminPersonUser)(nil)).Elem())
+}
+
+type AdminPrincipalDiscoveryServiceSearchCriteria struct {
+	types.DynamicData
+
+	SearchString string `xml:"searchString"`
+	Domain       string `xml:"domain"`
+}
+
+func init() {
+	types.Add("sso:AdminPrincipalDiscoveryServiceSearchCriteria", reflect.TypeOf((*AdminPrincipalDiscoveryServiceSearchCriteria)(nil)).Elem())
+}
+
+type AdminPrincipalDiscoveryServiceSearchResult struct {
+	types.DynamicData
+
+	PersonUsers   []AdminPersonUser   `xml:"personUsers,omitempty"`
+	SolutionUsers []AdminSolutionUser `xml:"solutionUsers,omitempty"`
+	Groups        []AdminGroup        `xml:"groups,omitempty"`
+}
+
+func init() {
+	types.Add("sso:AdminPrincipalDiscoveryServiceSearchResult", reflect.TypeOf((*AdminPrincipalDiscoveryServiceSearchResult)(nil)).Elem())
+}
+
+type AdminServiceContent struct {
+	types.DynamicData
+
+	SessionManager                  types.ManagedObjectReference `xml:"sessionManager"`
+	ConfigurationManagementService  types.ManagedObjectReference `xml:"configurationManagementService"`
+	SmtpManagementService           types.ManagedObjectReference `xml:"smtpManagementService"`
+	PrincipalDiscoveryService       types.ManagedObjectReference `xml:"principalDiscoveryService"`
+	PrincipalManagementService      types.ManagedObjectReference `xml:"principalManagementService"`
+	RoleManagementService           types.ManagedObjectReference `xml:"roleManagementService"`
+	PasswordPolicyService           types.ManagedObjectReference `xml:"passwordPolicyService"`
+	LockoutPolicyService            types.ManagedObjectReference `xml:"lockoutPolicyService"`
+	DomainManagementService         types.ManagedObjectReference `xml:"domainManagementService"`
+	IdentitySourceManagementService types.ManagedObjectReference `xml:"identitySourceManagementService"`
+	SystemManagementService         types.ManagedObjectReference `xml:"systemManagementService"`
+	ComputerManagementService       types.ManagedObjectReference `xml:"computerManagementService"`
+	SsoHealthManagementService      types.ManagedObjectReference `xml:"ssoHealthManagementService"`
+	DeploymentInformationService    types.ManagedObjectReference `xml:"deploymentInformationService"`
+	ReplicationService              types.ManagedObjectReference `xml:"replicationService"`
+}
+
+func init() {
+	types.Add("sso:AdminServiceContent", reflect.TypeOf((*AdminServiceContent)(nil)).Elem())
+}
+
+type AdminSmtpConfig struct {
+	types.DynamicData
+
+	Host         string `xml:"host,omitempty"`
+	Port         int32  `xml:"port,omitempty"`
+	Authenticate *bool  `xml:"authenticate"`
+	User         string `xml:"user,omitempty"`
+	Password     string `xml:"password,omitempty"`
+}
+
+func init() {
+	types.Add("sso:AdminSmtpConfig", reflect.TypeOf((*AdminSmtpConfig)(nil)).Elem())
+}
+
+type AdminSolutionDetails struct {
+	types.DynamicData
+
+	Description string `xml:"description,omitempty"`
+	Certificate string `xml:"certificate"`
+}
+
+func init() {
+	types.Add("sso:AdminSolutionDetails", reflect.TypeOf((*AdminSolutionDetails)(nil)).Elem())
+}
+
+type AdminSolutionUser struct {
+	types.DynamicData
+
+	Id       PrincipalId          `xml:"id"`
+	Alias    *PrincipalId         `xml:"alias,omitempty"`
+	Details  AdminSolutionDetails `xml:"details"`
+	Disabled bool                 `xml:"disabled"`
+}
+
+func init() {
+	types.Add("sso:AdminSolutionUser", reflect.TypeOf((*AdminSolutionUser)(nil)).Elem())
+}
+
+type AdminUser struct {
+	types.DynamicData
+
+	Id          PrincipalId  `xml:"id"`
+	Alias       *PrincipalId `xml:"alias,omitempty"`
+	Kind        string       `xml:"kind"`
+	Description string       `xml:"description,omitempty"`
+}
+
+func init() {
+	types.Add("sso:AdminUser", reflect.TypeOf((*AdminUser)(nil)).Elem())
+}
+
+type CreateLocalGroup CreateLocalGroupRequestType
+
+func init() {
+	types.Add("sso:CreateLocalGroup", reflect.TypeOf((*CreateLocalGroup)(nil)).Elem())
+}
+
+type CreateLocalGroupRequestType struct {
+	This         types.ManagedObjectReference `xml:"_this"`
+	GroupName    string                       `xml:"groupName"`
+	GroupDetails AdminGroupDetails            `xml:"groupDetails"`
+}
+
+func init() {
+	types.Add("sso:CreateLocalGroupRequestType", reflect.TypeOf((*CreateLocalGroupRequestType)(nil)).Elem())
+}
+
+type CreateLocalGroupResponse struct {
+}
+
+type CreateLocalPersonUser CreateLocalPersonUserRequestType
+
+func init() {
+	types.Add("sso:CreateLocalPersonUser", reflect.TypeOf((*CreateLocalPersonUser)(nil)).Elem())
+}
+
+type CreateLocalPersonUserRequestType struct {
+	This        types.ManagedObjectReference `xml:"_this"`
+	UserName    string                       `xml:"userName"`
+	UserDetails AdminPersonDetails           `xml:"userDetails"`
+	Password    string                       `xml:"password"`
+}
+
+func init() {
+	types.Add("sso:CreateLocalPersonUserRequestType", reflect.TypeOf((*CreateLocalPersonUserRequestType)(nil)).Elem())
+}
+
+type CreateLocalPersonUserResponse struct {
+}
+
+type CreateLocalSolutionUser CreateLocalSolutionUserRequestType
+
+func init() {
+	types.Add("sso:CreateLocalSolutionUser", reflect.TypeOf((*CreateLocalSolutionUser)(nil)).Elem())
+}
+
+type CreateLocalSolutionUserRequestType struct {
+	This        types.ManagedObjectReference `xml:"_this"`
+	UserName    string                       `xml:"userName"`
+	UserDetails AdminSolutionDetails         `xml:"userDetails"`
+}
+
+func init() {
+	types.Add("sso:CreateLocalSolutionUserRequestType", reflect.TypeOf((*CreateLocalSolutionUserRequestType)(nil)).Elem())
+}
+
+type CreateLocalSolutionUserResponse struct {
+}
+
+type DeleteCertificate DeleteCertificateRequestType
+
+func init() {
+	types.Add("sso:DeleteCertificate", reflect.TypeOf((*DeleteCertificate)(nil)).Elem())
+}
+
+type DeleteCertificateRequestType struct {
+	This        types.ManagedObjectReference `xml:"_this"`
+	Fingerprint string                       `xml:"fingerprint"`
+}
+
+func init() {
+	types.Add("sso:DeleteCertificateRequestType", reflect.TypeOf((*DeleteCertificateRequestType)(nil)).Elem())
+}
+
+type DeleteCertificateResponse struct {
+	Returnval bool `xml:"returnval"`
+}
+
+type DeleteDomain DeleteDomainRequestType
+
+func init() {
+	types.Add("sso:DeleteDomain", reflect.TypeOf((*DeleteDomain)(nil)).Elem())
+}
+
+type DeleteDomainRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+	Name string                       `xml:"name"`
+}
+
+func init() {
+	types.Add("sso:DeleteDomainRequestType", reflect.TypeOf((*DeleteDomainRequestType)(nil)).Elem())
+}
+
+type DeleteDomainResponse struct {
+}
+
+type DeleteLocalPrincipal DeleteLocalPrincipalRequestType
+
+func init() {
+	types.Add("sso:DeleteLocalPrincipal", reflect.TypeOf((*DeleteLocalPrincipal)(nil)).Elem())
+}
+
+type DeleteLocalPrincipalRequestType struct {
+	This          types.ManagedObjectReference `xml:"_this"`
+	PrincipalName string                       `xml:"principalName"`
+}
+
+func init() {
+	types.Add("sso:DeleteLocalPrincipalRequestType", reflect.TypeOf((*DeleteLocalPrincipalRequestType)(nil)).Elem())
+}
+
+type DeleteLocalPrincipalResponse struct {
+}
+
+type DisableUserAccount DisableUserAccountRequestType
+
+func init() {
+	types.Add("sso:DisableUserAccount", reflect.TypeOf((*DisableUserAccount)(nil)).Elem())
+}
+
+type DisableUserAccountRequestType struct {
+	This   types.ManagedObjectReference `xml:"_this"`
+	UserId PrincipalId                  `xml:"userId"`
+}
+
+func init() {
+	types.Add("sso:DisableUserAccountRequestType", reflect.TypeOf((*DisableUserAccountRequestType)(nil)).Elem())
+}
+
+type DisableUserAccountResponse struct {
+	Returnval bool `xml:"returnval"`
+}
+
+type EnableUserAccount EnableUserAccountRequestType
+
+func init() {
+	types.Add("sso:EnableUserAccount", reflect.TypeOf((*EnableUserAccount)(nil)).Elem())
+}
+
+type EnableUserAccountRequestType struct {
+	This   types.ManagedObjectReference `xml:"_this"`
+	UserId PrincipalId                  `xml:"userId"`
+}
+
+func init() {
+	types.Add("sso:EnableUserAccountRequestType", reflect.TypeOf((*EnableUserAccountRequestType)(nil)).Elem())
+}
+
+type EnableUserAccountResponse struct {
+	Returnval bool `xml:"returnval"`
+}
+
+type Find FindRequestType
+
+func init() {
+	types.Add("sso:Find", reflect.TypeOf((*Find)(nil)).Elem())
+}
+
+type FindAllParentGroups FindAllParentGroupsRequestType
+
+func init() {
+	types.Add("sso:FindAllParentGroups", reflect.TypeOf((*FindAllParentGroups)(nil)).Elem())
+}
+
+type FindAllParentGroupsRequestType struct {
+	This   types.ManagedObjectReference `xml:"_this"`
+	UserId PrincipalId                  `xml:"userId"`
+}
+
+func init() {
+	types.Add("sso:FindAllParentGroupsRequestType", reflect.TypeOf((*FindAllParentGroupsRequestType)(nil)).Elem())
+}
+
+type FindAllParentGroupsResponse struct {
+	Returnval []PrincipalId `xml:"returnval,omitempty"`
+}
+
+type FindCertificate FindCertificateRequestType
+
+func init() {
+	types.Add("sso:FindCertificate", reflect.TypeOf((*FindCertificate)(nil)).Elem())
+}
+
+type FindCertificateRequestType struct {
+	This        types.ManagedObjectReference `xml:"_this"`
+	Fingerprint string                       `xml:"fingerprint"`
+}
+
+func init() {
+	types.Add("sso:FindCertificateRequestType", reflect.TypeOf((*FindCertificateRequestType)(nil)).Elem())
+}
+
+type FindCertificateResponse struct {
+	Returnval string `xml:"returnval,omitempty"`
+}
+
+type FindDirectParentGroups FindDirectParentGroupsRequestType
+
+func init() {
+	types.Add("sso:FindDirectParentGroups", reflect.TypeOf((*FindDirectParentGroups)(nil)).Elem())
+}
+
+type FindDirectParentGroupsRequestType struct {
+	This        types.ManagedObjectReference `xml:"_this"`
+	PrincipalId PrincipalId                  `xml:"principalId"`
+}
+
+func init() {
+	types.Add("sso:FindDirectParentGroupsRequestType", reflect.TypeOf((*FindDirectParentGroupsRequestType)(nil)).Elem())
+}
+
+type FindDirectParentGroupsResponse struct {
+	Returnval []AdminGroup `xml:"returnval,omitempty"`
+}
+
+type FindDisabledPersonUsers FindDisabledPersonUsersRequestType
+
+func init() {
+	types.Add("sso:FindDisabledPersonUsers", reflect.TypeOf((*FindDisabledPersonUsers)(nil)).Elem())
+}
+
+type FindDisabledPersonUsersRequestType struct {
+	This      types.ManagedObjectReference `xml:"_this"`
+	SearchStr string                       `xml:"searchStr"`
+	Limit     int32                        `xml:"limit"`
+}
+
+func init() {
+	types.Add("sso:FindDisabledPersonUsersRequestType", reflect.TypeOf((*FindDisabledPersonUsersRequestType)(nil)).Elem())
+}
+
+type FindDisabledPersonUsersResponse struct {
+	Returnval []AdminPersonUser `xml:"returnval,omitempty"`
+}
+
+type FindDisabledSolutionUsers FindDisabledSolutionUsersRequestType
+
+func init() {
+	types.Add("sso:FindDisabledSolutionUsers", reflect.TypeOf((*FindDisabledSolutionUsers)(nil)).Elem())
+}
+
+type FindDisabledSolutionUsersRequestType struct {
+	This      types.ManagedObjectReference `xml:"_this"`
+	SearchStr string                       `xml:"searchStr"`
+}
+
+func init() {
+	types.Add("sso:FindDisabledSolutionUsersRequestType", reflect.TypeOf((*FindDisabledSolutionUsersRequestType)(nil)).Elem())
+}
+
+type FindDisabledSolutionUsersResponse struct {
+	Returnval []AdminSolutionUser `xml:"returnval,omitempty"`
+}
+
+type FindExternalDomain FindExternalDomainRequestType
+
+func init() {
+	types.Add("sso:FindExternalDomain", reflect.TypeOf((*FindExternalDomain)(nil)).Elem())
+}
+
+type FindExternalDomainRequestType struct {
+	This   types.ManagedObjectReference `xml:"_this"`
+	Filter string                       `xml:"filter"`
+}
+
+func init() {
+	types.Add("sso:FindExternalDomainRequestType", reflect.TypeOf((*FindExternalDomainRequestType)(nil)).Elem())
+}
+
+type FindExternalDomainResponse struct {
+	Returnval *AdminExternalDomain `xml:"returnval,omitempty"`
+}
+
+type FindGroup FindGroupRequestType
+
+func init() {
+	types.Add("sso:FindGroup", reflect.TypeOf((*FindGroup)(nil)).Elem())
+}
+
+type FindGroupRequestType struct {
+	This    types.ManagedObjectReference `xml:"_this"`
+	GroupId PrincipalId                  `xml:"groupId"`
+}
+
+func init() {
+	types.Add("sso:FindGroupRequestType", reflect.TypeOf((*FindGroupRequestType)(nil)).Elem())
+}
+
+type FindGroupResponse struct {
+	Returnval *AdminGroup `xml:"returnval,omitempty"`
+}
+
+type FindGroups FindGroupsRequestType
+
+func init() {
+	types.Add("sso:FindGroups", reflect.TypeOf((*FindGroups)(nil)).Elem())
+}
+
+type FindGroupsInGroup FindGroupsInGroupRequestType
+
+func init() {
+	types.Add("sso:FindGroupsInGroup", reflect.TypeOf((*FindGroupsInGroup)(nil)).Elem())
+}
+
+type FindGroupsInGroupRequestType struct {
+	This         types.ManagedObjectReference `xml:"_this"`
+	GroupId      PrincipalId                  `xml:"groupId"`
+	SearchString string                       `xml:"searchString"`
+	Limit        int32                        `xml:"limit"`
+}
+
+func init() {
+	types.Add("sso:FindGroupsInGroupRequestType", reflect.TypeOf((*FindGroupsInGroupRequestType)(nil)).Elem())
+}
+
+type FindGroupsInGroupResponse struct {
+	Returnval []AdminGroup `xml:"returnval,omitempty"`
+}
+
+type FindGroupsRequestType struct {
+	This     types.ManagedObjectReference                 `xml:"_this"`
+	Criteria AdminPrincipalDiscoveryServiceSearchCriteria `xml:"criteria"`
+	Limit    int32                                        `xml:"limit"`
+}
+
+func init() {
+	types.Add("sso:FindGroupsRequestType", reflect.TypeOf((*FindGroupsRequestType)(nil)).Elem())
+}
+
+type FindGroupsResponse struct {
+	Returnval []AdminGroup `xml:"returnval,omitempty"`
+}
+
+type FindLockedUsers FindLockedUsersRequestType
+
+func init() {
+	types.Add("sso:FindLockedUsers", reflect.TypeOf((*FindLockedUsers)(nil)).Elem())
+}
+
+type FindLockedUsersRequestType struct {
+	This      types.ManagedObjectReference `xml:"_this"`
+	SearchStr string                       `xml:"searchStr"`
+	Limit     int32                        `xml:"limit"`
+}
+
+func init() {
+	types.Add("sso:FindLockedUsersRequestType", reflect.TypeOf((*FindLockedUsersRequestType)(nil)).Elem())
+}
+
+type FindLockedUsersResponse struct {
+	Returnval []AdminPersonUser `xml:"returnval,omitempty"`
+}
+
+type FindNestedParentGroups FindNestedParentGroupsRequestType
+
+func init() {
+	types.Add("sso:FindNestedParentGroups", reflect.TypeOf((*FindNestedParentGroups)(nil)).Elem())
+}
+
+type FindNestedParentGroupsRequestType struct {
+	This   types.ManagedObjectReference `xml:"_this"`
+	UserId PrincipalId                  `xml:"userId"`
+}
+
+func init() {
+	types.Add("sso:FindNestedParentGroupsRequestType", reflect.TypeOf((*FindNestedParentGroupsRequestType)(nil)).Elem())
+}
+
+type FindNestedParentGroupsResponse struct {
+	Returnval []AdminGroup `xml:"returnval,omitempty"`
+}
+
+type FindParentGroups FindParentGroupsRequestType
+
+func init() {
+	types.Add("sso:FindParentGroups", reflect.TypeOf((*FindParentGroups)(nil)).Elem())
+}
+
+type FindParentGroupsRequestType struct {
+	This      types.ManagedObjectReference `xml:"_this"`
+	UserId    PrincipalId                  `xml:"userId"`
+	GroupList []PrincipalId                `xml:"groupList,omitempty"`
+}
+
+func init() {
+	types.Add("sso:FindParentGroupsRequestType", reflect.TypeOf((*FindParentGroupsRequestType)(nil)).Elem())
+}
+
+type FindParentGroupsResponse struct {
+	Returnval []PrincipalId `xml:"returnval,omitempty"`
+}
+
+type FindPersonUser FindPersonUserRequestType
+
+func init() {
+	types.Add("sso:FindPersonUser", reflect.TypeOf((*FindPersonUser)(nil)).Elem())
+}
+
+type FindPersonUserRequestType struct {
+	This   types.ManagedObjectReference `xml:"_this"`
+	UserId PrincipalId                  `xml:"userId"`
+}
+
+func init() {
+	types.Add("sso:FindPersonUserRequestType", reflect.TypeOf((*FindPersonUserRequestType)(nil)).Elem())
+}
+
+type FindPersonUserResponse struct {
+	Returnval *AdminPersonUser `xml:"returnval,omitempty"`
+}
+
+type FindPersonUsers FindPersonUsersRequestType
+
+func init() {
+	types.Add("sso:FindPersonUsers", reflect.TypeOf((*FindPersonUsers)(nil)).Elem())
+}
+
+type FindPersonUsersInGroup FindPersonUsersInGroupRequestType
+
+func init() {
+	types.Add("sso:FindPersonUsersInGroup", reflect.TypeOf((*FindPersonUsersInGroup)(nil)).Elem())
+}
+
+type FindPersonUsersInGroupRequestType struct {
+	This         types.ManagedObjectReference `xml:"_this"`
+	GroupId      PrincipalId                  `xml:"groupId"`
+	SearchString string                       `xml:"searchString"`
+	Limit        int32                        `xml:"limit"`
+}
+
+func init() {
+	types.Add("sso:FindPersonUsersInGroupRequestType", reflect.TypeOf((*FindPersonUsersInGroupRequestType)(nil)).Elem())
+}
+
+type FindPersonUsersInGroupResponse struct {
+	Returnval []AdminPersonUser `xml:"returnval,omitempty"`
+}
+
+type FindPersonUsersRequestType struct {
+	This     types.ManagedObjectReference                 `xml:"_this"`
+	Criteria AdminPrincipalDiscoveryServiceSearchCriteria `xml:"criteria"`
+	Limit    int32                                        `xml:"limit"`
+}
+
+func init() {
+	types.Add("sso:FindPersonUsersRequestType", reflect.TypeOf((*FindPersonUsersRequestType)(nil)).Elem())
+}
+
+type FindPersonUsersResponse struct {
+	Returnval []AdminPersonUser `xml:"returnval,omitempty"`
+}
+
+type FindRequestType struct {
+	This     types.ManagedObjectReference                 `xml:"_this"`
+	Criteria AdminPrincipalDiscoveryServiceSearchCriteria `xml:"criteria"`
+	Limit    int32                                        `xml:"limit"`
+}
+
+func init() {
+	types.Add("sso:FindRequestType", reflect.TypeOf((*FindRequestType)(nil)).Elem())
+}
+
+type FindResponse struct {
+	Returnval AdminPrincipalDiscoveryServiceSearchResult `xml:"returnval"`
+}
+
+type FindSolutionUser FindSolutionUserRequestType
+
+func init() {
+	types.Add("sso:FindSolutionUser", reflect.TypeOf((*FindSolutionUser)(nil)).Elem())
+}
+
+type FindSolutionUserRequestType struct {
+	This     types.ManagedObjectReference `xml:"_this"`
+	UserName string                       `xml:"userName"`
+}
+
+func init() {
+	types.Add("sso:FindSolutionUserRequestType", reflect.TypeOf((*FindSolutionUserRequestType)(nil)).Elem())
+}
+
+type FindSolutionUserResponse struct {
+	Returnval *AdminSolutionUser `xml:"returnval,omitempty"`
+}
+
+type FindSolutionUsers FindSolutionUsersRequestType
+
+func init() {
+	types.Add("sso:FindSolutionUsers", reflect.TypeOf((*FindSolutionUsers)(nil)).Elem())
+}
+
+type FindSolutionUsersInGroup FindSolutionUsersInGroupRequestType
+
+func init() {
+	types.Add("sso:FindSolutionUsersInGroup", reflect.TypeOf((*FindSolutionUsersInGroup)(nil)).Elem())
+}
+
+type FindSolutionUsersInGroupRequestType struct {
+	This         types.ManagedObjectReference `xml:"_this"`
+	GroupName    string                       `xml:"groupName"`
+	SearchString string                       `xml:"searchString"`
+	Limit        int32                        `xml:"limit"`
+}
+
+func init() {
+	types.Add("sso:FindSolutionUsersInGroupRequestType", reflect.TypeOf((*FindSolutionUsersInGroupRequestType)(nil)).Elem())
+}
+
+type FindSolutionUsersInGroupResponse struct {
+	Returnval []AdminSolutionUser `xml:"returnval,omitempty"`
+}
+
+type FindSolutionUsersRequestType struct {
+	This         types.ManagedObjectReference `xml:"_this"`
+	SearchString string                       `xml:"searchString"`
+	Limit        int32                        `xml:"limit"`
+}
+
+func init() {
+	types.Add("sso:FindSolutionUsersRequestType", reflect.TypeOf((*FindSolutionUsersRequestType)(nil)).Elem())
+}
+
+type FindSolutionUsersResponse struct {
+	Returnval []AdminSolutionUser `xml:"returnval,omitempty"`
+}
+
+type FindUser FindUserRequestType
+
+func init() {
+	types.Add("sso:FindUser", reflect.TypeOf((*FindUser)(nil)).Elem())
+}
+
+type FindUserRequestType struct {
+	This   types.ManagedObjectReference `xml:"_this"`
+	UserId PrincipalId                  `xml:"userId"`
+}
+
+func init() {
+	types.Add("sso:FindUserRequestType", reflect.TypeOf((*FindUserRequestType)(nil)).Elem())
+}
+
+type FindUserResponse struct {
+	Returnval *AdminUser `xml:"returnval,omitempty"`
+}
+
+type FindUsers FindUsersRequestType
+
+func init() {
+	types.Add("sso:FindUsers", reflect.TypeOf((*FindUsers)(nil)).Elem())
+}
+
+type FindUsersInGroup FindUsersInGroupRequestType
+
+func init() {
+	types.Add("sso:FindUsersInGroup", reflect.TypeOf((*FindUsersInGroup)(nil)).Elem())
+}
+
+type FindUsersInGroupRequestType struct {
+	This         types.ManagedObjectReference `xml:"_this"`
+	GroupId      PrincipalId                  `xml:"groupId"`
+	SearchString string                       `xml:"searchString"`
+	Limit        int32                        `xml:"limit"`
+}
+
+func init() {
+	types.Add("sso:FindUsersInGroupRequestType", reflect.TypeOf((*FindUsersInGroupRequestType)(nil)).Elem())
+}
+
+type FindUsersInGroupResponse struct {
+	Returnval []AdminUser `xml:"returnval,omitempty"`
+}
+
+type FindUsersRequestType struct {
+	This     types.ManagedObjectReference                 `xml:"_this"`
+	Criteria AdminPrincipalDiscoveryServiceSearchCriteria `xml:"criteria"`
+	Limit    int32                                        `xml:"limit"`
+}
+
+func init() {
+	types.Add("sso:FindUsersRequestType", reflect.TypeOf((*FindUsersRequestType)(nil)).Elem())
+}
+
+type FindUsersResponse struct {
+	Returnval []AdminUser `xml:"returnval,omitempty"`
+}
+
+type GetAllCertificates GetAllCertificatesRequestType
+
+func init() {
+	types.Add("sso:GetAllCertificates", reflect.TypeOf((*GetAllCertificates)(nil)).Elem())
+}
+
+type GetAllCertificatesRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("sso:GetAllCertificatesRequestType", reflect.TypeOf((*GetAllCertificatesRequestType)(nil)).Elem())
+}
+
+type GetAllCertificatesResponse struct {
+	Returnval []string `xml:"returnval,omitempty"`
+}
+
+type GetClockTolerance GetClockToleranceRequestType
+
+func init() {
+	types.Add("sso:GetClockTolerance", reflect.TypeOf((*GetClockTolerance)(nil)).Elem())
+}
+
+type GetClockToleranceRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("sso:GetClockToleranceRequestType", reflect.TypeOf((*GetClockToleranceRequestType)(nil)).Elem())
+}
+
+type GetClockToleranceResponse struct {
+	Returnval int64 `xml:"returnval"`
+}
+
+type GetDelegationCount GetDelegationCountRequestType
+
+func init() {
+	types.Add("sso:GetDelegationCount", reflect.TypeOf((*GetDelegationCount)(nil)).Elem())
+}
+
+type GetDelegationCountRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("sso:GetDelegationCountRequestType", reflect.TypeOf((*GetDelegationCountRequestType)(nil)).Elem())
+}
+
+type GetDelegationCountResponse struct {
+	Returnval int32 `xml:"returnval"`
+}
+
+type GetDomains GetDomainsRequestType
+
+func init() {
+	types.Add("sso:GetDomains", reflect.TypeOf((*GetDomains)(nil)).Elem())
+}
+
+type GetDomainsRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("sso:GetDomainsRequestType", reflect.TypeOf((*GetDomainsRequestType)(nil)).Elem())
+}
+
+type GetDomainsResponse struct {
+	Returnval *AdminDomains `xml:"returnval,omitempty"`
+}
+
+type GetIssuersCertificates GetIssuersCertificatesRequestType
+
+func init() {
+	types.Add("sso:GetIssuersCertificates", reflect.TypeOf((*GetIssuersCertificates)(nil)).Elem())
+}
+
+type GetIssuersCertificatesRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("sso:GetIssuersCertificatesRequestType", reflect.TypeOf((*GetIssuersCertificatesRequestType)(nil)).Elem())
+}
+
+type GetIssuersCertificatesResponse struct {
+	Returnval []string `xml:"returnval"`
+}
+
+type GetKnownCertificateChains GetKnownCertificateChainsRequestType
+
+func init() {
+	types.Add("sso:GetKnownCertificateChains", reflect.TypeOf((*GetKnownCertificateChains)(nil)).Elem())
+}
+
+type GetKnownCertificateChainsRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("sso:GetKnownCertificateChainsRequestType", reflect.TypeOf((*GetKnownCertificateChainsRequestType)(nil)).Elem())
+}
+
+type GetKnownCertificateChainsResponse struct {
+	Returnval []AdminConfigurationManagementServiceCertificateChain `xml:"returnval"`
+}
+
+type GetLocalPasswordPolicy GetLocalPasswordPolicyRequestType
+
+func init() {
+	types.Add("sso:GetLocalPasswordPolicy", reflect.TypeOf((*GetLocalPasswordPolicy)(nil)).Elem())
+}
+
+type GetLocalPasswordPolicyRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("sso:GetLocalPasswordPolicyRequestType", reflect.TypeOf((*GetLocalPasswordPolicyRequestType)(nil)).Elem())
+}
+
+type GetLocalPasswordPolicyResponse struct {
+	Returnval AdminPasswordPolicy `xml:"returnval"`
+}
+
+type GetLockoutPolicy GetLockoutPolicyRequestType
+
+func init() {
+	types.Add("sso:GetLockoutPolicy", reflect.TypeOf((*GetLockoutPolicy)(nil)).Elem())
+}
+
+type GetLockoutPolicyRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("sso:GetLockoutPolicyRequestType", reflect.TypeOf((*GetLockoutPolicyRequestType)(nil)).Elem())
+}
+
+type GetLockoutPolicyResponse struct {
+	Returnval AdminLockoutPolicy `xml:"returnval"`
+}
+
+type GetMaximumBearerTokenLifetime GetMaximumBearerTokenLifetimeRequestType
+
+func init() {
+	types.Add("sso:GetMaximumBearerTokenLifetime", reflect.TypeOf((*GetMaximumBearerTokenLifetime)(nil)).Elem())
+}
+
+type GetMaximumBearerTokenLifetimeRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("sso:GetMaximumBearerTokenLifetimeRequestType", reflect.TypeOf((*GetMaximumBearerTokenLifetimeRequestType)(nil)).Elem())
+}
+
+type GetMaximumBearerTokenLifetimeResponse struct {
+	Returnval int64 `xml:"returnval"`
+}
+
+type GetMaximumHoKTokenLifetime GetMaximumHoKTokenLifetimeRequestType
+
+func init() {
+	types.Add("sso:GetMaximumHoKTokenLifetime", reflect.TypeOf((*GetMaximumHoKTokenLifetime)(nil)).Elem())
+}
+
+type GetMaximumHoKTokenLifetimeRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("sso:GetMaximumHoKTokenLifetimeRequestType", reflect.TypeOf((*GetMaximumHoKTokenLifetimeRequestType)(nil)).Elem())
+}
+
+type GetMaximumHoKTokenLifetimeResponse struct {
+	Returnval int64 `xml:"returnval"`
+}
+
+type GetPasswordExpirationConfiguration GetPasswordExpirationConfigurationRequestType
+
+func init() {
+	types.Add("sso:GetPasswordExpirationConfiguration", reflect.TypeOf((*GetPasswordExpirationConfiguration)(nil)).Elem())
+}
+
+type GetPasswordExpirationConfigurationRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("sso:GetPasswordExpirationConfigurationRequestType", reflect.TypeOf((*GetPasswordExpirationConfigurationRequestType)(nil)).Elem())
+}
+
+type GetPasswordExpirationConfigurationResponse struct {
+	Returnval AdminPasswordExpirationConfig `xml:"returnval"`
+}
+
+type GetRenewCount GetRenewCountRequestType
+
+func init() {
+	types.Add("sso:GetRenewCount", reflect.TypeOf((*GetRenewCount)(nil)).Elem())
+}
+
+type GetRenewCountRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("sso:GetRenewCountRequestType", reflect.TypeOf((*GetRenewCountRequestType)(nil)).Elem())
+}
+
+type GetRenewCountResponse struct {
+	Returnval int32 `xml:"returnval"`
+}
+
+type GetSmtpConfiguration GetSmtpConfigurationRequestType
+
+func init() {
+	types.Add("sso:GetSmtpConfiguration", reflect.TypeOf((*GetSmtpConfiguration)(nil)).Elem())
+}
+
+type GetSmtpConfigurationRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("sso:GetSmtpConfigurationRequestType", reflect.TypeOf((*GetSmtpConfigurationRequestType)(nil)).Elem())
+}
+
+type GetSmtpConfigurationResponse struct {
+	Returnval AdminSmtpConfig `xml:"returnval"`
+}
+
+type GetSslCertificateManager GetSslCertificateManagerRequestType
+
+func init() {
+	types.Add("sso:GetSslCertificateManager", reflect.TypeOf((*GetSslCertificateManager)(nil)).Elem())
+}
+
+type GetSslCertificateManagerRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("sso:GetSslCertificateManagerRequestType", reflect.TypeOf((*GetSslCertificateManagerRequestType)(nil)).Elem())
+}
+
+type GetSslCertificateManagerResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type GetSystemDomainName GetSystemDomainNameRequestType
+
+func init() {
+	types.Add("sso:GetSystemDomainName", reflect.TypeOf((*GetSystemDomainName)(nil)).Elem())
+}
+
+type GetSystemDomainNameRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("sso:GetSystemDomainNameRequestType", reflect.TypeOf((*GetSystemDomainNameRequestType)(nil)).Elem())
+}
+
+type GetSystemDomainNameResponse struct {
+	Returnval string `xml:"returnval"`
+}
+
+type GetTrustedCertificates GetTrustedCertificatesRequestType
+
+func init() {
+	types.Add("sso:GetTrustedCertificates", reflect.TypeOf((*GetTrustedCertificates)(nil)).Elem())
+}
+
+type GetTrustedCertificatesRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("sso:GetTrustedCertificatesRequestType", reflect.TypeOf((*GetTrustedCertificatesRequestType)(nil)).Elem())
+}
+
+type GetTrustedCertificatesResponse struct {
+	Returnval []string `xml:"returnval"`
+}
+
+type GroupcheckServiceContent struct {
+	types.DynamicData
+
+	SessionManager    types.ManagedObjectReference `xml:"sessionManager"`
+	GroupCheckService types.ManagedObjectReference `xml:"groupCheckService"`
+}
+
+func init() {
+	types.Add("sso:GroupcheckServiceContent", reflect.TypeOf((*GroupcheckServiceContent)(nil)).Elem())
+}
+
+type HasAdministratorRole HasAdministratorRoleRequestType
+
+func init() {
+	types.Add("sso:HasAdministratorRole", reflect.TypeOf((*HasAdministratorRole)(nil)).Elem())
+}
+
+type HasAdministratorRoleRequestType struct {
+	This   types.ManagedObjectReference `xml:"_this"`
+	UserId PrincipalId                  `xml:"userId"`
+}
+
+func init() {
+	types.Add("sso:HasAdministratorRoleRequestType", reflect.TypeOf((*HasAdministratorRoleRequestType)(nil)).Elem())
+}
+
+type HasAdministratorRoleResponse struct {
+	Returnval bool `xml:"returnval"`
+}
+
+type HasRegularUserRole HasRegularUserRoleRequestType
+
+func init() {
+	types.Add("sso:HasRegularUserRole", reflect.TypeOf((*HasRegularUserRole)(nil)).Elem())
+}
+
+type HasRegularUserRoleRequestType struct {
+	This   types.ManagedObjectReference `xml:"_this"`
+	UserId PrincipalId                  `xml:"userId"`
+}
+
+func init() {
+	types.Add("sso:HasRegularUserRoleRequestType", reflect.TypeOf((*HasRegularUserRoleRequestType)(nil)).Elem())
+}
+
+type HasRegularUserRoleResponse struct {
+	Returnval bool `xml:"returnval"`
+}
+
+type IsMemberOfGroup IsMemberOfGroupRequestType
+
+func init() {
+	types.Add("sso:IsMemberOfGroup", reflect.TypeOf((*IsMemberOfGroup)(nil)).Elem())
+}
+
+type IsMemberOfGroupRequestType struct {
+	This    types.ManagedObjectReference `xml:"_this"`
+	UserId  PrincipalId                  `xml:"userId"`
+	GroupId PrincipalId                  `xml:"groupId"`
+}
+
+func init() {
+	types.Add("sso:IsMemberOfGroupRequestType", reflect.TypeOf((*IsMemberOfGroupRequestType)(nil)).Elem())
+}
+
+type IsMemberOfGroupResponse struct {
+	Returnval bool `xml:"returnval"`
+}
+
+type Login LoginRequestType
+
+func init() {
+	types.Add("sso:Login", reflect.TypeOf((*Login)(nil)).Elem())
+}
+
+type LoginRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("sso:LoginRequestType", reflect.TypeOf((*LoginRequestType)(nil)).Elem())
+}
+
+type LoginResponse struct {
+}
+
+type Logout LogoutRequestType
+
+func init() {
+	types.Add("sso:Logout", reflect.TypeOf((*Logout)(nil)).Elem())
+}
+
+type LogoutRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("sso:LogoutRequestType", reflect.TypeOf((*LogoutRequestType)(nil)).Elem())
+}
+
+type LogoutResponse struct {
+}
+
+type PrincipalId struct {
+	types.DynamicData
+
+	Name   string `xml:"name"`
+	Domain string `xml:"domain"`
+}
+
+func init() {
+	types.Add("sso:PrincipalId", reflect.TypeOf((*PrincipalId)(nil)).Elem())
+}
+
+type ProbeConnectivity ProbeConnectivityRequestType
+
+func init() {
+	types.Add("sso:ProbeConnectivity", reflect.TypeOf((*ProbeConnectivity)(nil)).Elem())
+}
+
+type ProbeConnectivityRequestType struct {
+	This               types.ManagedObjectReference                           `xml:"_this"`
+	ServiceUri         url.URL                                                `xml:"serviceUri"`
+	AuthenticationType string                                                 `xml:"authenticationType"`
+	AuthnCredentials   *AdminDomainManagementServiceAuthenticationCredentails `xml:"authnCredentials,omitempty"`
+}
+
+func init() {
+	types.Add("sso:ProbeConnectivityRequestType", reflect.TypeOf((*ProbeConnectivityRequestType)(nil)).Elem())
+}
+
+type ProbeConnectivityResponse struct {
+}
+
+type RemoveFromLocalGroup RemoveFromLocalGroupRequestType
+
+func init() {
+	types.Add("sso:RemoveFromLocalGroup", reflect.TypeOf((*RemoveFromLocalGroup)(nil)).Elem())
+}
+
+type RemoveFromLocalGroupRequestType struct {
+	This        types.ManagedObjectReference `xml:"_this"`
+	PrincipalId PrincipalId                  `xml:"principalId"`
+	GroupName   string                       `xml:"groupName"`
+}
+
+func init() {
+	types.Add("sso:RemoveFromLocalGroupRequestType", reflect.TypeOf((*RemoveFromLocalGroupRequestType)(nil)).Elem())
+}
+
+type RemoveFromLocalGroupResponse struct {
+	Returnval bool `xml:"returnval"`
+}
+
+type RemovePrincipalsFromLocalGroup RemovePrincipalsFromLocalGroupRequestType
+
+func init() {
+	types.Add("sso:RemovePrincipalsFromLocalGroup", reflect.TypeOf((*RemovePrincipalsFromLocalGroup)(nil)).Elem())
+}
+
+type RemovePrincipalsFromLocalGroupRequestType struct {
+	This          types.ManagedObjectReference `xml:"_this"`
+	PrincipalsIds []PrincipalId                `xml:"principalsIds"`
+	GroupName     string                       `xml:"groupName"`
+}
+
+func init() {
+	types.Add("sso:RemovePrincipalsFromLocalGroupRequestType", reflect.TypeOf((*RemovePrincipalsFromLocalGroupRequestType)(nil)).Elem())
+}
+
+type RemovePrincipalsFromLocalGroupResponse struct {
+	Returnval []bool `xml:"returnval"`
+}
+
+type ResetLocalPersonUserPassword ResetLocalPersonUserPasswordRequestType
+
+func init() {
+	types.Add("sso:ResetLocalPersonUserPassword", reflect.TypeOf((*ResetLocalPersonUserPassword)(nil)).Elem())
+}
+
+type ResetLocalPersonUserPasswordRequestType struct {
+	This        types.ManagedObjectReference `xml:"_this"`
+	UserName    string                       `xml:"userName"`
+	NewPassword string                       `xml:"newPassword"`
+}
+
+func init() {
+	types.Add("sso:ResetLocalPersonUserPasswordRequestType", reflect.TypeOf((*ResetLocalPersonUserPasswordRequestType)(nil)).Elem())
+}
+
+type ResetLocalPersonUserPasswordResponse struct {
+}
+
+type ResetLocalUserPassword ResetLocalUserPasswordRequestType
+
+func init() {
+	types.Add("sso:ResetLocalUserPassword", reflect.TypeOf((*ResetLocalUserPassword)(nil)).Elem())
+}
+
+type ResetLocalUserPasswordRequestType struct {
+	This            types.ManagedObjectReference `xml:"_this"`
+	Username        string                       `xml:"username"`
+	CurrentPassword string                       `xml:"currentPassword"`
+	NewPassword     string                       `xml:"newPassword"`
+}
+
+func init() {
+	types.Add("sso:ResetLocalUserPasswordRequestType", reflect.TypeOf((*ResetLocalUserPasswordRequestType)(nil)).Elem())
+}
+
+type ResetLocalUserPasswordResponse struct {
+}
+
+type ResetSelfLocalPersonUserPassword ResetSelfLocalPersonUserPasswordRequestType
+
+func init() {
+	types.Add("sso:ResetSelfLocalPersonUserPassword", reflect.TypeOf((*ResetSelfLocalPersonUserPassword)(nil)).Elem())
+}
+
+type ResetSelfLocalPersonUserPasswordRequestType struct {
+	This        types.ManagedObjectReference `xml:"_this"`
+	NewPassword string                       `xml:"newPassword"`
+}
+
+func init() {
+	types.Add("sso:ResetSelfLocalPersonUserPasswordRequestType", reflect.TypeOf((*ResetSelfLocalPersonUserPasswordRequestType)(nil)).Elem())
+}
+
+type ResetSelfLocalPersonUserPasswordResponse struct {
+}
+
+type SendMail SendMailRequestType
+
+func init() {
+	types.Add("sso:SendMail", reflect.TypeOf((*SendMail)(nil)).Elem())
+}
+
+type SendMailRequestType struct {
+	This    types.ManagedObjectReference `xml:"_this"`
+	Content AdminMailContent             `xml:"content"`
+}
+
+func init() {
+	types.Add("sso:SendMailRequestType", reflect.TypeOf((*SendMailRequestType)(nil)).Elem())
+}
+
+type SendMailResponse struct {
+}
+
+type SetClockTolerance SetClockToleranceRequestType
+
+func init() {
+	types.Add("sso:SetClockTolerance", reflect.TypeOf((*SetClockTolerance)(nil)).Elem())
+}
+
+type SetClockToleranceRequestType struct {
+	This         types.ManagedObjectReference `xml:"_this"`
+	Milliseconds int64                        `xml:"milliseconds"`
+}
+
+func init() {
+	types.Add("sso:SetClockToleranceRequestType", reflect.TypeOf((*SetClockToleranceRequestType)(nil)).Elem())
+}
+
+type SetClockToleranceResponse struct {
+}
+
+type SetDelegationCount SetDelegationCountRequestType
+
+func init() {
+	types.Add("sso:SetDelegationCount", reflect.TypeOf((*SetDelegationCount)(nil)).Elem())
+}
+
+type SetDelegationCountRequestType struct {
+	This            types.ManagedObjectReference `xml:"_this"`
+	DelegationCount int32                        `xml:"delegationCount"`
+}
+
+func init() {
+	types.Add("sso:SetDelegationCountRequestType", reflect.TypeOf((*SetDelegationCountRequestType)(nil)).Elem())
+}
+
+type SetDelegationCountResponse struct {
+}
+
+type SetMaximumBearerTokenLifetime SetMaximumBearerTokenLifetimeRequestType
+
+func init() {
+	types.Add("sso:SetMaximumBearerTokenLifetime", reflect.TypeOf((*SetMaximumBearerTokenLifetime)(nil)).Elem())
+}
+
+type SetMaximumBearerTokenLifetimeRequestType struct {
+	This        types.ManagedObjectReference `xml:"_this"`
+	MaxLifetime int64                        `xml:"maxLifetime"`
+}
+
+func init() {
+	types.Add("sso:SetMaximumBearerTokenLifetimeRequestType", reflect.TypeOf((*SetMaximumBearerTokenLifetimeRequestType)(nil)).Elem())
+}
+
+type SetMaximumBearerTokenLifetimeResponse struct {
+}
+
+type SetMaximumHoKTokenLifetime SetMaximumHoKTokenLifetimeRequestType
+
+func init() {
+	types.Add("sso:SetMaximumHoKTokenLifetime", reflect.TypeOf((*SetMaximumHoKTokenLifetime)(nil)).Elem())
+}
+
+type SetMaximumHoKTokenLifetimeRequestType struct {
+	This        types.ManagedObjectReference `xml:"_this"`
+	MaxLifetime int64                        `xml:"maxLifetime"`
+}
+
+func init() {
+	types.Add("sso:SetMaximumHoKTokenLifetimeRequestType", reflect.TypeOf((*SetMaximumHoKTokenLifetimeRequestType)(nil)).Elem())
+}
+
+type SetMaximumHoKTokenLifetimeResponse struct {
+}
+
+type SetNewSignerIdentity SetNewSignerIdentityRequestType
+
+func init() {
+	types.Add("sso:SetNewSignerIdentity", reflect.TypeOf((*SetNewSignerIdentity)(nil)).Elem())
+}
+
+type SetNewSignerIdentityRequestType struct {
+	This                    types.ManagedObjectReference                        `xml:"_this"`
+	SigningKey              string                                              `xml:"signingKey"`
+	SigningCertificateChain AdminConfigurationManagementServiceCertificateChain `xml:"signingCertificateChain"`
+}
+
+func init() {
+	types.Add("sso:SetNewSignerIdentityRequestType", reflect.TypeOf((*SetNewSignerIdentityRequestType)(nil)).Elem())
+}
+
+type SetNewSignerIdentityResponse struct {
+}
+
+type SetRenewCount SetRenewCountRequestType
+
+func init() {
+	types.Add("sso:SetRenewCount", reflect.TypeOf((*SetRenewCount)(nil)).Elem())
+}
+
+type SetRenewCountRequestType struct {
+	This       types.ManagedObjectReference `xml:"_this"`
+	RenewCount int32                        `xml:"renewCount"`
+}
+
+func init() {
+	types.Add("sso:SetRenewCountRequestType", reflect.TypeOf((*SetRenewCountRequestType)(nil)).Elem())
+}
+
+type SetRenewCountResponse struct {
+}
+
+type SetRole SetRoleRequestType
+
+func init() {
+	types.Add("sso:SetRole", reflect.TypeOf((*SetRole)(nil)).Elem())
+}
+
+type SetRoleRequestType struct {
+	This   types.ManagedObjectReference `xml:"_this"`
+	UserId PrincipalId                  `xml:"userId"`
+	Role   string                       `xml:"role"`
+}
+
+func init() {
+	types.Add("sso:SetRoleRequestType", reflect.TypeOf((*SetRoleRequestType)(nil)).Elem())
+}
+
+type SetRoleResponse struct {
+	Returnval bool `xml:"returnval"`
+}
+
+type SetSignerIdentity SetSignerIdentityRequestType
+
+func init() {
+	types.Add("sso:SetSignerIdentity", reflect.TypeOf((*SetSignerIdentity)(nil)).Elem())
+}
+
+type SetSignerIdentityRequestType struct {
+	This                    types.ManagedObjectReference                        `xml:"_this"`
+	AdminUser               PrincipalId                                         `xml:"adminUser"`
+	AdminPass               string                                              `xml:"adminPass"`
+	SigningKey              string                                              `xml:"signingKey"`
+	SigningCertificateChain AdminConfigurationManagementServiceCertificateChain `xml:"signingCertificateChain"`
+}
+
+func init() {
+	types.Add("sso:SetSignerIdentityRequestType", reflect.TypeOf((*SetSignerIdentityRequestType)(nil)).Elem())
+}
+
+type SetSignerIdentityResponse struct {
+}
+
+type SsoAdminServiceInstance SsoAdminServiceInstanceRequestType
+
+func init() {
+	types.Add("sso:SsoAdminServiceInstance", reflect.TypeOf((*SsoAdminServiceInstance)(nil)).Elem())
+}
+
+type SsoAdminServiceInstanceRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("sso:SsoAdminServiceInstanceRequestType", reflect.TypeOf((*SsoAdminServiceInstanceRequestType)(nil)).Elem())
+}
+
+type SsoAdminServiceInstanceResponse struct {
+	Returnval AdminServiceContent `xml:"returnval"`
+}
+
+type SsoGroupcheckServiceInstance SsoGroupcheckServiceInstanceRequestType
+
+func init() {
+	types.Add("sso:SsoGroupcheckServiceInstance", reflect.TypeOf((*SsoGroupcheckServiceInstance)(nil)).Elem())
+}
+
+type SsoGroupcheckServiceInstanceRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("sso:SsoGroupcheckServiceInstanceRequestType", reflect.TypeOf((*SsoGroupcheckServiceInstanceRequestType)(nil)).Elem())
+}
+
+type SsoGroupcheckServiceInstanceResponse struct {
+	Returnval GroupcheckServiceContent `xml:"returnval"`
+}
+
+type UnlockUserAccount UnlockUserAccountRequestType
+
+func init() {
+	types.Add("sso:UnlockUserAccount", reflect.TypeOf((*UnlockUserAccount)(nil)).Elem())
+}
+
+type UnlockUserAccountRequestType struct {
+	This   types.ManagedObjectReference `xml:"_this"`
+	UserId PrincipalId                  `xml:"userId"`
+}
+
+func init() {
+	types.Add("sso:UnlockUserAccountRequestType", reflect.TypeOf((*UnlockUserAccountRequestType)(nil)).Elem())
+}
+
+type UnlockUserAccountResponse struct {
+	Returnval bool `xml:"returnval"`
+}
+
+type UpdateExternalDomainAuthnType UpdateExternalDomainAuthnTypeRequestType
+
+func init() {
+	types.Add("sso:UpdateExternalDomainAuthnType", reflect.TypeOf((*UpdateExternalDomainAuthnType)(nil)).Elem())
+}
+
+type UpdateExternalDomainAuthnTypeRequestType struct {
+	This             types.ManagedObjectReference                           `xml:"_this"`
+	Name             string                                                 `xml:"name"`
+	AuthnType        string                                                 `xml:"authnType"`
+	AuthnCredentials *AdminDomainManagementServiceAuthenticationCredentails `xml:"authnCredentials,omitempty"`
+}
+
+func init() {
+	types.Add("sso:UpdateExternalDomainAuthnTypeRequestType", reflect.TypeOf((*UpdateExternalDomainAuthnTypeRequestType)(nil)).Elem())
+}
+
+type UpdateExternalDomainAuthnTypeResponse struct {
+}
+
+type UpdateExternalDomainDetails UpdateExternalDomainDetailsRequestType
+
+func init() {
+	types.Add("sso:UpdateExternalDomainDetails", reflect.TypeOf((*UpdateExternalDomainDetails)(nil)).Elem())
+}
+
+type UpdateExternalDomainDetailsRequestType struct {
+	This    types.ManagedObjectReference `xml:"_this"`
+	Name    string                       `xml:"name"`
+	Details AdminExternalDomainDetails   `xml:"details"`
+}
+
+func init() {
+	types.Add("sso:UpdateExternalDomainDetailsRequestType", reflect.TypeOf((*UpdateExternalDomainDetailsRequestType)(nil)).Elem())
+}
+
+type UpdateExternalDomainDetailsResponse struct {
+}
+
+type UpdateLocalGroupDetails UpdateLocalGroupDetailsRequestType
+
+func init() {
+	types.Add("sso:UpdateLocalGroupDetails", reflect.TypeOf((*UpdateLocalGroupDetails)(nil)).Elem())
+}
+
+type UpdateLocalGroupDetailsRequestType struct {
+	This         types.ManagedObjectReference `xml:"_this"`
+	GroupName    string                       `xml:"groupName"`
+	GroupDetails AdminGroupDetails            `xml:"groupDetails"`
+}
+
+func init() {
+	types.Add("sso:UpdateLocalGroupDetailsRequestType", reflect.TypeOf((*UpdateLocalGroupDetailsRequestType)(nil)).Elem())
+}
+
+type UpdateLocalGroupDetailsResponse struct {
+}
+
+type UpdateLocalPasswordPolicy UpdateLocalPasswordPolicyRequestType
+
+func init() {
+	types.Add("sso:UpdateLocalPasswordPolicy", reflect.TypeOf((*UpdateLocalPasswordPolicy)(nil)).Elem())
+}
+
+type UpdateLocalPasswordPolicyRequestType struct {
+	This   types.ManagedObjectReference `xml:"_this"`
+	Policy AdminPasswordPolicy          `xml:"policy"`
+}
+
+func init() {
+	types.Add("sso:UpdateLocalPasswordPolicyRequestType", reflect.TypeOf((*UpdateLocalPasswordPolicyRequestType)(nil)).Elem())
+}
+
+type UpdateLocalPasswordPolicyResponse struct {
+}
+
+type UpdateLocalPersonUserDetails UpdateLocalPersonUserDetailsRequestType
+
+func init() {
+	types.Add("sso:UpdateLocalPersonUserDetails", reflect.TypeOf((*UpdateLocalPersonUserDetails)(nil)).Elem())
+}
+
+type UpdateLocalPersonUserDetailsRequestType struct {
+	This        types.ManagedObjectReference `xml:"_this"`
+	UserName    string                       `xml:"userName"`
+	UserDetails AdminPersonDetails           `xml:"userDetails"`
+}
+
+func init() {
+	types.Add("sso:UpdateLocalPersonUserDetailsRequestType", reflect.TypeOf((*UpdateLocalPersonUserDetailsRequestType)(nil)).Elem())
+}
+
+type UpdateLocalPersonUserDetailsResponse struct {
+}
+
+type UpdateLocalSolutionUserDetails UpdateLocalSolutionUserDetailsRequestType
+
+func init() {
+	types.Add("sso:UpdateLocalSolutionUserDetails", reflect.TypeOf((*UpdateLocalSolutionUserDetails)(nil)).Elem())
+}
+
+type UpdateLocalSolutionUserDetailsRequestType struct {
+	This        types.ManagedObjectReference `xml:"_this"`
+	UserName    string                       `xml:"userName"`
+	UserDetails AdminSolutionDetails         `xml:"userDetails"`
+}
+
+func init() {
+	types.Add("sso:UpdateLocalSolutionUserDetailsRequestType", reflect.TypeOf((*UpdateLocalSolutionUserDetailsRequestType)(nil)).Elem())
+}
+
+type UpdateLocalSolutionUserDetailsResponse struct {
+}
+
+type UpdateLockoutPolicy UpdateLockoutPolicyRequestType
+
+func init() {
+	types.Add("sso:UpdateLockoutPolicy", reflect.TypeOf((*UpdateLockoutPolicy)(nil)).Elem())
+}
+
+type UpdateLockoutPolicyRequestType struct {
+	This   types.ManagedObjectReference `xml:"_this"`
+	Policy AdminLockoutPolicy           `xml:"policy"`
+}
+
+func init() {
+	types.Add("sso:UpdateLockoutPolicyRequestType", reflect.TypeOf((*UpdateLockoutPolicyRequestType)(nil)).Elem())
+}
+
+type UpdateLockoutPolicyResponse struct {
+}
+
+type UpdatePasswordExpirationConfiguration UpdatePasswordExpirationConfigurationRequestType
+
+func init() {
+	types.Add("sso:UpdatePasswordExpirationConfiguration", reflect.TypeOf((*UpdatePasswordExpirationConfiguration)(nil)).Elem())
+}
+
+type UpdatePasswordExpirationConfigurationRequestType struct {
+	This   types.ManagedObjectReference  `xml:"_this"`
+	Config AdminPasswordExpirationConfig `xml:"config"`
+}
+
+func init() {
+	types.Add("sso:UpdatePasswordExpirationConfigurationRequestType", reflect.TypeOf((*UpdatePasswordExpirationConfigurationRequestType)(nil)).Elem())
+}
+
+type UpdatePasswordExpirationConfigurationResponse struct {
+}
+
+type UpdateSelfLocalPersonUserDetails UpdateSelfLocalPersonUserDetailsRequestType
+
+func init() {
+	types.Add("sso:UpdateSelfLocalPersonUserDetails", reflect.TypeOf((*UpdateSelfLocalPersonUserDetails)(nil)).Elem())
+}
+
+type UpdateSelfLocalPersonUserDetailsRequestType struct {
+	This        types.ManagedObjectReference `xml:"_this"`
+	UserDetails AdminPersonDetails           `xml:"userDetails"`
+}
+
+func init() {
+	types.Add("sso:UpdateSelfLocalPersonUserDetailsRequestType", reflect.TypeOf((*UpdateSelfLocalPersonUserDetailsRequestType)(nil)).Elem())
+}
+
+type UpdateSelfLocalPersonUserDetailsResponse struct {
+}
+
+type UpdateSelfLocalSolutionUserDetails UpdateSelfLocalSolutionUserDetailsRequestType
+
+func init() {
+	types.Add("sso:UpdateSelfLocalSolutionUserDetails", reflect.TypeOf((*UpdateSelfLocalSolutionUserDetails)(nil)).Elem())
+}
+
+type UpdateSelfLocalSolutionUserDetailsRequestType struct {
+	This        types.ManagedObjectReference `xml:"_this"`
+	UserDetails AdminSolutionDetails         `xml:"userDetails"`
+}
+
+func init() {
+	types.Add("sso:UpdateSelfLocalSolutionUserDetailsRequestType", reflect.TypeOf((*UpdateSelfLocalSolutionUserDetailsRequestType)(nil)).Elem())
+}
+
+type UpdateSelfLocalSolutionUserDetailsResponse struct {
+}
+
+type UpdateSmtpConfiguration UpdateSmtpConfigurationRequestType
+
+func init() {
+	types.Add("sso:UpdateSmtpConfiguration", reflect.TypeOf((*UpdateSmtpConfiguration)(nil)).Elem())
+}
+
+type UpdateSmtpConfigurationRequestType struct {
+	This   types.ManagedObjectReference `xml:"_this"`
+	Config AdminSmtpConfig              `xml:"config"`
+}
+
+func init() {
+	types.Add("sso:UpdateSmtpConfigurationRequestType", reflect.TypeOf((*UpdateSmtpConfigurationRequestType)(nil)).Elem())
+}
+
+type UpdateSmtpConfigurationResponse struct {
+}

--- a/vendor/github.com/vmware/govmomi/sts/client.go
+++ b/vendor/github.com/vmware/govmomi/sts/client.go
@@ -1,0 +1,209 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sts
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net/url"
+	"time"
+
+	"github.com/vmware/govmomi/lookup"
+	"github.com/vmware/govmomi/lookup/types"
+	"github.com/vmware/govmomi/sts/internal"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+const (
+	Namespace = "oasis:names:tc:SAML:2.0:assertion"
+	Path      = "/sts/STSService"
+)
+
+// Client is a soap.Client targeting the STS (Secure Token Service) API endpoint.
+type Client struct {
+	*soap.Client
+}
+
+// NewClient returns a client targeting the STS API endpoint.
+// The Client.URL will be set to that of the Lookup Service's endpoint registration,
+// as the SSO endpoint can be external to vCenter.  If the Lookup Service is not available,
+// URL defaults to Path on the vim25.Client.URL.Host.
+func NewClient(ctx context.Context, c *vim25.Client) (*Client, error) {
+	filter := &types.LookupServiceRegistrationFilter{
+		ServiceType: &types.LookupServiceRegistrationServiceType{
+			Product: "com.vmware.cis",
+			Type:    "cs.identity",
+		},
+		EndpointType: &types.LookupServiceRegistrationEndpointType{
+			Protocol: "wsTrust",
+			Type:     "com.vmware.cis.cs.identity.sso",
+		},
+	}
+
+	url := lookup.EndpointURL(ctx, c, Path, filter)
+	sc := c.Client.NewServiceClient(url, Namespace)
+
+	return &Client{sc}, nil
+}
+
+// TokenRequest parameters for issuing a SAML token.
+// At least one of Userinfo or Certificate must be specified.
+type TokenRequest struct {
+	Userinfo    *url.Userinfo    // Userinfo when set issues a Bearer token
+	Certificate *tls.Certificate // Certificate when set issues a HoK token
+	Lifetime    time.Duration    // Lifetime is the token's lifetime, defaults to 10m
+	Renewable   bool             // Renewable allows the issued token to be renewed
+	Delegatable bool             // Delegatable allows the issued token to be delegated (e.g. for use with ActAs)
+	ActAs       bool             // ActAs allows to request an ActAs token based on the passed Token.
+	Token       string           // Token for Renew request or Issue request ActAs identity or to be exchanged.
+	KeyType     string           // KeyType for requested token (if not set will be decucted from Userinfo and Certificate options)
+	KeyID       string           // KeyID used for signing the requests
+}
+
+func (c *Client) newRequest(req TokenRequest, kind string, s *Signer) (internal.RequestSecurityToken, error) {
+	if req.Lifetime == 0 {
+		req.Lifetime = 5 * time.Minute
+	}
+
+	created := time.Now().UTC()
+	rst := internal.RequestSecurityToken{
+		TokenType:          c.Namespace,
+		RequestType:        "http://docs.oasis-open.org/ws-sx/ws-trust/200512/" + kind,
+		SignatureAlgorithm: internal.SHA256,
+		Lifetime: &internal.Lifetime{
+			Created: created.Format(internal.Time),
+			Expires: created.Add(req.Lifetime).Format(internal.Time),
+		},
+		Renewing: &internal.Renewing{
+			Allow: req.Renewable,
+			// /wst:RequestSecurityToken/wst:Renewing/@OK
+			// "It NOT RECOMMENDED to use this as it can leave you open to certain types of security attacks.
+			// Issuers MAY restrict the period after expiration during which time the token can be renewed.
+			// This window is governed by the issuer's policy."
+			OK: false,
+		},
+		Delegatable: req.Delegatable,
+		KeyType:     req.KeyType,
+	}
+
+	if req.KeyType == "" {
+		// Deduce KeyType based on Certificate nad Userinfo.
+		if req.Certificate == nil {
+			if req.Userinfo == nil {
+				return rst, errors.New("one of TokenRequest Certificate or Userinfo is required")
+			}
+			rst.KeyType = "http://docs.oasis-open.org/ws-sx/ws-trust/200512/Bearer"
+		} else {
+			rst.KeyType = "http://docs.oasis-open.org/ws-sx/ws-trust/200512/PublicKey"
+			// For HOK KeyID is required.
+			if req.KeyID == "" {
+				req.KeyID = newID()
+			}
+		}
+	}
+
+	if req.KeyID != "" {
+		rst.UseKey = &internal.UseKey{Sig: req.KeyID}
+		s.keyID = rst.UseKey.Sig
+	}
+
+	return rst, nil
+}
+
+func (s *Signer) setLifetime(lifetime *internal.Lifetime) error {
+	var err error
+	if lifetime != nil {
+		s.Lifetime.Created, err = time.Parse(internal.Time, lifetime.Created)
+		if err == nil {
+			s.Lifetime.Expires, err = time.Parse(internal.Time, lifetime.Expires)
+		}
+	}
+	return err
+}
+
+// Issue is used to request a security token.
+// The returned Signer can be used to sign SOAP requests, such as the SessionManager LoginByToken method and the RequestSecurityToken method itself.
+// One of TokenRequest Certificate or Userinfo is required, with Certificate taking precedence.
+// When Certificate is set, a Holder-of-Key token will be requested.  Otherwise, a Bearer token is requested with the Userinfo credentials.
+// See: http://docs.oasis-open.org/ws-sx/ws-trust/v1.4/errata01/os/ws-trust-1.4-errata01-os-complete.html#_Toc325658937
+func (c *Client) Issue(ctx context.Context, req TokenRequest) (*Signer, error) {
+	s := &Signer{
+		Certificate: req.Certificate,
+		keyID:       req.KeyID,
+		Token:       req.Token,
+		user:        req.Userinfo,
+	}
+
+	rst, err := c.newRequest(req, "Issue", s)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.ActAs {
+		rst.ActAs = &internal.Target{
+			Token: req.Token,
+		}
+	}
+
+	header := soap.Header{
+		Security: s,
+		Action:   rst.Action(),
+	}
+
+	res, err := internal.Issue(c.WithHeader(ctx, header), c, &rst)
+	if err != nil {
+		return nil, err
+	}
+
+	s.Token = res.RequestSecurityTokenResponse.RequestedSecurityToken.Assertion
+
+	return s, s.setLifetime(res.RequestSecurityTokenResponse.Lifetime)
+}
+
+// Renew is used to request a security token renewal.
+func (c *Client) Renew(ctx context.Context, req TokenRequest) (*Signer, error) {
+	s := &Signer{
+		Certificate: req.Certificate,
+	}
+
+	rst, err := c.newRequest(req, "Renew", s)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.Token == "" {
+		return nil, errors.New("TokenRequest Token is required")
+	}
+
+	rst.RenewTarget = &internal.Target{Token: req.Token}
+
+	header := soap.Header{
+		Security: s,
+		Action:   rst.Action(),
+	}
+
+	res, err := internal.Renew(c.WithHeader(ctx, header), c, &rst)
+	if err != nil {
+		return nil, err
+	}
+
+	s.Token = res.RequestedSecurityToken.Assertion
+
+	return s, s.setLifetime(res.Lifetime)
+}

--- a/vendor/github.com/vmware/govmomi/sts/signer.go
+++ b/vendor/github.com/vmware/govmomi/sts/signer.go
@@ -1,0 +1,330 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sts
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	mrand "math/rand"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/vmware/govmomi/sts/internal"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/xml"
+)
+
+// Signer implements the soap.Signer interface.
+type Signer struct {
+	Token       string           // Token is a SAML token
+	Certificate *tls.Certificate // Certificate is used to sign requests
+	Lifetime    struct {
+		Created time.Time
+		Expires time.Time
+	}
+	user  *url.Userinfo // user contains the credentials for bearer token request
+	keyID string        // keyID is the Signature UseKey ID, which is referenced in both the soap body and header
+}
+
+// signedEnvelope is similar to soap.Envelope, but with namespace and Body as innerxml
+type signedEnvelope struct {
+	XMLName xml.Name    `xml:"soap:Envelope"`
+	NS      string      `xml:"xmlns:soap,attr"`
+	Header  soap.Header `xml:"soap:Header"`
+	Body    string      `xml:",innerxml"`
+}
+
+// newID returns a unique Reference ID, with a leading underscore as required by STS.
+func newID() string {
+	return "_" + uuid.New().String()
+}
+
+func (s *Signer) setTokenReference(info *internal.KeyInfo) error {
+	var token struct {
+		ID       string `xml:",attr"`     // parse saml2:Assertion ID attribute
+		InnerXML string `xml:",innerxml"` // no need to parse the entire token
+	}
+	if err := xml.Unmarshal([]byte(s.Token), &token); err != nil {
+		return err
+	}
+
+	info.SecurityTokenReference = &internal.SecurityTokenReference{
+		WSSE11:    "http://docs.oasis-open.org/wss/oasis-wss-wssecurity-secext-1.1.xsd",
+		TokenType: "http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV2.0",
+		KeyIdentifier: &internal.KeyIdentifier{
+			ID:        token.ID,
+			ValueType: "http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLID",
+		},
+	}
+
+	return nil
+}
+
+// Sign is a soap.Signer implementation which can be used to sign RequestSecurityToken and LoginByTokenBody requests.
+func (s *Signer) Sign(env soap.Envelope) ([]byte, error) {
+	var key *rsa.PrivateKey
+	hasKey := false
+	if s.Certificate != nil {
+		key, hasKey = s.Certificate.PrivateKey.(*rsa.PrivateKey)
+		if !hasKey {
+			return nil, errors.New("sts: rsa.PrivateKey is required")
+		}
+	}
+
+	created := time.Now().UTC()
+	header := &internal.Security{
+		WSU:  internal.WSU,
+		WSSE: "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd",
+		Timestamp: internal.Timestamp{
+			NS:      internal.WSU,
+			ID:      newID(),
+			Created: created.Format(internal.Time),
+			Expires: created.Add(time.Minute).Format(internal.Time), // If STS receives this request after this, it is assumed to have expired.
+		},
+	}
+	env.Header.Security = header
+
+	info := internal.KeyInfo{XMLName: xml.Name{Local: "ds:KeyInfo"}}
+	var c14n, body string
+	type requestToken interface {
+		RequestSecurityToken() *internal.RequestSecurityToken
+	}
+
+	switch x := env.Body.(type) {
+	case requestToken:
+		if hasKey {
+			// We need c14n for all requests, as its digest is included in the signature and must match on the server side.
+			// We need the body in original form when using an ActAs or RenewTarget token, where the token and its signature are embedded in the body.
+			req := x.RequestSecurityToken()
+			c14n = req.C14N()
+			body = req.String()
+			id := newID()
+
+			info.SecurityTokenReference = &internal.SecurityTokenReference{
+				Reference: &internal.SecurityReference{
+					URI:       "#" + id,
+					ValueType: "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3",
+				},
+			}
+
+			header.BinarySecurityToken = &internal.BinarySecurityToken{
+				EncodingType: "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary",
+				ValueType:    "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3",
+				ID:           id,
+				Value:        base64.StdEncoding.EncodeToString(s.Certificate.Certificate[0]),
+			}
+		}
+		// When requesting HoK token for interactive user, request will have both priv. key and username/password.
+		if s.user.Username() != "" {
+			header.UsernameToken = &internal.UsernameToken{
+				Username: s.user.Username(),
+			}
+			header.UsernameToken.Password, _ = s.user.Password()
+		}
+	case *methods.LoginByTokenBody:
+		header.Assertion = s.Token
+
+		if hasKey {
+			if err := s.setTokenReference(&info); err != nil {
+				return nil, err
+			}
+
+			c14n = internal.Marshal(x.Req)
+		}
+	default:
+		// We can end up here via ssoadmin.SessionManager.Login().
+		// No other known cases where a signed request is needed.
+		header.Assertion = s.Token
+		if hasKey {
+			if err := s.setTokenReference(&info); err != nil {
+				return nil, err
+			}
+			type Req interface {
+				C14N() string
+			}
+			c14n = env.Body.(Req).C14N()
+		}
+	}
+
+	if !hasKey {
+		return xml.Marshal(env) // Bearer token without key to sign
+	}
+
+	id := newID()
+	tmpl := `<soap:Body xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:wsu="%s" wsu:Id="%s">%s</soap:Body>`
+	c14n = fmt.Sprintf(tmpl, internal.WSU, id, c14n)
+	if body == "" {
+		body = c14n
+	} else {
+		body = fmt.Sprintf(tmpl, internal.WSU, id, body)
+	}
+
+	header.Signature = &internal.Signature{
+		XMLName: xml.Name{Local: "ds:Signature"},
+		NS:      internal.DSIG,
+		ID:      s.keyID,
+		KeyInfo: info,
+		SignedInfo: internal.SignedInfo{
+			XMLName: xml.Name{Local: "ds:SignedInfo"},
+			NS:      internal.DSIG,
+			CanonicalizationMethod: internal.Method{
+				XMLName:   xml.Name{Local: "ds:CanonicalizationMethod"},
+				Algorithm: "http://www.w3.org/2001/10/xml-exc-c14n#",
+			},
+			SignatureMethod: internal.Method{
+				XMLName:   xml.Name{Local: "ds:SignatureMethod"},
+				Algorithm: internal.SHA256,
+			},
+			Reference: []internal.Reference{
+				internal.NewReference(header.Timestamp.ID, header.Timestamp.C14N()),
+				internal.NewReference(id, c14n),
+			},
+		},
+	}
+
+	sum := sha256.Sum256([]byte(header.Signature.SignedInfo.C14N()))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, sum[:])
+	if err != nil {
+		return nil, err
+	}
+
+	header.Signature.SignatureValue = internal.Value{
+		XMLName: xml.Name{Local: "ds:SignatureValue"},
+		Value:   base64.StdEncoding.EncodeToString(sig),
+	}
+
+	return xml.Marshal(signedEnvelope{
+		NS:     "http://schemas.xmlsoap.org/soap/envelope/",
+		Header: *env.Header,
+		Body:   body,
+	})
+}
+
+// SignRequest is a rest.Signer implementation which can be used to sign rest.Client.LoginByTokenBody requests.
+func (s *Signer) SignRequest(req *http.Request) error {
+	type param struct {
+		key, val string
+	}
+	var params []string
+	add := func(p param) {
+		params = append(params, fmt.Sprintf(`%s="%s"`, p.key, p.val))
+	}
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	if _, err := io.WriteString(gz, s.Token); err != nil {
+		return fmt.Errorf("zip token: %s", err)
+	}
+	if err := gz.Close(); err != nil {
+		return fmt.Errorf("zip token: %s", err)
+	}
+	add(param{
+		key: "token",
+		val: base64.StdEncoding.EncodeToString(buf.Bytes()),
+	})
+
+	if s.Certificate != nil {
+		nonce := fmt.Sprintf("%d:%d", time.Now().UnixNano()/1e6, mrand.Int())
+		var body []byte
+		if req.GetBody != nil {
+			r, rerr := req.GetBody()
+			if rerr != nil {
+				return fmt.Errorf("sts: getting http.Request body: %s", rerr)
+			}
+			defer r.Close()
+			body, rerr = ioutil.ReadAll(r)
+			if rerr != nil {
+				return fmt.Errorf("sts: reading http.Request body: %s", rerr)
+			}
+		}
+		bhash := sha256.New().Sum(body)
+
+		port := req.URL.Port()
+		if port == "" {
+			port = "80" // Default port for the "Host" header on the server side
+		}
+
+		var buf bytes.Buffer
+		msg := []string{
+			nonce,
+			req.Method,
+			req.URL.Path,
+			strings.ToLower(req.URL.Hostname()),
+			port,
+		}
+		for i := range msg {
+			buf.WriteString(msg[i])
+			buf.WriteByte('\n')
+		}
+		buf.Write(bhash)
+		buf.WriteByte('\n')
+
+		sum := sha256.Sum256(buf.Bytes())
+		key, ok := s.Certificate.PrivateKey.(*rsa.PrivateKey)
+		if !ok {
+			return errors.New("sts: rsa.PrivateKey is required to sign http.Request")
+		}
+		sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, sum[:])
+		if err != nil {
+			return err
+		}
+
+		add(param{
+			key: "signature_alg",
+			val: "RSA-SHA256",
+		})
+		add(param{
+			key: "signature",
+			val: base64.StdEncoding.EncodeToString(sig),
+		})
+		add(param{
+			key: "nonce",
+			val: nonce,
+		})
+		add(param{
+			key: "bodyhash",
+			val: base64.StdEncoding.EncodeToString(bhash),
+		})
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("SIGN %s", strings.Join(params, ", ")))
+
+	return nil
+}
+
+func (s *Signer) NewRequest() TokenRequest {
+	return TokenRequest{
+		Token:       s.Token,
+		Certificate: s.Certificate,
+		Userinfo:    s.user,
+		KeyID:       s.keyID,
+	}
+}

--- a/vendor/github.com/vmware/govmomi/units/size.go
+++ b/vendor/github.com/vmware/govmomi/units/size.go
@@ -1,0 +1,109 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package units
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+type ByteSize int64
+
+const (
+	_  = iota
+	KB = 1 << (10 * iota)
+	MB
+	GB
+	TB
+	PB
+	EB
+)
+
+func (b ByteSize) String() string {
+	switch {
+	case b >= EB:
+		return fmt.Sprintf("%.1fEB", float32(b)/EB)
+	case b >= PB:
+		return fmt.Sprintf("%.1fPB", float32(b)/PB)
+	case b >= TB:
+		return fmt.Sprintf("%.1fTB", float32(b)/TB)
+	case b >= GB:
+		return fmt.Sprintf("%.1fGB", float32(b)/GB)
+	case b >= MB:
+		return fmt.Sprintf("%.1fMB", float32(b)/MB)
+	case b >= KB:
+		return fmt.Sprintf("%.1fKB", float32(b)/KB)
+	}
+	return fmt.Sprintf("%dB", b)
+}
+
+type FileSize int64
+
+func (b FileSize) String() string {
+	switch {
+	case b >= EB:
+		return fmt.Sprintf("%.1fE", float32(b)/EB)
+	case b >= PB:
+		return fmt.Sprintf("%.1fP", float32(b)/PB)
+	case b >= TB:
+		return fmt.Sprintf("%.1fT", float32(b)/TB)
+	case b >= GB:
+		return fmt.Sprintf("%.1fG", float32(b)/GB)
+	case b >= MB:
+		return fmt.Sprintf("%.1fM", float32(b)/MB)
+	case b >= KB:
+		return fmt.Sprintf("%.1fK", float32(b)/KB)
+	}
+	return fmt.Sprintf("%d", b)
+}
+
+var bytesRegexp = regexp.MustCompile(`^(?i)(\d+)([BKMGTPE]?)(ib|b)?$`)
+
+func (b *ByteSize) Set(s string) error {
+	m := bytesRegexp.FindStringSubmatch(s)
+	if len(m) == 0 {
+		return errors.New("invalid byte value")
+	}
+
+	i, err := strconv.ParseInt(m[1], 10, 64)
+	if err != nil {
+		return err
+	}
+	*b = ByteSize(i)
+
+	switch m[2] {
+	case "B", "b", "":
+	case "K", "k":
+		*b *= ByteSize(KB)
+	case "M", "m":
+		*b *= ByteSize(MB)
+	case "G", "g":
+		*b *= ByteSize(GB)
+	case "T", "t":
+		*b *= ByteSize(TB)
+	case "P", "p":
+		*b *= ByteSize(PB)
+	case "E", "e":
+		*b *= ByteSize(EB)
+	default:
+		return errors.New("invalid byte suffix")
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/vapi/library/finder/finder.go
+++ b/vendor/github.com/vmware/govmomi/vapi/library/finder/finder.go
@@ -1,0 +1,328 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package finder
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/vmware/govmomi/vapi/library"
+)
+
+// Finder is a helper object for finding content library objects by their
+// inventory paths: /LIBRARY/ITEM/FILE.
+//
+// Wildcard characters `*` and `?` are both supported. However, the use
+// of a wildcard character in the search string results in a full listing of
+// that part of the path's server-side items.
+//
+// Path parts that do not use wildcard characters rely on server-side Find
+// functions to find the path token by its name. Ironically finding one
+// item with a direct path takes longer than if a wildcard is used because
+// of the multiple round-trips. Direct paths will be more performant on
+// systems that have numerous items.
+type Finder struct {
+	M *library.Manager
+}
+
+// NewFinder returns a new Finder.
+func NewFinder(m *library.Manager) *Finder {
+	return &Finder{m}
+}
+
+// Find finds one or more items that match the provided inventory path(s).
+func (f *Finder) Find(
+	ctx context.Context, ipath ...string) ([]FindResult, error) {
+
+	if len(ipath) == 0 {
+		ipath = []string{""}
+	}
+	var result []FindResult
+	for _, p := range ipath {
+		results, err := f.find(ctx, p)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, results...)
+	}
+	return result, nil
+}
+
+func (f *Finder) find(ctx context.Context, ipath string) ([]FindResult, error) {
+
+	if ipath == "" {
+		ipath = "*"
+	}
+
+	// Get the argument and remove any leading separator characters.
+	ipath = strings.TrimPrefix(ipath, "/")
+
+	// Tokenize the path into its distinct parts.
+	parts := strings.Split(ipath, "/")
+
+	// If there are more than three parts then the file name contains
+	// the "/" character. In that case collapse any additional parts
+	// back into the filename.
+	if len(parts) > 3 {
+		parts = []string{
+			parts[0],
+			parts[1],
+			strings.Join(parts[2:], "/"),
+		}
+	}
+
+	libs, err := f.findLibraries(ctx, parts[0])
+	if err != nil {
+		return nil, err
+	}
+
+	// If the path is a single token then the libraries are requested.
+	if len(parts) < 2 {
+		return libs, nil
+	}
+
+	items, err := f.findLibraryItems(ctx, libs, parts[1])
+	if err != nil {
+		return nil, err
+	}
+
+	// If the path is two tokens then the library items are requested.
+	if len(parts) < 3 {
+		return items, nil
+	}
+
+	// Get the library item files.
+	return f.findLibraryItemFiles(ctx, items, parts[2])
+}
+
+// FindResult is the type of object returned from a Find operation.
+type FindResult interface {
+
+	// GetParent returns the parent of the find result. If the find result
+	// is a Library then this function will return nil.
+	GetParent() FindResult
+
+	// GetPath returns the inventory path of the find result.
+	GetPath() string
+
+	// GetID returns the ID of the find result.
+	GetID() string
+
+	// GetName returns the name of the find result.
+	GetName() string
+
+	// GetResult gets the underlying library object.
+	GetResult() interface{}
+}
+
+type findResult struct {
+	result interface{}
+	parent FindResult
+}
+
+func (f findResult) GetResult() interface{} {
+	return f.result
+}
+func (f findResult) GetParent() FindResult {
+	return f.parent
+}
+func (f findResult) GetPath() string {
+	switch f.result.(type) {
+	case library.Library:
+		return fmt.Sprintf("/%s", f.GetName())
+	case library.Item, library.File:
+		return fmt.Sprintf("%s/%s", f.parent.GetPath(), f.GetName())
+	default:
+		return ""
+	}
+}
+
+func (f findResult) GetID() string {
+	switch t := f.result.(type) {
+	case library.Library:
+		return t.ID
+	case library.Item:
+		return t.ID
+	default:
+		return ""
+	}
+}
+
+func (f findResult) GetName() string {
+	switch t := f.result.(type) {
+	case library.Library:
+		return t.Name
+	case library.Item:
+		return t.Name
+	case library.File:
+		return t.Name
+	default:
+		return ""
+	}
+}
+
+func (f findResult) MarshalJSON() ([]byte, error) {
+	return json.Marshal(f.GetResult())
+}
+
+func (f *Finder) findLibraries(
+	ctx context.Context,
+	token string) ([]FindResult, error) {
+
+	if token == "" {
+		token = "*"
+	}
+
+	var result []FindResult
+
+	// If the token does not contain any wildcard characters then perform
+	// a lookup by name using a server side call.
+	if !strings.ContainsAny(token, "*?") {
+		libIDs, err := f.M.FindLibrary(ctx, library.Find{Name: token})
+		if err != nil {
+			return nil, err
+		}
+		for _, id := range libIDs {
+			lib, err := f.M.GetLibraryByID(ctx, id)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, findResult{result: *lib})
+		}
+		if len(result) == 0 {
+			lib, err := f.M.GetLibraryByID(ctx, token)
+			if err == nil {
+				result = append(result, findResult{result: *lib})
+			}
+		}
+		return result, nil
+	}
+
+	libs, err := f.M.GetLibraries(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, lib := range libs {
+		match, err := path.Match(token, lib.Name)
+		if err != nil {
+			return nil, err
+		}
+		if match {
+			result = append(result, findResult{result: lib})
+		}
+	}
+	return result, nil
+}
+
+func (f *Finder) findLibraryItems(
+	ctx context.Context,
+	parents []FindResult, token string) ([]FindResult, error) {
+
+	if token == "" {
+		token = "*"
+	}
+
+	var result []FindResult
+
+	for _, parent := range parents {
+		// If the token does not contain any wildcard characters then perform
+		// a lookup by name using a server side call.
+		if !strings.ContainsAny(token, "*?") {
+			childIDs, err := f.M.FindLibraryItems(
+				ctx, library.FindItem{
+					Name:      token,
+					LibraryID: parent.GetID(),
+				})
+			if err != nil {
+				return nil, err
+			}
+			for _, id := range childIDs {
+				child, err := f.M.GetLibraryItem(ctx, id)
+				if err != nil {
+					return nil, err
+				}
+				result = append(result, findResult{
+					result: *child,
+					parent: parent,
+				})
+			}
+			continue
+		}
+
+		children, err := f.M.GetLibraryItems(ctx, parent.GetID())
+		if err != nil {
+			return nil, err
+		}
+		for _, child := range children {
+			match, err := path.Match(token, child.Name)
+			if err != nil {
+				return nil, err
+			}
+			if match {
+				result = append(
+					result, findResult{parent: parent, result: child})
+			}
+		}
+	}
+	return result, nil
+}
+
+func (f *Finder) findLibraryItemFiles(
+	ctx context.Context,
+	parents []FindResult, token string) ([]FindResult, error) {
+
+	if token == "" {
+		token = "*"
+	}
+
+	var result []FindResult
+
+	for _, parent := range parents {
+		// If the token does not contain any wildcard characters then perform
+		// a lookup by name using a server side call.
+		if !strings.ContainsAny(token, "*?") {
+			child, err := f.M.GetLibraryItemFile(ctx, parent.GetID(), token)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, findResult{
+				result: *child,
+				parent: parent,
+			})
+			continue
+		}
+
+		children, err := f.M.ListLibraryItemFiles(ctx, parent.GetID())
+		if err != nil {
+			return nil, err
+		}
+		for _, child := range children {
+			match, err := path.Match(token, child.Name)
+			if err != nil {
+				return nil, err
+			}
+			if match {
+				result = append(
+					result, findResult{parent: parent, result: child})
+			}
+		}
+	}
+	return result, nil
+}

--- a/vendor/github.com/vmware/govmomi/vmdk/import.go
+++ b/vendor/github.com/vmware/govmomi/vmdk/import.go
@@ -1,0 +1,342 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+nSee the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vmdk
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/ovf"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/progress"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+var (
+	ErrInvalidFormat = errors.New("vmdk: invalid format (must be streamOptimized)")
+)
+
+// info is used to inspect a vmdk and generate an ovf template
+type info struct {
+	Header struct {
+		MagicNumber uint32
+		Version     uint32
+		Flags       uint32
+		Capacity    uint64
+	}
+
+	Capacity   uint64
+	Size       int64
+	Name       string
+	ImportName string
+}
+
+// stat looks at the vmdk header to make sure the format is streamOptimized and
+// extracts the disk capacity required to properly generate the ovf descriptor.
+func stat(name string) (*info, error) {
+	f, err := os.Open(filepath.Clean(name))
+	if err != nil {
+		return nil, err
+	}
+
+	var di info
+
+	var buf bytes.Buffer
+
+	_, err = io.CopyN(&buf, f, int64(binary.Size(di.Header)))
+	if err != nil {
+		return nil, err
+	}
+
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	err = f.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	err = binary.Read(&buf, binary.LittleEndian, &di.Header)
+	if err != nil {
+		return nil, err
+	}
+
+	if di.Header.MagicNumber != 0x564d444b { // SPARSE_MAGICNUMBER
+		return nil, ErrInvalidFormat
+	}
+
+	if di.Header.Flags&(1<<16) == 0 { // SPARSEFLAG_COMPRESSED
+		// Needs to be converted, for example:
+		//   vmware-vdiskmanager -r src.vmdk -t 5 dst.vmdk
+		//   qemu-img convert -O vmdk -o subformat=streamOptimized src.vmdk dst.vmdk
+		return nil, ErrInvalidFormat
+	}
+
+	di.Capacity = di.Header.Capacity * 512 // VMDK_SECTOR_SIZE
+	di.Size = fi.Size()
+	di.Name = filepath.Base(name)
+	di.ImportName = strings.TrimSuffix(di.Name, ".vmdk")
+
+	return &di, nil
+}
+
+// ovfenv is the minimal descriptor template required to import a vmdk
+var ovfenv = `<?xml version="1.0" encoding="UTF-8"?>
+<Envelope xmlns="http://schemas.dmtf.org/ovf/envelope/1"
+          xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1"
+          xmlns:cim="http://schemas.dmtf.org/wbem/wscim/1/common"
+          xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData"
+          xmlns:vmw="http://www.vmware.com/schema/ovf"
+          xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <References>
+    <File ovf:href="{{ .Name }}" ovf:id="file1" ovf:size="{{ .Size }}"/>
+  </References>
+  <DiskSection>
+    <Info>Virtual disk information</Info>
+    <Disk ovf:capacity="{{ .Capacity }}" ovf:capacityAllocationUnits="byte" ovf:diskId="vmdisk1" ovf:fileRef="file1" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized" ovf:populatedSize="0"/>
+  </DiskSection>
+  <VirtualSystem ovf:id="{{ .ImportName }}">
+    <Info>A virtual machine</Info>
+    <Name>{{ .ImportName }}</Name>
+    <OperatingSystemSection ovf:id="100" vmw:osType="other26xLinux64Guest">
+      <Info>The kind of installed guest operating system</Info>
+    </OperatingSystemSection>
+    <VirtualHardwareSection>
+      <Info>Virtual hardware requirements</Info>
+      <System>
+        <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+        <vssd:InstanceID>0</vssd:InstanceID>
+        <vssd:VirtualSystemIdentifier>{{ .ImportName }}</vssd:VirtualSystemIdentifier>
+        <vssd:VirtualSystemType>vmx-07</vssd:VirtualSystemType>
+      </System>
+      <Item>
+        <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+        <rasd:Description>Number of Virtual CPUs</rasd:Description>
+        <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
+        <rasd:InstanceID>1</rasd:InstanceID>
+        <rasd:ResourceType>3</rasd:ResourceType>
+        <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+        <rasd:Description>Memory Size</rasd:Description>
+        <rasd:ElementName>1024MB of memory</rasd:ElementName>
+        <rasd:InstanceID>2</rasd:InstanceID>
+        <rasd:ResourceType>4</rasd:ResourceType>
+        <rasd:VirtualQuantity>1024</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:Address>0</rasd:Address>
+        <rasd:Description>SCSI Controller</rasd:Description>
+        <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
+        <rasd:InstanceID>3</rasd:InstanceID>
+        <rasd:ResourceSubType>VirtualSCSI</rasd:ResourceSubType>
+        <rasd:ResourceType>6</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>0</rasd:AddressOnParent>
+        <rasd:ElementName>Hard Disk 1</rasd:ElementName>
+        <rasd:HostResource>ovf:/disk/vmdisk1</rasd:HostResource>
+        <rasd:InstanceID>9</rasd:InstanceID>
+        <rasd:Parent>3</rasd:Parent>
+        <rasd:ResourceType>17</rasd:ResourceType>
+        <vmw:Config ovf:required="false" vmw:key="backing.writeThrough" vmw:value="false"/>
+      </Item>
+    </VirtualHardwareSection>
+  </VirtualSystem>
+</Envelope>`
+
+// ovf returns an expanded descriptor template
+func (di *info) ovf() (string, error) {
+	var buf bytes.Buffer
+
+	tmpl, err := template.New("ovf").Parse(ovfenv)
+	if err != nil {
+		return "", err
+	}
+
+	err = tmpl.Execute(&buf, di)
+	if err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+// ImportParams contains the set of optional params to the Import function.
+// Note that "optional" may depend on environment, such as ESX or vCenter.
+type ImportParams struct {
+	Path       string
+	Logger     progress.Sinker
+	Type       types.VirtualDiskType
+	Force      bool
+	Datacenter *object.Datacenter
+	Pool       *object.ResourcePool
+	Folder     *object.Folder
+	Host       *object.HostSystem
+}
+
+// Import uploads a local vmdk file specified by name to the given datastore.
+func Import(ctx context.Context, c *vim25.Client, name string, datastore *object.Datastore, p ImportParams) error {
+	m := ovf.NewManager(c)
+	fm := datastore.NewFileManager(p.Datacenter, p.Force)
+
+	disk, err := stat(name)
+	if err != nil {
+		return err
+	}
+
+	var rename string
+
+	p.Path = strings.TrimSuffix(p.Path, "/")
+	if p.Path != "" {
+		disk.ImportName = p.Path
+		rename = path.Join(disk.ImportName, disk.Name)
+	}
+
+	// "target" is the path that will be created by ImportVApp()
+	// ImportVApp uses the same name for the VM and the disk.
+	target := fmt.Sprintf("%s/%s.vmdk", disk.ImportName, disk.ImportName)
+
+	if _, err = datastore.Stat(ctx, target); err == nil {
+		if p.Force {
+			// If we don't delete, the nfc upload adds a file name suffix
+			if err = fm.Delete(ctx, target); err != nil {
+				return err
+			}
+		} else {
+			return fmt.Errorf("%s: %s", os.ErrExist, datastore.Path(target))
+		}
+	}
+
+	// If we need to rename at the end, check if the file exists early unless Force.
+	if !p.Force && rename != "" {
+		if _, err = datastore.Stat(ctx, rename); err == nil {
+			return fmt.Errorf("%s: %s", os.ErrExist, datastore.Path(rename))
+		}
+	}
+
+	// Expand the ovf template
+	descriptor, err := disk.ovf()
+	if err != nil {
+		return err
+	}
+
+	pool := p.Pool     // TODO: use datastore to derive a default
+	folder := p.Folder // TODO: use datacenter to derive a default
+
+	kind := p.Type
+	if kind == "" {
+		kind = types.VirtualDiskTypeThin
+	}
+
+	params := types.OvfCreateImportSpecParams{
+		DiskProvisioning: string(kind),
+		EntityName:       disk.ImportName,
+	}
+
+	spec, err := m.CreateImportSpec(ctx, descriptor, pool, datastore, params)
+	if err != nil {
+		return err
+	}
+	if spec.Error != nil {
+		return errors.New(spec.Error[0].LocalizedMessage)
+	}
+
+	lease, err := pool.ImportVApp(ctx, spec.ImportSpec, folder, p.Host)
+	if err != nil {
+		return err
+	}
+
+	info, err := lease.Wait(ctx, spec.FileItem)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Open(filepath.Clean(name))
+	if err != nil {
+		return err
+	}
+
+	opts := soap.Upload{
+		ContentLength: disk.Size,
+		Progress:      p.Logger,
+	}
+
+	u := lease.StartUpdater(ctx, info)
+	defer u.Done()
+
+	item := info.Items[0] // we only have 1 disk to upload
+
+	err = lease.Upload(ctx, item, f, opts)
+	if err != nil {
+		return err
+	}
+
+	err = f.Close()
+	if err != nil {
+		return err
+	}
+
+	if err = lease.Complete(ctx); err != nil {
+		return err
+	}
+
+	// ImportVApp created a VM, here we detach the vmdk, then delete the VM.
+	vm := object.NewVirtualMachine(c, info.Entity)
+
+	device, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	device = device.SelectByType((*types.VirtualDisk)(nil))
+
+	err = vm.RemoveDevice(ctx, true, device...)
+	if err != nil {
+		return err
+	}
+
+	task, err := vm.Destroy(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err = task.Wait(ctx); err != nil {
+		return err
+	}
+
+	if rename == "" {
+		return nil
+	}
+
+	return fm.Move(ctx, target, rename)
+}

--- a/vendor/github.com/vmware/govmomi/vslm/client.go
+++ b/vendor/github.com/vmware/govmomi/vslm/client.go
@@ -1,0 +1,59 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vslm
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+	vim "github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vslm/methods"
+	"github.com/vmware/govmomi/vslm/types"
+)
+
+const (
+	Namespace = "vslm"
+	Path      = "/vslm/sdk"
+)
+
+var (
+	ServiceInstance = vim.ManagedObjectReference{
+		Type:  "VslmServiceInstance",
+		Value: "ServiceInstance",
+	}
+)
+
+type Client struct {
+	*soap.Client
+
+	ServiceContent types.VslmServiceInstanceContent
+}
+
+func NewClient(ctx context.Context, c *vim25.Client) (*Client, error) {
+	sc := c.Client.NewServiceClient(Path, Namespace)
+	req := types.RetrieveContent{
+		This: ServiceInstance,
+	}
+
+	res, err := methods.RetrieveContent(ctx, sc, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{sc, res.Returnval}, nil
+}

--- a/vendor/github.com/vmware/govmomi/vslm/doc.go
+++ b/vendor/github.com/vmware/govmomi/vslm/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package vslm provides access to the vSphere Storage Lifecycle Management service.
+*/
+package vslm

--- a/vendor/github.com/vmware/govmomi/vslm/global_object_manager.go
+++ b/vendor/github.com/vmware/govmomi/vslm/global_object_manager.go
@@ -1,0 +1,676 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vslm
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	vim "github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vslm/methods"
+	"github.com/vmware/govmomi/vslm/types"
+)
+
+type Task struct {
+	c *Client
+	object.Common
+	vim.ManagedObjectReference
+}
+
+func NewTask(client *Client, mref vim.ManagedObjectReference) *Task {
+	m := Task{
+		ManagedObjectReference: mref,
+		c:                      client,
+	}
+	return &m
+}
+
+func (this *Task) QueryResult(ctx context.Context) (vim.AnyType, error) {
+	req := types.VslmQueryTaskResult{
+		This: this.ManagedObjectReference,
+	}
+	res, err := methods.VslmQueryTaskResult(ctx, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+	return res.Returnval, nil
+}
+
+func (this *Task) QueryInfo(ctx context.Context) (*types.VslmTaskInfo, error) {
+	req := types.VslmQueryInfo{
+		This: this.ManagedObjectReference,
+	}
+	res, err := methods.VslmQueryInfo(ctx, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+	return &res.Returnval, nil
+}
+
+func (this *Task) Cancel(ctx context.Context) error {
+	req := types.VslmCancelTask{
+		This: this.ManagedObjectReference,
+	}
+	_, err := methods.VslmCancelTask(ctx, this.c, &req)
+	return err
+}
+
+func (this *Task) Wait(ctx context.Context, timeoutNS time.Duration) (vim.AnyType, error) {
+	return this.WaitNonDefault(ctx, timeoutNS, 10000, true, 10000000)
+}
+
+func (this *Task) WaitNonDefault(ctx context.Context, timeoutNS time.Duration, startIntervalNS time.Duration,
+	exponential bool, maxIntervalNS time.Duration) (vim.AnyType, error) {
+	waitIntervalNS := startIntervalNS
+	startTimeNS := time.Now()
+	for time.Now().Sub(startTimeNS) < timeoutNS {
+		info, err := this.QueryInfo(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if info.State == types.VslmTaskInfoStateQueued || info.State == types.VslmTaskInfoStateRunning {
+			time.Sleep(waitIntervalNS)
+			if exponential {
+				waitIntervalNS = waitIntervalNS * 2
+				if maxIntervalNS > 0 && waitIntervalNS > maxIntervalNS {
+					waitIntervalNS = maxIntervalNS
+				}
+			}
+		} else if info.State == types.VslmTaskInfoStateError {
+			return nil, errors.New(info.Error.LocalizedMessage)
+		} else {
+			break
+		}
+		// Check context here to see if we should exit
+	}
+	return this.QueryResult(ctx)
+}
+
+type GlobalObjectManager struct {
+	vim.ManagedObjectReference
+	c *Client
+}
+
+// NewGlobalObjectManager returns an ObjectManager referecing the vslm VcenterVStorageObjectManager endpoint.
+// This endpoint is always connected to vpxd and utilizes the global catalog to locate objects and does
+// not require a datastore.  To connect to the VStorageObjectManager on the host or in vpxd use the
+// vslm.ObjectManager type.
+func NewGlobalObjectManager(client *Client) *GlobalObjectManager {
+	mref := client.ServiceContent.VStorageObjectManager
+
+	m := GlobalObjectManager{
+		ManagedObjectReference: mref,
+		c:                      client,
+	}
+
+	return &m
+}
+
+func (this *GlobalObjectManager) CreateDisk(ctx context.Context, spec vim.VslmCreateSpec) (*Task, error) {
+	req := types.VslmCreateDisk_Task{
+		This: this.Reference(),
+		Spec: spec,
+	}
+
+	res, err := methods.VslmCreateDisk_Task(ctx, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(this.c, res.Returnval), nil
+}
+
+func (this *GlobalObjectManager) RegisterDisk(ctx context.Context, path string, name string) (*vim.VStorageObject, error) {
+	req := types.VslmRegisterDisk{
+		This: this.Reference(),
+		Path: path,
+		Name: name,
+	}
+
+	res, err := methods.VslmRegisterDisk(ctx, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Returnval, nil
+}
+
+func (this *GlobalObjectManager) ExtendDisk(ctx context.Context, id vim.ID, newCapacityInMB int64) (*Task, error) {
+	req := types.VslmExtendDisk_Task{
+		This:            this.Reference(),
+		Id:              id,
+		NewCapacityInMB: newCapacityInMB,
+	}
+
+	res, err := methods.VslmExtendDisk_Task(ctx, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(this.c, res.Returnval), nil
+}
+
+func (this *GlobalObjectManager) InflateDisk(ctx context.Context, id vim.ID) (*Task, error) {
+	req := types.VslmInflateDisk_Task{
+		This: this.Reference(),
+		Id:   id,
+	}
+
+	res, err := methods.VslmInflateDisk_Task(ctx, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(this.c, res.Returnval), nil
+}
+
+func (this *GlobalObjectManager) Rename(ctx context.Context, id vim.ID, name string) error {
+	req := types.VslmRenameVStorageObject{
+		This: this.Reference(),
+		Id:   id,
+		Name: name,
+	}
+
+	_, err := methods.VslmRenameVStorageObject(ctx, this.c, &req)
+
+	return err
+}
+
+func (this *GlobalObjectManager) UpdatePolicy(ct context.Context, id vim.ID, profile []vim.VirtualMachineProfileSpec) (
+	*Task, error) {
+	req := types.VslmUpdateVstorageObjectPolicy_Task{
+		This:    this.Reference(),
+		Id:      id,
+		Profile: profile,
+	}
+
+	res, err := methods.VslmUpdateVstorageObjectPolicy_Task(ct, this.c, &req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(this.c, res.Returnval), nil
+}
+
+func (this *GlobalObjectManager) UpdateInfrastructurePolicy(ct context.Context,
+	spec vim.VslmInfrastructureObjectPolicySpec) (*Task, error) {
+	req := types.VslmUpdateVStorageInfrastructureObjectPolicy_Task{
+		This: this.Reference(),
+		Spec: spec,
+	}
+
+	res, err := methods.VslmUpdateVStorageInfrastructureObjectPolicy_Task(ct, this.c, &req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(this.c, res.Returnval), nil
+}
+
+func (this *GlobalObjectManager) RetrieveInfrastructurePolicy(ct context.Context, datastore mo.Reference) (
+	[]vim.VslmInfrastructureObjectPolicy, error) {
+	req := types.VslmRetrieveVStorageInfrastructureObjectPolicy{
+		This:      this.Reference(),
+		Datastore: datastore.Reference(),
+	}
+
+	res, err := methods.VslmRetrieveVStorageInfrastructureObjectPolicy(ct, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (this *GlobalObjectManager) Delete(ctx context.Context, id vim.ID) (*Task, error) {
+	req := types.VslmDeleteVStorageObject_Task{
+		This: this.Reference(),
+		Id:   id,
+	}
+
+	res, err := methods.VslmDeleteVStorageObject_Task(ctx, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(this.c, res.Returnval), nil
+}
+
+func (this *GlobalObjectManager) Retrieve(ctx context.Context, id vim.ID) (*vim.VStorageObject, error) {
+	req := types.VslmRetrieveVStorageObject{
+		This: this.Reference(),
+		Id:   id,
+	}
+
+	res, err := methods.VslmRetrieveVStorageObject(ctx, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Returnval, nil
+}
+
+func (this *GlobalObjectManager) RetrieveState(ct context.Context, id vim.ID) (*vim.VStorageObjectStateInfo, error) {
+	req := types.VslmRetrieveVStorageObjectState{
+		This: this.Reference(),
+		Id:   id,
+	}
+
+	res, err := methods.VslmRetrieveVStorageObjectState(ct, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Returnval, nil
+}
+
+func (this *GlobalObjectManager) RetrieveAssociations(ct context.Context, ids []vim.ID) (
+	[]types.VslmVsoVStorageObjectAssociations, error) {
+	req := types.VslmRetrieveVStorageObjectAssociations{
+		This: this.Reference(),
+		Ids:  ids,
+	}
+
+	res, err := methods.VslmRetrieveVStorageObjectAssociations(ct, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (this *GlobalObjectManager) ListObjectsForSpec(ctx context.Context, query []types.VslmVsoVStorageObjectQuerySpec,
+	maxResult int32) (*types.VslmVsoVStorageObjectQueryResult, error) {
+	req := types.VslmListVStorageObjectForSpec{
+		This:      this.Reference(),
+		Query:     query,
+		MaxResult: maxResult,
+	}
+
+	res, err := methods.VslmListVStorageObjectForSpec(ctx, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (this *GlobalObjectManager) Clone(ctx context.Context, id vim.ID, spec vim.VslmCloneSpec) (*Task, error) {
+	req := types.VslmCloneVStorageObject_Task{
+		This: this.Reference(),
+		Id:   id,
+		Spec: spec,
+	}
+
+	res, err := methods.VslmCloneVStorageObject_Task(ctx, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(this.c, res.Returnval), nil
+}
+
+func (this *GlobalObjectManager) Relocate(ct context.Context, id vim.ID, spec vim.VslmRelocateSpec) (*Task, error) {
+	req := types.VslmRelocateVStorageObject_Task{
+		This: this.Reference(),
+		Id:   id,
+		Spec: spec,
+	}
+
+	res, err := methods.VslmRelocateVStorageObject_Task(ct, this.c, &req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(this.c, res.Returnval), nil
+}
+
+func (this *GlobalObjectManager) SetControlFlags(ct context.Context, controlFlags []string) error {
+	req := types.VslmSetVStorageObjectControlFlags{
+		This:         this.Reference(),
+		ControlFlags: controlFlags,
+	}
+
+	_, err := methods.VslmSetVStorageObjectControlFlags(ct, this.c, &req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (this *GlobalObjectManager) ClearControlFlags(ct context.Context) error {
+	req := types.VslmClearVStorageObjectControlFlags{
+		This: this.Reference(),
+	}
+
+	_, err := methods.VslmClearVStorageObjectControlFlags(ct, this.c, &req)
+
+	return err
+}
+
+func (this *GlobalObjectManager) AttachTag(ctx context.Context, id vim.ID, category string, tag string) error {
+	req := types.VslmAttachTagToVStorageObject{
+		This:     this.Reference(),
+		Id:       id,
+		Category: category,
+		Tag:      tag,
+	}
+
+	_, err := methods.VslmAttachTagToVStorageObject(ctx, this.c, &req)
+
+	return err
+}
+
+func (this *GlobalObjectManager) DetachTag(ctx context.Context, id vim.ID, category string, tag string) error {
+	req := types.VslmDetachTagFromVStorageObject{
+		This:     this.Reference(),
+		Id:       id,
+		Category: category,
+		Tag:      tag,
+	}
+
+	_, err := methods.VslmDetachTagFromVStorageObject(ctx, this.c, &req)
+
+	return err
+}
+
+func (this *GlobalObjectManager) ListObjectsAttachedToTag(ctx context.Context, id vim.ID, category string, tag string) (
+	[]vim.ID, error) {
+	req := types.VslmListVStorageObjectsAttachedToTag{
+		This:     this.Reference(),
+		Category: category,
+		Tag:      tag,
+	}
+
+	res, err := methods.VslmListVStorageObjectsAttachedToTag(ctx, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, err
+}
+
+func (this *GlobalObjectManager) ListAttachedTags(ctx context.Context, id vim.ID) ([]vim.VslmTagEntry, error) {
+	req := types.VslmListTagsAttachedToVStorageObject{
+		This: this.Reference(),
+		Id:   id,
+	}
+
+	res, err := methods.VslmListTagsAttachedToVStorageObject(ctx, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (this *GlobalObjectManager) ReconcileDatastoreInventory(ctx context.Context, datastore mo.Reference) (*Task, error) {
+	req := &types.VslmReconcileDatastoreInventory_Task{
+		This:      this.Reference(),
+		Datastore: datastore.Reference(),
+	}
+
+	res, err := methods.VslmReconcileDatastoreInventory_Task(ctx, this.c, req)
+	if err != nil {
+		return nil, err
+	}
+	return NewTask(this.c, res.Returnval), nil
+}
+
+func (this *GlobalObjectManager) ScheduleReconcileDatastoreInventory(ctx context.Context, datastore mo.Reference) error {
+	req := &types.VslmScheduleReconcileDatastoreInventory{
+		This:      this.Reference(),
+		Datastore: datastore.Reference(),
+	}
+
+	_, err := methods.VslmScheduleReconcileDatastoreInventory(ctx, this.c, req)
+
+	return err
+}
+
+func (this *GlobalObjectManager) CreateSnapshot(ctx context.Context, id vim.ID, description string) (*Task, error) {
+	req := types.VslmCreateSnapshot_Task{
+		This:        this.Reference(),
+		Id:          id,
+		Description: description,
+	}
+
+	res, err := methods.VslmCreateSnapshot_Task(ctx, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(this.c, res.Returnval), nil
+}
+
+func (this *GlobalObjectManager) DeleteSnapshot(ctx context.Context, id vim.ID, snapshotID vim.ID) (*Task, error) {
+	req := types.VslmDeleteSnapshot_Task{
+		This:       this.Reference(),
+		Id:         id,
+		SnapshotId: snapshotID,
+	}
+
+	res, err := methods.VslmDeleteSnapshot_Task(ctx, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(this.c, res.Returnval), nil
+}
+
+func (this *GlobalObjectManager) RetrieveSnapshotInfo(ctx context.Context, id vim.ID) (
+	[]vim.VStorageObjectSnapshotInfoVStorageObjectSnapshot, error) {
+	req := types.VslmRetrieveSnapshotInfo{
+		This: this.Reference(),
+		Id:   id,
+	}
+
+	res, err := methods.VslmRetrieveSnapshotInfo(ctx, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval.Snapshots, nil
+}
+
+func (this *GlobalObjectManager) CreateDiskFromSnapshot(ctx context.Context, id vim.ID, snapshotId vim.ID, name string,
+	profile []vim.VirtualMachineProfileSpec, crypto *vim.CryptoSpec,
+	path string) (*Task, error) {
+	req := types.VslmCreateDiskFromSnapshot_Task{
+		This:       this.Reference(),
+		Id:         id,
+		SnapshotId: snapshotId,
+		Name:       name,
+		Profile:    profile,
+		Crypto:     crypto,
+		Path:       path,
+	}
+
+	res, err := methods.VslmCreateDiskFromSnapshot_Task(ctx, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(this.c, res.Returnval), nil
+}
+
+func (this *GlobalObjectManager) Revert(ctx context.Context, id vim.ID, snapshotID vim.ID) (*Task, error) {
+	req := types.VslmRevertVStorageObject_Task{
+		This:       this.Reference(),
+		Id:         id,
+		SnapshotId: snapshotID,
+	}
+
+	res, err := methods.VslmRevertVStorageObject_Task(ctx, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(this.c, res.Returnval), nil
+}
+
+func (this *GlobalObjectManager) RetrieveSnapshotDetails(ctx context.Context, id vim.ID, snapshotId vim.ID) (
+	*vim.VStorageObjectSnapshotDetails, error) {
+	req := types.VslmRetrieveSnapshotDetails{
+		This:       this.Reference(),
+		Id:         id,
+		SnapshotId: snapshotId,
+	}
+
+	res, err := methods.VslmRetrieveSnapshotDetails(ctx, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Returnval, nil
+}
+
+func (this *GlobalObjectManager) QueryChangedDiskAreas(ctx context.Context, id vim.ID, snapshotId vim.ID, startOffset int64,
+	changeId string) (*vim.DiskChangeInfo, error) {
+	req := types.VslmQueryChangedDiskAreas{
+		This:        this.Reference(),
+		Id:          id,
+		SnapshotId:  snapshotId,
+		StartOffset: startOffset,
+		ChangeId:    changeId,
+	}
+
+	res, err := methods.VslmQueryChangedDiskAreas(ctx, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Returnval, nil
+}
+
+func (this *GlobalObjectManager) QueryGlobalCatalogSyncStatus(ct context.Context) ([]types.VslmDatastoreSyncStatus, error) {
+	req := types.VslmQueryGlobalCatalogSyncStatus{
+		This: this.Reference(),
+	}
+
+	res, err := methods.VslmQueryGlobalCatalogSyncStatus(ct, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (this *GlobalObjectManager) QueryGlobalCatalogSyncStatusForDatastore(ct context.Context, datastoreURL string) (
+	*types.VslmDatastoreSyncStatus, error) {
+	req := types.VslmQueryGlobalCatalogSyncStatusForDatastore{
+		This:         this.Reference(),
+		DatastoreURL: datastoreURL,
+	}
+
+	res, err := methods.VslmQueryGlobalCatalogSyncStatusForDatastore(ct, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (this *GlobalObjectManager) UpdateMetadata(ctx context.Context, id vim.ID, metadata []vim.KeyValue,
+	deleteKeys []string) (*Task, error) {
+	req := &types.VslmUpdateVStorageObjectMetadata_Task{
+		This:       this.Reference(),
+		Id:         id,
+		Metadata:   metadata,
+		DeleteKeys: deleteKeys,
+	}
+
+	res, err := methods.VslmUpdateVStorageObjectMetadata_Task(ctx, this.c, req)
+	if err != nil {
+		return nil, err
+	}
+	return NewTask(this.c, res.Returnval), nil
+}
+
+func (this *GlobalObjectManager) RetrieveMetadata(ct context.Context, id vim.ID, snapshotID *vim.ID, prefix string) (
+	[]vim.KeyValue, error) {
+	req := types.VslmRetrieveVStorageObjectMetadata{
+		This:       this.Reference(),
+		Id:         id,
+		SnapshotId: snapshotID,
+		Prefix:     prefix,
+	}
+
+	res, err := methods.VslmRetrieveVStorageObjectMetadata(ct, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (this *GlobalObjectManager) RetrieveMetadataValue(ct context.Context, id vim.ID, snapshotID *vim.ID, key string) (
+	string, error) {
+	req := types.VslmRetrieveVStorageObjectMetadataValue{
+		This:       this.Reference(),
+		Id:         id,
+		SnapshotId: snapshotID,
+		Key:        key,
+	}
+
+	res, err := methods.VslmRetrieveVStorageObjectMetadataValue(ct, this.c, &req)
+	if err != nil {
+		return "", err
+	}
+
+	return res.Returnval, nil
+}
+
+func (this *GlobalObjectManager) RetrieveObjects(ct context.Context, ids []vim.ID) ([]types.VslmVsoVStorageObjectResult,
+	error) {
+	req := types.VslmRetrieveVStorageObjects{
+		This: this.Reference(),
+		Ids:  ids,
+	}
+
+	res, err := methods.VslmRetrieveVStorageObjects(ct, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (this *GlobalObjectManager) AttachDisk(ct context.Context, id vim.ID, vm mo.Reference, controllerKey int32,
+	unitNumber int32) (*Task, error) {
+	req := types.VslmAttachDisk_Task{
+		This:          this.Reference(),
+		Id:            id,
+		Vm:            vm.Reference(),
+		ControllerKey: controllerKey,
+		UnitNumber:    &unitNumber,
+	}
+
+	res, err := methods.VslmAttachDisk_Task(ct, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(this.c, res.Returnval), nil
+}

--- a/vendor/github.com/vmware/govmomi/vslm/methods/methods.go
+++ b/vendor/github.com/vmware/govmomi/vslm/methods/methods.go
@@ -1,0 +1,924 @@
+/*
+Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package methods
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vslm/types"
+)
+
+type RetrieveContentBody struct {
+	Req    *types.RetrieveContent         `xml:"urn:vslm RetrieveContent,omitempty"`
+	Res    *types.RetrieveContentResponse `xml:"urn:vslm RetrieveContentResponse,omitempty"`
+	Fault_ *soap.Fault                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RetrieveContentBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RetrieveContent(ctx context.Context, r soap.RoundTripper, req *types.RetrieveContent) (*types.RetrieveContentResponse, error) {
+	var reqBody, resBody RetrieveContentBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmAttachDisk_TaskBody struct {
+	Req    *types.VslmAttachDisk_Task         `xml:"urn:vslm VslmAttachDisk_Task,omitempty"`
+	Res    *types.VslmAttachDisk_TaskResponse `xml:"urn:vslm VslmAttachDisk_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                        `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmAttachDisk_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmAttachDisk_Task(ctx context.Context, r soap.RoundTripper, req *types.VslmAttachDisk_Task) (*types.VslmAttachDisk_TaskResponse, error) {
+	var reqBody, resBody VslmAttachDisk_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmAttachTagToVStorageObjectBody struct {
+	Req    *types.VslmAttachTagToVStorageObject         `xml:"urn:vslm VslmAttachTagToVStorageObject,omitempty"`
+	Res    *types.VslmAttachTagToVStorageObjectResponse `xml:"urn:vslm VslmAttachTagToVStorageObjectResponse,omitempty"`
+	Fault_ *soap.Fault                                  `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmAttachTagToVStorageObjectBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmAttachTagToVStorageObject(ctx context.Context, r soap.RoundTripper, req *types.VslmAttachTagToVStorageObject) (*types.VslmAttachTagToVStorageObjectResponse, error) {
+	var reqBody, resBody VslmAttachTagToVStorageObjectBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmCancelTaskBody struct {
+	Req    *types.VslmCancelTask         `xml:"urn:vslm VslmCancelTask,omitempty"`
+	Res    *types.VslmCancelTaskResponse `xml:"urn:vslm VslmCancelTaskResponse,omitempty"`
+	Fault_ *soap.Fault                   `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmCancelTaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmCancelTask(ctx context.Context, r soap.RoundTripper, req *types.VslmCancelTask) (*types.VslmCancelTaskResponse, error) {
+	var reqBody, resBody VslmCancelTaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmClearVStorageObjectControlFlagsBody struct {
+	Req    *types.VslmClearVStorageObjectControlFlags         `xml:"urn:vslm VslmClearVStorageObjectControlFlags,omitempty"`
+	Res    *types.VslmClearVStorageObjectControlFlagsResponse `xml:"urn:vslm VslmClearVStorageObjectControlFlagsResponse,omitempty"`
+	Fault_ *soap.Fault                                        `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmClearVStorageObjectControlFlagsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmClearVStorageObjectControlFlags(ctx context.Context, r soap.RoundTripper, req *types.VslmClearVStorageObjectControlFlags) (*types.VslmClearVStorageObjectControlFlagsResponse, error) {
+	var reqBody, resBody VslmClearVStorageObjectControlFlagsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmCloneVStorageObject_TaskBody struct {
+	Req    *types.VslmCloneVStorageObject_Task         `xml:"urn:vslm VslmCloneVStorageObject_Task,omitempty"`
+	Res    *types.VslmCloneVStorageObject_TaskResponse `xml:"urn:vslm VslmCloneVStorageObject_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                 `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmCloneVStorageObject_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmCloneVStorageObject_Task(ctx context.Context, r soap.RoundTripper, req *types.VslmCloneVStorageObject_Task) (*types.VslmCloneVStorageObject_TaskResponse, error) {
+	var reqBody, resBody VslmCloneVStorageObject_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmCreateDiskFromSnapshot_TaskBody struct {
+	Req    *types.VslmCreateDiskFromSnapshot_Task         `xml:"urn:vslm VslmCreateDiskFromSnapshot_Task,omitempty"`
+	Res    *types.VslmCreateDiskFromSnapshot_TaskResponse `xml:"urn:vslm VslmCreateDiskFromSnapshot_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmCreateDiskFromSnapshot_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmCreateDiskFromSnapshot_Task(ctx context.Context, r soap.RoundTripper, req *types.VslmCreateDiskFromSnapshot_Task) (*types.VslmCreateDiskFromSnapshot_TaskResponse, error) {
+	var reqBody, resBody VslmCreateDiskFromSnapshot_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmCreateDisk_TaskBody struct {
+	Req    *types.VslmCreateDisk_Task         `xml:"urn:vslm VslmCreateDisk_Task,omitempty"`
+	Res    *types.VslmCreateDisk_TaskResponse `xml:"urn:vslm VslmCreateDisk_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                        `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmCreateDisk_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmCreateDisk_Task(ctx context.Context, r soap.RoundTripper, req *types.VslmCreateDisk_Task) (*types.VslmCreateDisk_TaskResponse, error) {
+	var reqBody, resBody VslmCreateDisk_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmCreateSnapshot_TaskBody struct {
+	Req    *types.VslmCreateSnapshot_Task         `xml:"urn:vslm VslmCreateSnapshot_Task,omitempty"`
+	Res    *types.VslmCreateSnapshot_TaskResponse `xml:"urn:vslm VslmCreateSnapshot_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmCreateSnapshot_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmCreateSnapshot_Task(ctx context.Context, r soap.RoundTripper, req *types.VslmCreateSnapshot_Task) (*types.VslmCreateSnapshot_TaskResponse, error) {
+	var reqBody, resBody VslmCreateSnapshot_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmDeleteSnapshot_TaskBody struct {
+	Req    *types.VslmDeleteSnapshot_Task         `xml:"urn:vslm VslmDeleteSnapshot_Task,omitempty"`
+	Res    *types.VslmDeleteSnapshot_TaskResponse `xml:"urn:vslm VslmDeleteSnapshot_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmDeleteSnapshot_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmDeleteSnapshot_Task(ctx context.Context, r soap.RoundTripper, req *types.VslmDeleteSnapshot_Task) (*types.VslmDeleteSnapshot_TaskResponse, error) {
+	var reqBody, resBody VslmDeleteSnapshot_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmDeleteVStorageObject_TaskBody struct {
+	Req    *types.VslmDeleteVStorageObject_Task         `xml:"urn:vslm VslmDeleteVStorageObject_Task,omitempty"`
+	Res    *types.VslmDeleteVStorageObject_TaskResponse `xml:"urn:vslm VslmDeleteVStorageObject_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                  `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmDeleteVStorageObject_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmDeleteVStorageObject_Task(ctx context.Context, r soap.RoundTripper, req *types.VslmDeleteVStorageObject_Task) (*types.VslmDeleteVStorageObject_TaskResponse, error) {
+	var reqBody, resBody VslmDeleteVStorageObject_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmDetachTagFromVStorageObjectBody struct {
+	Req    *types.VslmDetachTagFromVStorageObject         `xml:"urn:vslm VslmDetachTagFromVStorageObject,omitempty"`
+	Res    *types.VslmDetachTagFromVStorageObjectResponse `xml:"urn:vslm VslmDetachTagFromVStorageObjectResponse,omitempty"`
+	Fault_ *soap.Fault                                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmDetachTagFromVStorageObjectBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmDetachTagFromVStorageObject(ctx context.Context, r soap.RoundTripper, req *types.VslmDetachTagFromVStorageObject) (*types.VslmDetachTagFromVStorageObjectResponse, error) {
+	var reqBody, resBody VslmDetachTagFromVStorageObjectBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmExtendDisk_TaskBody struct {
+	Req    *types.VslmExtendDisk_Task         `xml:"urn:vslm VslmExtendDisk_Task,omitempty"`
+	Res    *types.VslmExtendDisk_TaskResponse `xml:"urn:vslm VslmExtendDisk_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                        `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmExtendDisk_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmExtendDisk_Task(ctx context.Context, r soap.RoundTripper, req *types.VslmExtendDisk_Task) (*types.VslmExtendDisk_TaskResponse, error) {
+	var reqBody, resBody VslmExtendDisk_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmInflateDisk_TaskBody struct {
+	Req    *types.VslmInflateDisk_Task         `xml:"urn:vslm VslmInflateDisk_Task,omitempty"`
+	Res    *types.VslmInflateDisk_TaskResponse `xml:"urn:vslm VslmInflateDisk_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmInflateDisk_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmInflateDisk_Task(ctx context.Context, r soap.RoundTripper, req *types.VslmInflateDisk_Task) (*types.VslmInflateDisk_TaskResponse, error) {
+	var reqBody, resBody VslmInflateDisk_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmListTagsAttachedToVStorageObjectBody struct {
+	Req    *types.VslmListTagsAttachedToVStorageObject         `xml:"urn:vslm VslmListTagsAttachedToVStorageObject,omitempty"`
+	Res    *types.VslmListTagsAttachedToVStorageObjectResponse `xml:"urn:vslm VslmListTagsAttachedToVStorageObjectResponse,omitempty"`
+	Fault_ *soap.Fault                                         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmListTagsAttachedToVStorageObjectBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmListTagsAttachedToVStorageObject(ctx context.Context, r soap.RoundTripper, req *types.VslmListTagsAttachedToVStorageObject) (*types.VslmListTagsAttachedToVStorageObjectResponse, error) {
+	var reqBody, resBody VslmListTagsAttachedToVStorageObjectBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmListVStorageObjectForSpecBody struct {
+	Req    *types.VslmListVStorageObjectForSpec         `xml:"urn:vslm VslmListVStorageObjectForSpec,omitempty"`
+	Res    *types.VslmListVStorageObjectForSpecResponse `xml:"urn:vslm VslmListVStorageObjectForSpecResponse,omitempty"`
+	Fault_ *soap.Fault                                  `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmListVStorageObjectForSpecBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmListVStorageObjectForSpec(ctx context.Context, r soap.RoundTripper, req *types.VslmListVStorageObjectForSpec) (*types.VslmListVStorageObjectForSpecResponse, error) {
+	var reqBody, resBody VslmListVStorageObjectForSpecBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmListVStorageObjectsAttachedToTagBody struct {
+	Req    *types.VslmListVStorageObjectsAttachedToTag         `xml:"urn:vslm VslmListVStorageObjectsAttachedToTag,omitempty"`
+	Res    *types.VslmListVStorageObjectsAttachedToTagResponse `xml:"urn:vslm VslmListVStorageObjectsAttachedToTagResponse,omitempty"`
+	Fault_ *soap.Fault                                         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmListVStorageObjectsAttachedToTagBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmListVStorageObjectsAttachedToTag(ctx context.Context, r soap.RoundTripper, req *types.VslmListVStorageObjectsAttachedToTag) (*types.VslmListVStorageObjectsAttachedToTagResponse, error) {
+	var reqBody, resBody VslmListVStorageObjectsAttachedToTagBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmLoginByTokenBody struct {
+	Req    *types.VslmLoginByToken         `xml:"urn:vslm VslmLoginByToken,omitempty"`
+	Res    *types.VslmLoginByTokenResponse `xml:"urn:vslm VslmLoginByTokenResponse,omitempty"`
+	Fault_ *soap.Fault                     `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmLoginByTokenBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmLoginByToken(ctx context.Context, r soap.RoundTripper, req *types.VslmLoginByToken) (*types.VslmLoginByTokenResponse, error) {
+	var reqBody, resBody VslmLoginByTokenBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmLogoutBody struct {
+	Req    *types.VslmLogout         `xml:"urn:vslm VslmLogout,omitempty"`
+	Res    *types.VslmLogoutResponse `xml:"urn:vslm VslmLogoutResponse,omitempty"`
+	Fault_ *soap.Fault               `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmLogoutBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmLogout(ctx context.Context, r soap.RoundTripper, req *types.VslmLogout) (*types.VslmLogoutResponse, error) {
+	var reqBody, resBody VslmLogoutBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmQueryChangedDiskAreasBody struct {
+	Req    *types.VslmQueryChangedDiskAreas         `xml:"urn:vslm VslmQueryChangedDiskAreas,omitempty"`
+	Res    *types.VslmQueryChangedDiskAreasResponse `xml:"urn:vslm VslmQueryChangedDiskAreasResponse,omitempty"`
+	Fault_ *soap.Fault                              `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmQueryChangedDiskAreasBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmQueryChangedDiskAreas(ctx context.Context, r soap.RoundTripper, req *types.VslmQueryChangedDiskAreas) (*types.VslmQueryChangedDiskAreasResponse, error) {
+	var reqBody, resBody VslmQueryChangedDiskAreasBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmQueryDatastoreInfoBody struct {
+	Req    *types.VslmQueryDatastoreInfo         `xml:"urn:vslm VslmQueryDatastoreInfo,omitempty"`
+	Res    *types.VslmQueryDatastoreInfoResponse `xml:"urn:vslm VslmQueryDatastoreInfoResponse,omitempty"`
+	Fault_ *soap.Fault                           `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmQueryDatastoreInfoBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmQueryDatastoreInfo(ctx context.Context, r soap.RoundTripper, req *types.VslmQueryDatastoreInfo) (*types.VslmQueryDatastoreInfoResponse, error) {
+	var reqBody, resBody VslmQueryDatastoreInfoBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmQueryGlobalCatalogSyncStatusBody struct {
+	Req    *types.VslmQueryGlobalCatalogSyncStatus         `xml:"urn:vslm VslmQueryGlobalCatalogSyncStatus,omitempty"`
+	Res    *types.VslmQueryGlobalCatalogSyncStatusResponse `xml:"urn:vslm VslmQueryGlobalCatalogSyncStatusResponse,omitempty"`
+	Fault_ *soap.Fault                                     `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmQueryGlobalCatalogSyncStatusBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmQueryGlobalCatalogSyncStatus(ctx context.Context, r soap.RoundTripper, req *types.VslmQueryGlobalCatalogSyncStatus) (*types.VslmQueryGlobalCatalogSyncStatusResponse, error) {
+	var reqBody, resBody VslmQueryGlobalCatalogSyncStatusBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmQueryGlobalCatalogSyncStatusForDatastoreBody struct {
+	Req    *types.VslmQueryGlobalCatalogSyncStatusForDatastore         `xml:"urn:vslm VslmQueryGlobalCatalogSyncStatusForDatastore,omitempty"`
+	Res    *types.VslmQueryGlobalCatalogSyncStatusForDatastoreResponse `xml:"urn:vslm VslmQueryGlobalCatalogSyncStatusForDatastoreResponse,omitempty"`
+	Fault_ *soap.Fault                                                 `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmQueryGlobalCatalogSyncStatusForDatastoreBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmQueryGlobalCatalogSyncStatusForDatastore(ctx context.Context, r soap.RoundTripper, req *types.VslmQueryGlobalCatalogSyncStatusForDatastore) (*types.VslmQueryGlobalCatalogSyncStatusForDatastoreResponse, error) {
+	var reqBody, resBody VslmQueryGlobalCatalogSyncStatusForDatastoreBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmQueryInfoBody struct {
+	Req    *types.VslmQueryInfo         `xml:"urn:vslm VslmQueryInfo,omitempty"`
+	Res    *types.VslmQueryInfoResponse `xml:"urn:vslm VslmQueryInfoResponse,omitempty"`
+	Fault_ *soap.Fault                  `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmQueryInfoBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmQueryInfo(ctx context.Context, r soap.RoundTripper, req *types.VslmQueryInfo) (*types.VslmQueryInfoResponse, error) {
+	var reqBody, resBody VslmQueryInfoBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmQueryTaskResultBody struct {
+	Req    *types.VslmQueryTaskResult         `xml:"urn:vslm VslmQueryTaskResult,omitempty"`
+	Res    *types.VslmQueryTaskResultResponse `xml:"urn:vslm VslmQueryTaskResultResponse,omitempty"`
+	Fault_ *soap.Fault                        `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmQueryTaskResultBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmQueryTaskResult(ctx context.Context, r soap.RoundTripper, req *types.VslmQueryTaskResult) (*types.VslmQueryTaskResultResponse, error) {
+	var reqBody, resBody VslmQueryTaskResultBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmReconcileDatastoreInventory_TaskBody struct {
+	Req    *types.VslmReconcileDatastoreInventory_Task         `xml:"urn:vslm VslmReconcileDatastoreInventory_Task,omitempty"`
+	Res    *types.VslmReconcileDatastoreInventory_TaskResponse `xml:"urn:vslm VslmReconcileDatastoreInventory_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmReconcileDatastoreInventory_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmReconcileDatastoreInventory_Task(ctx context.Context, r soap.RoundTripper, req *types.VslmReconcileDatastoreInventory_Task) (*types.VslmReconcileDatastoreInventory_TaskResponse, error) {
+	var reqBody, resBody VslmReconcileDatastoreInventory_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmRegisterDiskBody struct {
+	Req    *types.VslmRegisterDisk         `xml:"urn:vslm VslmRegisterDisk,omitempty"`
+	Res    *types.VslmRegisterDiskResponse `xml:"urn:vslm VslmRegisterDiskResponse,omitempty"`
+	Fault_ *soap.Fault                     `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmRegisterDiskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmRegisterDisk(ctx context.Context, r soap.RoundTripper, req *types.VslmRegisterDisk) (*types.VslmRegisterDiskResponse, error) {
+	var reqBody, resBody VslmRegisterDiskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmRelocateVStorageObject_TaskBody struct {
+	Req    *types.VslmRelocateVStorageObject_Task         `xml:"urn:vslm VslmRelocateVStorageObject_Task,omitempty"`
+	Res    *types.VslmRelocateVStorageObject_TaskResponse `xml:"urn:vslm VslmRelocateVStorageObject_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmRelocateVStorageObject_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmRelocateVStorageObject_Task(ctx context.Context, r soap.RoundTripper, req *types.VslmRelocateVStorageObject_Task) (*types.VslmRelocateVStorageObject_TaskResponse, error) {
+	var reqBody, resBody VslmRelocateVStorageObject_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmRenameVStorageObjectBody struct {
+	Req    *types.VslmRenameVStorageObject         `xml:"urn:vslm VslmRenameVStorageObject,omitempty"`
+	Res    *types.VslmRenameVStorageObjectResponse `xml:"urn:vslm VslmRenameVStorageObjectResponse,omitempty"`
+	Fault_ *soap.Fault                             `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmRenameVStorageObjectBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmRenameVStorageObject(ctx context.Context, r soap.RoundTripper, req *types.VslmRenameVStorageObject) (*types.VslmRenameVStorageObjectResponse, error) {
+	var reqBody, resBody VslmRenameVStorageObjectBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmRetrieveSnapshotDetailsBody struct {
+	Req    *types.VslmRetrieveSnapshotDetails         `xml:"urn:vslm VslmRetrieveSnapshotDetails,omitempty"`
+	Res    *types.VslmRetrieveSnapshotDetailsResponse `xml:"urn:vslm VslmRetrieveSnapshotDetailsResponse,omitempty"`
+	Fault_ *soap.Fault                                `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmRetrieveSnapshotDetailsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmRetrieveSnapshotDetails(ctx context.Context, r soap.RoundTripper, req *types.VslmRetrieveSnapshotDetails) (*types.VslmRetrieveSnapshotDetailsResponse, error) {
+	var reqBody, resBody VslmRetrieveSnapshotDetailsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmRetrieveSnapshotInfoBody struct {
+	Req    *types.VslmRetrieveSnapshotInfo         `xml:"urn:vslm VslmRetrieveSnapshotInfo,omitempty"`
+	Res    *types.VslmRetrieveSnapshotInfoResponse `xml:"urn:vslm VslmRetrieveSnapshotInfoResponse,omitempty"`
+	Fault_ *soap.Fault                             `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmRetrieveSnapshotInfoBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmRetrieveSnapshotInfo(ctx context.Context, r soap.RoundTripper, req *types.VslmRetrieveSnapshotInfo) (*types.VslmRetrieveSnapshotInfoResponse, error) {
+	var reqBody, resBody VslmRetrieveSnapshotInfoBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmRetrieveVStorageInfrastructureObjectPolicyBody struct {
+	Req    *types.VslmRetrieveVStorageInfrastructureObjectPolicy         `xml:"urn:vslm VslmRetrieveVStorageInfrastructureObjectPolicy,omitempty"`
+	Res    *types.VslmRetrieveVStorageInfrastructureObjectPolicyResponse `xml:"urn:vslm VslmRetrieveVStorageInfrastructureObjectPolicyResponse,omitempty"`
+	Fault_ *soap.Fault                                                   `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmRetrieveVStorageInfrastructureObjectPolicyBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmRetrieveVStorageInfrastructureObjectPolicy(ctx context.Context, r soap.RoundTripper, req *types.VslmRetrieveVStorageInfrastructureObjectPolicy) (*types.VslmRetrieveVStorageInfrastructureObjectPolicyResponse, error) {
+	var reqBody, resBody VslmRetrieveVStorageInfrastructureObjectPolicyBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmRetrieveVStorageObjectBody struct {
+	Req    *types.VslmRetrieveVStorageObject         `xml:"urn:vslm VslmRetrieveVStorageObject,omitempty"`
+	Res    *types.VslmRetrieveVStorageObjectResponse `xml:"urn:vslm VslmRetrieveVStorageObjectResponse,omitempty"`
+	Fault_ *soap.Fault                               `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmRetrieveVStorageObjectBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmRetrieveVStorageObject(ctx context.Context, r soap.RoundTripper, req *types.VslmRetrieveVStorageObject) (*types.VslmRetrieveVStorageObjectResponse, error) {
+	var reqBody, resBody VslmRetrieveVStorageObjectBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmRetrieveVStorageObjectAssociationsBody struct {
+	Req    *types.VslmRetrieveVStorageObjectAssociations         `xml:"urn:vslm VslmRetrieveVStorageObjectAssociations,omitempty"`
+	Res    *types.VslmRetrieveVStorageObjectAssociationsResponse `xml:"urn:vslm VslmRetrieveVStorageObjectAssociationsResponse,omitempty"`
+	Fault_ *soap.Fault                                           `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmRetrieveVStorageObjectAssociationsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmRetrieveVStorageObjectAssociations(ctx context.Context, r soap.RoundTripper, req *types.VslmRetrieveVStorageObjectAssociations) (*types.VslmRetrieveVStorageObjectAssociationsResponse, error) {
+	var reqBody, resBody VslmRetrieveVStorageObjectAssociationsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmRetrieveVStorageObjectMetadataBody struct {
+	Req    *types.VslmRetrieveVStorageObjectMetadata         `xml:"urn:vslm VslmRetrieveVStorageObjectMetadata,omitempty"`
+	Res    *types.VslmRetrieveVStorageObjectMetadataResponse `xml:"urn:vslm VslmRetrieveVStorageObjectMetadataResponse,omitempty"`
+	Fault_ *soap.Fault                                       `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmRetrieveVStorageObjectMetadataBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmRetrieveVStorageObjectMetadata(ctx context.Context, r soap.RoundTripper, req *types.VslmRetrieveVStorageObjectMetadata) (*types.VslmRetrieveVStorageObjectMetadataResponse, error) {
+	var reqBody, resBody VslmRetrieveVStorageObjectMetadataBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmRetrieveVStorageObjectMetadataValueBody struct {
+	Req    *types.VslmRetrieveVStorageObjectMetadataValue         `xml:"urn:vslm VslmRetrieveVStorageObjectMetadataValue,omitempty"`
+	Res    *types.VslmRetrieveVStorageObjectMetadataValueResponse `xml:"urn:vslm VslmRetrieveVStorageObjectMetadataValueResponse,omitempty"`
+	Fault_ *soap.Fault                                            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmRetrieveVStorageObjectMetadataValueBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmRetrieveVStorageObjectMetadataValue(ctx context.Context, r soap.RoundTripper, req *types.VslmRetrieveVStorageObjectMetadataValue) (*types.VslmRetrieveVStorageObjectMetadataValueResponse, error) {
+	var reqBody, resBody VslmRetrieveVStorageObjectMetadataValueBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmRetrieveVStorageObjectStateBody struct {
+	Req    *types.VslmRetrieveVStorageObjectState         `xml:"urn:vslm VslmRetrieveVStorageObjectState,omitempty"`
+	Res    *types.VslmRetrieveVStorageObjectStateResponse `xml:"urn:vslm VslmRetrieveVStorageObjectStateResponse,omitempty"`
+	Fault_ *soap.Fault                                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmRetrieveVStorageObjectStateBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmRetrieveVStorageObjectState(ctx context.Context, r soap.RoundTripper, req *types.VslmRetrieveVStorageObjectState) (*types.VslmRetrieveVStorageObjectStateResponse, error) {
+	var reqBody, resBody VslmRetrieveVStorageObjectStateBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmRetrieveVStorageObjectsBody struct {
+	Req    *types.VslmRetrieveVStorageObjects         `xml:"urn:vslm VslmRetrieveVStorageObjects,omitempty"`
+	Res    *types.VslmRetrieveVStorageObjectsResponse `xml:"urn:vslm VslmRetrieveVStorageObjectsResponse,omitempty"`
+	Fault_ *soap.Fault                                `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmRetrieveVStorageObjectsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmRetrieveVStorageObjects(ctx context.Context, r soap.RoundTripper, req *types.VslmRetrieveVStorageObjects) (*types.VslmRetrieveVStorageObjectsResponse, error) {
+	var reqBody, resBody VslmRetrieveVStorageObjectsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmRevertVStorageObject_TaskBody struct {
+	Req    *types.VslmRevertVStorageObject_Task         `xml:"urn:vslm VslmRevertVStorageObject_Task,omitempty"`
+	Res    *types.VslmRevertVStorageObject_TaskResponse `xml:"urn:vslm VslmRevertVStorageObject_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                  `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmRevertVStorageObject_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmRevertVStorageObject_Task(ctx context.Context, r soap.RoundTripper, req *types.VslmRevertVStorageObject_Task) (*types.VslmRevertVStorageObject_TaskResponse, error) {
+	var reqBody, resBody VslmRevertVStorageObject_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmScheduleReconcileDatastoreInventoryBody struct {
+	Req    *types.VslmScheduleReconcileDatastoreInventory         `xml:"urn:vslm VslmScheduleReconcileDatastoreInventory,omitempty"`
+	Res    *types.VslmScheduleReconcileDatastoreInventoryResponse `xml:"urn:vslm VslmScheduleReconcileDatastoreInventoryResponse,omitempty"`
+	Fault_ *soap.Fault                                            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmScheduleReconcileDatastoreInventoryBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmScheduleReconcileDatastoreInventory(ctx context.Context, r soap.RoundTripper, req *types.VslmScheduleReconcileDatastoreInventory) (*types.VslmScheduleReconcileDatastoreInventoryResponse, error) {
+	var reqBody, resBody VslmScheduleReconcileDatastoreInventoryBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmSetVStorageObjectControlFlagsBody struct {
+	Req    *types.VslmSetVStorageObjectControlFlags         `xml:"urn:vslm VslmSetVStorageObjectControlFlags,omitempty"`
+	Res    *types.VslmSetVStorageObjectControlFlagsResponse `xml:"urn:vslm VslmSetVStorageObjectControlFlagsResponse,omitempty"`
+	Fault_ *soap.Fault                                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmSetVStorageObjectControlFlagsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmSetVStorageObjectControlFlags(ctx context.Context, r soap.RoundTripper, req *types.VslmSetVStorageObjectControlFlags) (*types.VslmSetVStorageObjectControlFlagsResponse, error) {
+	var reqBody, resBody VslmSetVStorageObjectControlFlagsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmSyncDatastoreBody struct {
+	Req    *types.VslmSyncDatastore         `xml:"urn:vslm VslmSyncDatastore,omitempty"`
+	Res    *types.VslmSyncDatastoreResponse `xml:"urn:vslm VslmSyncDatastoreResponse,omitempty"`
+	Fault_ *soap.Fault                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmSyncDatastoreBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmSyncDatastore(ctx context.Context, r soap.RoundTripper, req *types.VslmSyncDatastore) (*types.VslmSyncDatastoreResponse, error) {
+	var reqBody, resBody VslmSyncDatastoreBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmUpdateVStorageInfrastructureObjectPolicy_TaskBody struct {
+	Req    *types.VslmUpdateVStorageInfrastructureObjectPolicy_Task         `xml:"urn:vslm VslmUpdateVStorageInfrastructureObjectPolicy_Task,omitempty"`
+	Res    *types.VslmUpdateVStorageInfrastructureObjectPolicy_TaskResponse `xml:"urn:vslm VslmUpdateVStorageInfrastructureObjectPolicy_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmUpdateVStorageInfrastructureObjectPolicy_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmUpdateVStorageInfrastructureObjectPolicy_Task(ctx context.Context, r soap.RoundTripper, req *types.VslmUpdateVStorageInfrastructureObjectPolicy_Task) (*types.VslmUpdateVStorageInfrastructureObjectPolicy_TaskResponse, error) {
+	var reqBody, resBody VslmUpdateVStorageInfrastructureObjectPolicy_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmUpdateVStorageObjectMetadata_TaskBody struct {
+	Req    *types.VslmUpdateVStorageObjectMetadata_Task         `xml:"urn:vslm VslmUpdateVStorageObjectMetadata_Task,omitempty"`
+	Res    *types.VslmUpdateVStorageObjectMetadata_TaskResponse `xml:"urn:vslm VslmUpdateVStorageObjectMetadata_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                          `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmUpdateVStorageObjectMetadata_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmUpdateVStorageObjectMetadata_Task(ctx context.Context, r soap.RoundTripper, req *types.VslmUpdateVStorageObjectMetadata_Task) (*types.VslmUpdateVStorageObjectMetadata_TaskResponse, error) {
+	var reqBody, resBody VslmUpdateVStorageObjectMetadata_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VslmUpdateVstorageObjectPolicy_TaskBody struct {
+	Req    *types.VslmUpdateVstorageObjectPolicy_Task         `xml:"urn:vslm VslmUpdateVstorageObjectPolicy_Task,omitempty"`
+	Res    *types.VslmUpdateVstorageObjectPolicy_TaskResponse `xml:"urn:vslm VslmUpdateVstorageObjectPolicy_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                        `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VslmUpdateVstorageObjectPolicy_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VslmUpdateVstorageObjectPolicy_Task(ctx context.Context, r soap.RoundTripper, req *types.VslmUpdateVstorageObjectPolicy_Task) (*types.VslmUpdateVstorageObjectPolicy_TaskResponse, error) {
+	var reqBody, resBody VslmUpdateVstorageObjectPolicy_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}

--- a/vendor/github.com/vmware/govmomi/vslm/object_manager.go
+++ b/vendor/github.com/vmware/govmomi/vslm/object_manager.go
@@ -1,0 +1,422 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vslm
+
+import (
+	"context"
+	"errors"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// ObjectManager wraps VStorageObjectManagerBase.
+type ObjectManager struct {
+	types.ManagedObjectReference
+	c    *vim25.Client
+	isVC bool
+}
+
+// NewObjectManager returns an ObjectManager referencing the VcenterVStorageObjectManager singleton when connected to vCenter or
+// the HostVStorageObjectManager singleton when connected to an ESX host.  The optional ref param can be used to specify a ESX
+// host instead, when connected to vCenter.
+func NewObjectManager(client *vim25.Client, ref ...types.ManagedObjectReference) *ObjectManager {
+	mref := *client.ServiceContent.VStorageObjectManager
+
+	if len(ref) == 1 {
+		mref = ref[0]
+	}
+
+	m := ObjectManager{
+		ManagedObjectReference: mref,
+		c:                      client,
+		isVC:                   mref.Type == "VcenterVStorageObjectManager",
+	}
+
+	return &m
+}
+
+// PlaceDisk uses StorageResourceManager datastore placement recommendations to choose a Datastore from a Datastore cluster.
+// If the given spec backing Datastore field is not that of type StoragePod, the spec is unmodifed.
+// Otherwise, the backing Datastore field is replaced with a Datastore suggestion.
+func (m ObjectManager) PlaceDisk(ctx context.Context, spec *types.VslmCreateSpec, pool types.ManagedObjectReference) error {
+	backing := spec.BackingSpec.GetVslmCreateSpecBackingSpec()
+	if backing.Datastore.Type != "StoragePod" {
+		return nil
+	}
+
+	device := &types.VirtualDisk{
+		VirtualDevice: types.VirtualDevice{
+			Key: 0,
+			Backing: &types.VirtualDiskFlatVer2BackingInfo{
+				DiskMode:        string(types.VirtualDiskModePersistent),
+				ThinProvisioned: types.NewBool(true),
+			},
+			UnitNumber: types.NewInt32(0),
+		},
+		CapacityInKB: spec.CapacityInMB * 1024,
+	}
+
+	storage := types.StoragePlacementSpec{
+		Type:         string(types.StoragePlacementSpecPlacementTypeCreate),
+		ResourcePool: &pool,
+		PodSelectionSpec: types.StorageDrsPodSelectionSpec{
+			StoragePod: &backing.Datastore,
+			InitialVmConfig: []types.VmPodConfigForPlacement{
+				{
+					StoragePod: backing.Datastore,
+					Disk: []types.PodDiskLocator{
+						{
+							DiskId:          device.Key,
+							DiskBackingInfo: device.Backing,
+						},
+					},
+				},
+			},
+		},
+		ConfigSpec: &types.VirtualMachineConfigSpec{
+			Name: spec.Name,
+			DeviceChange: []types.BaseVirtualDeviceConfigSpec{
+				&types.VirtualDeviceConfigSpec{
+					Operation:     types.VirtualDeviceConfigSpecOperationAdd,
+					FileOperation: types.VirtualDeviceConfigSpecFileOperationCreate,
+					Device:        device,
+				},
+			},
+		},
+	}
+
+	req := types.RecommendDatastores{
+		This:        *m.c.ServiceContent.StorageResourceManager,
+		StorageSpec: storage,
+	}
+
+	res, err := methods.RecommendDatastores(ctx, m.c, &req)
+	if err != nil {
+		return err
+	}
+
+	r := res.Returnval.Recommendations
+	if len(r) == 0 {
+		return errors.New("no storage placement recommendations")
+	}
+
+	backing.Datastore = r[0].Action[0].(*types.StoragePlacementAction).Destination
+
+	return nil
+}
+
+func (m ObjectManager) CreateDisk(ctx context.Context, spec types.VslmCreateSpec) (*object.Task, error) {
+	req := types.CreateDisk_Task{
+		This: m.Reference(),
+		Spec: spec,
+	}
+
+	if m.isVC {
+		res, err := methods.CreateDisk_Task(ctx, m.c, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		return object.NewTask(m.c, res.Returnval), nil
+	}
+
+	res, err := methods.HostCreateDisk_Task(ctx, m.c, (*types.HostCreateDisk_Task)(&req))
+	if err != nil {
+		return nil, err
+	}
+
+	return object.NewTask(m.c, res.Returnval), nil
+}
+
+func (m ObjectManager) Rename(ctx context.Context, ds mo.Reference, id, name string) error {
+	req := types.RenameVStorageObject{
+		This:      m.Reference(),
+		Datastore: ds.Reference(),
+		Id:        types.ID{Id: id},
+		Name:      name,
+	}
+
+	if m.isVC {
+		_, err := methods.RenameVStorageObject(ctx, m.c, &req)
+		return err
+	}
+
+	_, err := methods.HostRenameVStorageObject(ctx, m.c, (*types.HostRenameVStorageObject)(&req))
+	return err
+}
+
+func (m ObjectManager) Delete(ctx context.Context, ds mo.Reference, id string) (*object.Task, error) {
+	req := types.DeleteVStorageObject_Task{
+		This:      m.Reference(),
+		Datastore: ds.Reference(),
+		Id:        types.ID{Id: id},
+	}
+
+	if m.isVC {
+		res, err := methods.DeleteVStorageObject_Task(ctx, m.c, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		return object.NewTask(m.c, res.Returnval), nil
+	}
+
+	res, err := methods.HostDeleteVStorageObject_Task(ctx, m.c, (*types.HostDeleteVStorageObject_Task)(&req))
+	if err != nil {
+		return nil, err
+	}
+
+	return object.NewTask(m.c, res.Returnval), nil
+}
+
+func (m ObjectManager) Retrieve(ctx context.Context, ds mo.Reference, id string) (*types.VStorageObject, error) {
+	req := types.RetrieveVStorageObject{
+		This:      m.Reference(),
+		Datastore: ds.Reference(),
+		Id:        types.ID{Id: id},
+	}
+
+	if m.isVC {
+		res, err := methods.RetrieveVStorageObject(ctx, m.c, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		return &res.Returnval, nil
+	}
+
+	res, err := methods.HostRetrieveVStorageObject(ctx, m.c, (*types.HostRetrieveVStorageObject)(&req))
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Returnval, nil
+}
+
+func (m ObjectManager) List(ctx context.Context, ds mo.Reference) ([]types.ID, error) {
+	req := types.ListVStorageObject{
+		This:      m.Reference(),
+		Datastore: ds.Reference(),
+	}
+
+	if m.isVC {
+		res, err := methods.ListVStorageObject(ctx, m.c, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		return res.Returnval, nil
+	}
+
+	res, err := methods.HostListVStorageObject(ctx, m.c, (*types.HostListVStorageObject)(&req))
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (m ObjectManager) RegisterDisk(ctx context.Context, path, name string) (*types.VStorageObject, error) {
+	req := types.RegisterDisk{
+		This: m.Reference(),
+		Path: path,
+		Name: name,
+	}
+
+	if m.isVC {
+		res, err := methods.RegisterDisk(ctx, m.c, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		return &res.Returnval, nil
+	}
+
+	res, err := methods.HostRegisterDisk(ctx, m.c, (*types.HostRegisterDisk)(&req))
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Returnval, nil
+}
+
+func (m ObjectManager) Clone(ctx context.Context, ds mo.Reference, id string, spec types.VslmCloneSpec) (*object.Task, error) {
+	req := types.CloneVStorageObject_Task{
+		This:      m.Reference(),
+		Datastore: ds.Reference(),
+		Id:        types.ID{Id: id},
+		Spec:      spec,
+	}
+
+	if m.isVC {
+		res, err := methods.CloneVStorageObject_Task(ctx, m.c, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		return object.NewTask(m.c, res.Returnval), nil
+	}
+
+	res, err := methods.HostCloneVStorageObject_Task(ctx, m.c, (*types.HostCloneVStorageObject_Task)(&req))
+	if err != nil {
+		return nil, err
+	}
+
+	return object.NewTask(m.c, res.Returnval), nil
+}
+
+func (m ObjectManager) CreateSnapshot(ctx context.Context, ds mo.Reference, id, desc string) (*object.Task, error) {
+	req := types.VStorageObjectCreateSnapshot_Task{
+		This:        m.Reference(),
+		Id:          types.ID{Id: id},
+		Description: desc,
+		Datastore:   ds.Reference(),
+	}
+
+	if m.isVC {
+		res, err := methods.VStorageObjectCreateSnapshot_Task(ctx, m.c, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		return object.NewTask(m.c, res.Returnval), nil
+	}
+
+	res, err := methods.HostVStorageObjectCreateSnapshot_Task(ctx, m.c, (*types.HostVStorageObjectCreateSnapshot_Task)(&req))
+	if err != nil {
+		return nil, err
+	}
+
+	return object.NewTask(m.c, res.Returnval), nil
+}
+
+func (m ObjectManager) DeleteSnapshot(ctx context.Context, ds mo.Reference, id, sid string) (*object.Task, error) {
+	req := types.DeleteSnapshot_Task{
+		This:       m.Reference(),
+		Datastore:  ds.Reference(),
+		Id:         types.ID{Id: id},
+		SnapshotId: types.ID{Id: sid},
+	}
+
+	if m.isVC {
+		res, err := methods.DeleteSnapshot_Task(ctx, m.c, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		return object.NewTask(m.c, res.Returnval), nil
+	}
+
+	res, err := methods.HostVStorageObjectDeleteSnapshot_Task(ctx, m.c, (*types.HostVStorageObjectDeleteSnapshot_Task)(&req))
+	if err != nil {
+		return nil, err
+	}
+
+	return object.NewTask(m.c, res.Returnval), nil
+}
+
+func (m ObjectManager) RetrieveSnapshotInfo(ctx context.Context, ds mo.Reference, id string) (*types.VStorageObjectSnapshotInfo, error) {
+	req := types.RetrieveSnapshotInfo{
+		This:      m.Reference(),
+		Datastore: ds.Reference(),
+		Id:        types.ID{Id: id},
+	}
+
+	if m.isVC {
+		res, err := methods.RetrieveSnapshotInfo(ctx, m.c, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		return &res.Returnval, nil
+	}
+
+	res, err := methods.HostVStorageObjectRetrieveSnapshotInfo(ctx, m.c, (*types.HostVStorageObjectRetrieveSnapshotInfo)(&req))
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Returnval, nil
+}
+
+func (m ObjectManager) AttachTag(ctx context.Context, id string, tag types.VslmTagEntry) error {
+	req := &types.AttachTagToVStorageObject{
+		This:     m.ManagedObjectReference,
+		Id:       types.ID{Id: id},
+		Category: tag.ParentCategoryName,
+		Tag:      tag.TagName,
+	}
+
+	_, err := methods.AttachTagToVStorageObject(ctx, m.c, req)
+	return err
+}
+
+func (m ObjectManager) DetachTag(ctx context.Context, id string, tag types.VslmTagEntry) error {
+	req := &types.DetachTagFromVStorageObject{
+		This:     m.ManagedObjectReference,
+		Id:       types.ID{Id: id},
+		Category: tag.ParentCategoryName,
+		Tag:      tag.TagName,
+	}
+
+	_, err := methods.DetachTagFromVStorageObject(ctx, m.c, req)
+	return err
+}
+
+func (m ObjectManager) ListAttachedObjects(ctx context.Context, category, tag string) ([]types.ID, error) {
+	req := &types.ListVStorageObjectsAttachedToTag{
+		This:     m.ManagedObjectReference,
+		Category: category,
+		Tag:      tag,
+	}
+
+	res, err := methods.ListVStorageObjectsAttachedToTag(ctx, m.c, req)
+	if err != nil {
+		return nil, err
+	}
+	return res.Returnval, nil
+}
+
+func (m ObjectManager) ListAttachedTags(ctx context.Context, id string) ([]types.VslmTagEntry, error) {
+	req := &types.ListTagsAttachedToVStorageObject{
+		This: m.ManagedObjectReference,
+		Id:   types.ID{Id: id},
+	}
+
+	res, err := methods.ListTagsAttachedToVStorageObject(ctx, m.c, req)
+	if err != nil {
+		return nil, err
+	}
+	return res.Returnval, nil
+}
+
+func (m ObjectManager) ReconcileDatastoreInventory(ctx context.Context, ds mo.Reference) (*object.Task, error) {
+	req := &types.ReconcileDatastoreInventory_Task{
+		This:      m.Reference(),
+		Datastore: ds.Reference(),
+	}
+
+	res, err := methods.ReconcileDatastoreInventory_Task(ctx, m.c, req)
+	if err != nil {
+		return nil, err
+	}
+	return object.NewTask(m.c, res.Returnval), nil
+}

--- a/vendor/github.com/vmware/govmomi/vslm/types/enum.go
+++ b/vendor/github.com/vmware/govmomi/vslm/types/enum.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"reflect"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type VslmTaskInfoState string
+
+const (
+	VslmTaskInfoStateQueued  = VslmTaskInfoState("queued")
+	VslmTaskInfoStateRunning = VslmTaskInfoState("running")
+	VslmTaskInfoStateSuccess = VslmTaskInfoState("success")
+	VslmTaskInfoStateError   = VslmTaskInfoState("error")
+)
+
+func init() {
+	types.Add("vslm:VslmTaskInfoState", reflect.TypeOf((*VslmTaskInfoState)(nil)).Elem())
+}
+
+type VslmVsoVStorageObjectQuerySpecQueryFieldEnum string
+
+const (
+	VslmVsoVStorageObjectQuerySpecQueryFieldEnumId              = VslmVsoVStorageObjectQuerySpecQueryFieldEnum("id")
+	VslmVsoVStorageObjectQuerySpecQueryFieldEnumName            = VslmVsoVStorageObjectQuerySpecQueryFieldEnum("name")
+	VslmVsoVStorageObjectQuerySpecQueryFieldEnumCapacity        = VslmVsoVStorageObjectQuerySpecQueryFieldEnum("capacity")
+	VslmVsoVStorageObjectQuerySpecQueryFieldEnumCreateTime      = VslmVsoVStorageObjectQuerySpecQueryFieldEnum("createTime")
+	VslmVsoVStorageObjectQuerySpecQueryFieldEnumBackingObjectId = VslmVsoVStorageObjectQuerySpecQueryFieldEnum("backingObjectId")
+	VslmVsoVStorageObjectQuerySpecQueryFieldEnumDatastoreMoId   = VslmVsoVStorageObjectQuerySpecQueryFieldEnum("datastoreMoId")
+	VslmVsoVStorageObjectQuerySpecQueryFieldEnumMetadataKey     = VslmVsoVStorageObjectQuerySpecQueryFieldEnum("metadataKey")
+	VslmVsoVStorageObjectQuerySpecQueryFieldEnumMetadataValue   = VslmVsoVStorageObjectQuerySpecQueryFieldEnum("metadataValue")
+)
+
+func init() {
+	types.Add("vslm:VslmVsoVStorageObjectQuerySpecQueryFieldEnum", reflect.TypeOf((*VslmVsoVStorageObjectQuerySpecQueryFieldEnum)(nil)).Elem())
+}
+
+type VslmVsoVStorageObjectQuerySpecQueryOperatorEnum string
+
+const (
+	VslmVsoVStorageObjectQuerySpecQueryOperatorEnumEquals             = VslmVsoVStorageObjectQuerySpecQueryOperatorEnum("equals")
+	VslmVsoVStorageObjectQuerySpecQueryOperatorEnumNotEquals          = VslmVsoVStorageObjectQuerySpecQueryOperatorEnum("notEquals")
+	VslmVsoVStorageObjectQuerySpecQueryOperatorEnumLessThan           = VslmVsoVStorageObjectQuerySpecQueryOperatorEnum("lessThan")
+	VslmVsoVStorageObjectQuerySpecQueryOperatorEnumGreaterThan        = VslmVsoVStorageObjectQuerySpecQueryOperatorEnum("greaterThan")
+	VslmVsoVStorageObjectQuerySpecQueryOperatorEnumLessThanOrEqual    = VslmVsoVStorageObjectQuerySpecQueryOperatorEnum("lessThanOrEqual")
+	VslmVsoVStorageObjectQuerySpecQueryOperatorEnumGreaterThanOrEqual = VslmVsoVStorageObjectQuerySpecQueryOperatorEnum("greaterThanOrEqual")
+	VslmVsoVStorageObjectQuerySpecQueryOperatorEnumContains           = VslmVsoVStorageObjectQuerySpecQueryOperatorEnum("contains")
+	VslmVsoVStorageObjectQuerySpecQueryOperatorEnumStartsWith         = VslmVsoVStorageObjectQuerySpecQueryOperatorEnum("startsWith")
+	VslmVsoVStorageObjectQuerySpecQueryOperatorEnumEndsWith           = VslmVsoVStorageObjectQuerySpecQueryOperatorEnum("endsWith")
+)
+
+func init() {
+	types.Add("vslm:VslmVsoVStorageObjectQuerySpecQueryOperatorEnum", reflect.TypeOf((*VslmVsoVStorageObjectQuerySpecQueryOperatorEnum)(nil)).Elem())
+}

--- a/vendor/github.com/vmware/govmomi/vslm/types/if.go
+++ b/vendor/github.com/vmware/govmomi/vslm/types/if.go
@@ -1,0 +1,43 @@
+/*
+Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"reflect"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func (b *VslmFault) GetVslmFault() *VslmFault { return b }
+
+type BaseVslmFault interface {
+	GetVslmFault() *VslmFault
+}
+
+func init() {
+	types.Add("BaseVslmFault", reflect.TypeOf((*VslmFault)(nil)).Elem())
+}
+
+func (b *VslmTaskReason) GetVslmTaskReason() *VslmTaskReason { return b }
+
+type BaseVslmTaskReason interface {
+	GetVslmTaskReason() *VslmTaskReason
+}
+
+func init() {
+	types.Add("BaseVslmTaskReason", reflect.TypeOf((*VslmTaskReason)(nil)).Elem())
+}

--- a/vendor/github.com/vmware/govmomi/vslm/types/types.go
+++ b/vendor/github.com/vmware/govmomi/vslm/types/types.go
@@ -1,0 +1,1201 @@
+/*
+Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"reflect"
+	"time"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ArrayOfVslmDatastoreSyncStatus struct {
+	VslmDatastoreSyncStatus []VslmDatastoreSyncStatus `xml:"VslmDatastoreSyncStatus,omitempty"`
+}
+
+func init() {
+	types.Add("vslm:ArrayOfVslmDatastoreSyncStatus", reflect.TypeOf((*ArrayOfVslmDatastoreSyncStatus)(nil)).Elem())
+}
+
+type ArrayOfVslmQueryDatastoreInfoResult struct {
+	VslmQueryDatastoreInfoResult []VslmQueryDatastoreInfoResult `xml:"VslmQueryDatastoreInfoResult,omitempty"`
+}
+
+func init() {
+	types.Add("vslm:ArrayOfVslmQueryDatastoreInfoResult", reflect.TypeOf((*ArrayOfVslmQueryDatastoreInfoResult)(nil)).Elem())
+}
+
+type ArrayOfVslmVsoVStorageObjectAssociations struct {
+	VslmVsoVStorageObjectAssociations []VslmVsoVStorageObjectAssociations `xml:"VslmVsoVStorageObjectAssociations,omitempty"`
+}
+
+func init() {
+	types.Add("vslm:ArrayOfVslmVsoVStorageObjectAssociations", reflect.TypeOf((*ArrayOfVslmVsoVStorageObjectAssociations)(nil)).Elem())
+}
+
+type ArrayOfVslmVsoVStorageObjectAssociationsVmDiskAssociation struct {
+	VslmVsoVStorageObjectAssociationsVmDiskAssociation []VslmVsoVStorageObjectAssociationsVmDiskAssociation `xml:"VslmVsoVStorageObjectAssociationsVmDiskAssociation,omitempty"`
+}
+
+func init() {
+	types.Add("vslm:ArrayOfVslmVsoVStorageObjectAssociationsVmDiskAssociation", reflect.TypeOf((*ArrayOfVslmVsoVStorageObjectAssociationsVmDiskAssociation)(nil)).Elem())
+}
+
+type ArrayOfVslmVsoVStorageObjectQuerySpec struct {
+	VslmVsoVStorageObjectQuerySpec []VslmVsoVStorageObjectQuerySpec `xml:"VslmVsoVStorageObjectQuerySpec,omitempty"`
+}
+
+func init() {
+	types.Add("vslm:ArrayOfVslmVsoVStorageObjectQuerySpec", reflect.TypeOf((*ArrayOfVslmVsoVStorageObjectQuerySpec)(nil)).Elem())
+}
+
+type ArrayOfVslmVsoVStorageObjectResult struct {
+	VslmVsoVStorageObjectResult []VslmVsoVStorageObjectResult `xml:"VslmVsoVStorageObjectResult,omitempty"`
+}
+
+func init() {
+	types.Add("vslm:ArrayOfVslmVsoVStorageObjectResult", reflect.TypeOf((*ArrayOfVslmVsoVStorageObjectResult)(nil)).Elem())
+}
+
+type ArrayOfVslmVsoVStorageObjectSnapshotResult struct {
+	VslmVsoVStorageObjectSnapshotResult []VslmVsoVStorageObjectSnapshotResult `xml:"VslmVsoVStorageObjectSnapshotResult,omitempty"`
+}
+
+func init() {
+	types.Add("vslm:ArrayOfVslmVsoVStorageObjectSnapshotResult", reflect.TypeOf((*ArrayOfVslmVsoVStorageObjectSnapshotResult)(nil)).Elem())
+}
+
+type RetrieveContent RetrieveContentRequestType
+
+func init() {
+	types.Add("vslm:RetrieveContent", reflect.TypeOf((*RetrieveContent)(nil)).Elem())
+}
+
+type RetrieveContentRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("vslm:RetrieveContentRequestType", reflect.TypeOf((*RetrieveContentRequestType)(nil)).Elem())
+}
+
+type RetrieveContentResponse struct {
+	Returnval VslmServiceInstanceContent `xml:"returnval"`
+}
+
+type VslmAboutInfo struct {
+	types.DynamicData
+
+	Name         string `xml:"name"`
+	FullName     string `xml:"fullName"`
+	Vendor       string `xml:"vendor"`
+	ApiVersion   string `xml:"apiVersion"`
+	InstanceUuid string `xml:"instanceUuid"`
+}
+
+func init() {
+	types.Add("vslm:VslmAboutInfo", reflect.TypeOf((*VslmAboutInfo)(nil)).Elem())
+}
+
+type VslmAttachDiskRequestType struct {
+	This          types.ManagedObjectReference `xml:"_this"`
+	Id            types.ID                     `xml:"id"`
+	Vm            types.ManagedObjectReference `xml:"vm"`
+	ControllerKey int32                        `xml:"controllerKey,omitempty"`
+	UnitNumber    *int32                       `xml:"unitNumber"`
+}
+
+func init() {
+	types.Add("vslm:VslmAttachDiskRequestType", reflect.TypeOf((*VslmAttachDiskRequestType)(nil)).Elem())
+}
+
+type VslmAttachDisk_Task VslmAttachDiskRequestType
+
+func init() {
+	types.Add("vslm:VslmAttachDisk_Task", reflect.TypeOf((*VslmAttachDisk_Task)(nil)).Elem())
+}
+
+type VslmAttachDisk_TaskResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type VslmAttachTagToVStorageObject VslmAttachTagToVStorageObjectRequestType
+
+func init() {
+	types.Add("vslm:VslmAttachTagToVStorageObject", reflect.TypeOf((*VslmAttachTagToVStorageObject)(nil)).Elem())
+}
+
+type VslmAttachTagToVStorageObjectRequestType struct {
+	This     types.ManagedObjectReference `xml:"_this"`
+	Id       types.ID                     `xml:"id"`
+	Category string                       `xml:"category"`
+	Tag      string                       `xml:"tag"`
+}
+
+func init() {
+	types.Add("vslm:VslmAttachTagToVStorageObjectRequestType", reflect.TypeOf((*VslmAttachTagToVStorageObjectRequestType)(nil)).Elem())
+}
+
+type VslmAttachTagToVStorageObjectResponse struct {
+}
+
+type VslmCancelTask VslmCancelTaskRequestType
+
+func init() {
+	types.Add("vslm:VslmCancelTask", reflect.TypeOf((*VslmCancelTask)(nil)).Elem())
+}
+
+type VslmCancelTaskRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("vslm:VslmCancelTaskRequestType", reflect.TypeOf((*VslmCancelTaskRequestType)(nil)).Elem())
+}
+
+type VslmCancelTaskResponse struct {
+}
+
+type VslmClearVStorageObjectControlFlags VslmClearVStorageObjectControlFlagsRequestType
+
+func init() {
+	types.Add("vslm:VslmClearVStorageObjectControlFlags", reflect.TypeOf((*VslmClearVStorageObjectControlFlags)(nil)).Elem())
+}
+
+type VslmClearVStorageObjectControlFlagsRequestType struct {
+	This         types.ManagedObjectReference `xml:"_this"`
+	Id           types.ID                     `xml:"id"`
+	ControlFlags []string                     `xml:"controlFlags,omitempty"`
+}
+
+func init() {
+	types.Add("vslm:VslmClearVStorageObjectControlFlagsRequestType", reflect.TypeOf((*VslmClearVStorageObjectControlFlagsRequestType)(nil)).Elem())
+}
+
+type VslmClearVStorageObjectControlFlagsResponse struct {
+}
+
+type VslmCloneVStorageObjectRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+	Id   types.ID                     `xml:"id"`
+	Spec types.VslmCloneSpec          `xml:"spec"`
+}
+
+func init() {
+	types.Add("vslm:VslmCloneVStorageObjectRequestType", reflect.TypeOf((*VslmCloneVStorageObjectRequestType)(nil)).Elem())
+}
+
+type VslmCloneVStorageObject_Task VslmCloneVStorageObjectRequestType
+
+func init() {
+	types.Add("vslm:VslmCloneVStorageObject_Task", reflect.TypeOf((*VslmCloneVStorageObject_Task)(nil)).Elem())
+}
+
+type VslmCloneVStorageObject_TaskResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type VslmCreateDiskFromSnapshotRequestType struct {
+	This       types.ManagedObjectReference      `xml:"_this"`
+	Id         types.ID                          `xml:"id"`
+	SnapshotId types.ID                          `xml:"snapshotId"`
+	Name       string                            `xml:"name"`
+	Profile    []types.VirtualMachineProfileSpec `xml:"profile,omitempty"`
+	Crypto     *types.CryptoSpec                 `xml:"crypto,omitempty"`
+	Path       string                            `xml:"path,omitempty"`
+}
+
+func init() {
+	types.Add("vslm:VslmCreateDiskFromSnapshotRequestType", reflect.TypeOf((*VslmCreateDiskFromSnapshotRequestType)(nil)).Elem())
+}
+
+type VslmCreateDiskFromSnapshot_Task VslmCreateDiskFromSnapshotRequestType
+
+func init() {
+	types.Add("vslm:VslmCreateDiskFromSnapshot_Task", reflect.TypeOf((*VslmCreateDiskFromSnapshot_Task)(nil)).Elem())
+}
+
+type VslmCreateDiskFromSnapshot_TaskResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type VslmCreateDiskRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+	Spec types.VslmCreateSpec         `xml:"spec"`
+}
+
+func init() {
+	types.Add("vslm:VslmCreateDiskRequestType", reflect.TypeOf((*VslmCreateDiskRequestType)(nil)).Elem())
+}
+
+type VslmCreateDisk_Task VslmCreateDiskRequestType
+
+func init() {
+	types.Add("vslm:VslmCreateDisk_Task", reflect.TypeOf((*VslmCreateDisk_Task)(nil)).Elem())
+}
+
+type VslmCreateDisk_TaskResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type VslmCreateSnapshotRequestType struct {
+	This        types.ManagedObjectReference `xml:"_this"`
+	Id          types.ID                     `xml:"id"`
+	Description string                       `xml:"description"`
+}
+
+func init() {
+	types.Add("vslm:VslmCreateSnapshotRequestType", reflect.TypeOf((*VslmCreateSnapshotRequestType)(nil)).Elem())
+}
+
+type VslmCreateSnapshot_Task VslmCreateSnapshotRequestType
+
+func init() {
+	types.Add("vslm:VslmCreateSnapshot_Task", reflect.TypeOf((*VslmCreateSnapshot_Task)(nil)).Elem())
+}
+
+type VslmCreateSnapshot_TaskResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type VslmDatastoreSyncStatus struct {
+	types.DynamicData
+
+	DatastoreURL    string                      `xml:"datastoreURL"`
+	ObjectVClock    int64                       `xml:"objectVClock"`
+	SyncVClock      int64                       `xml:"syncVClock"`
+	SyncTime        *time.Time                  `xml:"syncTime"`
+	NumberOfRetries int32                       `xml:"numberOfRetries,omitempty"`
+	Error           *types.LocalizedMethodFault `xml:"error,omitempty"`
+}
+
+func init() {
+	types.Add("vslm:VslmDatastoreSyncStatus", reflect.TypeOf((*VslmDatastoreSyncStatus)(nil)).Elem())
+}
+
+type VslmDeleteSnapshotRequestType struct {
+	This       types.ManagedObjectReference `xml:"_this"`
+	Id         types.ID                     `xml:"id"`
+	SnapshotId types.ID                     `xml:"snapshotId"`
+}
+
+func init() {
+	types.Add("vslm:VslmDeleteSnapshotRequestType", reflect.TypeOf((*VslmDeleteSnapshotRequestType)(nil)).Elem())
+}
+
+type VslmDeleteSnapshot_Task VslmDeleteSnapshotRequestType
+
+func init() {
+	types.Add("vslm:VslmDeleteSnapshot_Task", reflect.TypeOf((*VslmDeleteSnapshot_Task)(nil)).Elem())
+}
+
+type VslmDeleteSnapshot_TaskResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type VslmDeleteVStorageObjectRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+	Id   types.ID                     `xml:"id"`
+}
+
+func init() {
+	types.Add("vslm:VslmDeleteVStorageObjectRequestType", reflect.TypeOf((*VslmDeleteVStorageObjectRequestType)(nil)).Elem())
+}
+
+type VslmDeleteVStorageObject_Task VslmDeleteVStorageObjectRequestType
+
+func init() {
+	types.Add("vslm:VslmDeleteVStorageObject_Task", reflect.TypeOf((*VslmDeleteVStorageObject_Task)(nil)).Elem())
+}
+
+type VslmDeleteVStorageObject_TaskResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type VslmDetachTagFromVStorageObject VslmDetachTagFromVStorageObjectRequestType
+
+func init() {
+	types.Add("vslm:VslmDetachTagFromVStorageObject", reflect.TypeOf((*VslmDetachTagFromVStorageObject)(nil)).Elem())
+}
+
+type VslmDetachTagFromVStorageObjectRequestType struct {
+	This     types.ManagedObjectReference `xml:"_this"`
+	Id       types.ID                     `xml:"id"`
+	Category string                       `xml:"category"`
+	Tag      string                       `xml:"tag"`
+}
+
+func init() {
+	types.Add("vslm:VslmDetachTagFromVStorageObjectRequestType", reflect.TypeOf((*VslmDetachTagFromVStorageObjectRequestType)(nil)).Elem())
+}
+
+type VslmDetachTagFromVStorageObjectResponse struct {
+}
+
+type VslmExtendDiskRequestType struct {
+	This            types.ManagedObjectReference `xml:"_this"`
+	Id              types.ID                     `xml:"id"`
+	NewCapacityInMB int64                        `xml:"newCapacityInMB"`
+}
+
+func init() {
+	types.Add("vslm:VslmExtendDiskRequestType", reflect.TypeOf((*VslmExtendDiskRequestType)(nil)).Elem())
+}
+
+type VslmExtendDisk_Task VslmExtendDiskRequestType
+
+func init() {
+	types.Add("vslm:VslmExtendDisk_Task", reflect.TypeOf((*VslmExtendDisk_Task)(nil)).Elem())
+}
+
+type VslmExtendDisk_TaskResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type VslmFault struct {
+	types.MethodFault
+
+	Msg string `xml:"msg,omitempty"`
+}
+
+func init() {
+	types.Add("vslm:VslmFault", reflect.TypeOf((*VslmFault)(nil)).Elem())
+}
+
+type VslmFaultFault BaseVslmFault
+
+func init() {
+	types.Add("vslm:VslmFaultFault", reflect.TypeOf((*VslmFaultFault)(nil)).Elem())
+}
+
+type VslmInflateDiskRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+	Id   types.ID                     `xml:"id"`
+}
+
+func init() {
+	types.Add("vslm:VslmInflateDiskRequestType", reflect.TypeOf((*VslmInflateDiskRequestType)(nil)).Elem())
+}
+
+type VslmInflateDisk_Task VslmInflateDiskRequestType
+
+func init() {
+	types.Add("vslm:VslmInflateDisk_Task", reflect.TypeOf((*VslmInflateDisk_Task)(nil)).Elem())
+}
+
+type VslmInflateDisk_TaskResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type VslmListTagsAttachedToVStorageObject VslmListTagsAttachedToVStorageObjectRequestType
+
+func init() {
+	types.Add("vslm:VslmListTagsAttachedToVStorageObject", reflect.TypeOf((*VslmListTagsAttachedToVStorageObject)(nil)).Elem())
+}
+
+type VslmListTagsAttachedToVStorageObjectRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+	Id   types.ID                     `xml:"id"`
+}
+
+func init() {
+	types.Add("vslm:VslmListTagsAttachedToVStorageObjectRequestType", reflect.TypeOf((*VslmListTagsAttachedToVStorageObjectRequestType)(nil)).Elem())
+}
+
+type VslmListTagsAttachedToVStorageObjectResponse struct {
+	Returnval []types.VslmTagEntry `xml:"returnval,omitempty"`
+}
+
+type VslmListVStorageObjectForSpec VslmListVStorageObjectForSpecRequestType
+
+func init() {
+	types.Add("vslm:VslmListVStorageObjectForSpec", reflect.TypeOf((*VslmListVStorageObjectForSpec)(nil)).Elem())
+}
+
+type VslmListVStorageObjectForSpecRequestType struct {
+	This      types.ManagedObjectReference     `xml:"_this"`
+	Query     []VslmVsoVStorageObjectQuerySpec `xml:"query,omitempty"`
+	MaxResult int32                            `xml:"maxResult"`
+}
+
+func init() {
+	types.Add("vslm:VslmListVStorageObjectForSpecRequestType", reflect.TypeOf((*VslmListVStorageObjectForSpecRequestType)(nil)).Elem())
+}
+
+type VslmListVStorageObjectForSpecResponse struct {
+	Returnval *VslmVsoVStorageObjectQueryResult `xml:"returnval,omitempty"`
+}
+
+type VslmListVStorageObjectsAttachedToTag VslmListVStorageObjectsAttachedToTagRequestType
+
+func init() {
+	types.Add("vslm:VslmListVStorageObjectsAttachedToTag", reflect.TypeOf((*VslmListVStorageObjectsAttachedToTag)(nil)).Elem())
+}
+
+type VslmListVStorageObjectsAttachedToTagRequestType struct {
+	This     types.ManagedObjectReference `xml:"_this"`
+	Category string                       `xml:"category"`
+	Tag      string                       `xml:"tag"`
+}
+
+func init() {
+	types.Add("vslm:VslmListVStorageObjectsAttachedToTagRequestType", reflect.TypeOf((*VslmListVStorageObjectsAttachedToTagRequestType)(nil)).Elem())
+}
+
+type VslmListVStorageObjectsAttachedToTagResponse struct {
+	Returnval []types.ID `xml:"returnval,omitempty"`
+}
+
+type VslmLoginByToken VslmLoginByTokenRequestType
+
+func init() {
+	types.Add("vslm:VslmLoginByToken", reflect.TypeOf((*VslmLoginByToken)(nil)).Elem())
+}
+
+type VslmLoginByTokenRequestType struct {
+	This              types.ManagedObjectReference `xml:"_this"`
+	DelegatedTokenXml string                       `xml:"delegatedTokenXml"`
+}
+
+func init() {
+	types.Add("vslm:VslmLoginByTokenRequestType", reflect.TypeOf((*VslmLoginByTokenRequestType)(nil)).Elem())
+}
+
+type VslmLoginByTokenResponse struct {
+}
+
+type VslmLogout VslmLogoutRequestType
+
+func init() {
+	types.Add("vslm:VslmLogout", reflect.TypeOf((*VslmLogout)(nil)).Elem())
+}
+
+type VslmLogoutRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("vslm:VslmLogoutRequestType", reflect.TypeOf((*VslmLogoutRequestType)(nil)).Elem())
+}
+
+type VslmLogoutResponse struct {
+}
+
+type VslmQueryChangedDiskAreas VslmQueryChangedDiskAreasRequestType
+
+func init() {
+	types.Add("vslm:VslmQueryChangedDiskAreas", reflect.TypeOf((*VslmQueryChangedDiskAreas)(nil)).Elem())
+}
+
+type VslmQueryChangedDiskAreasRequestType struct {
+	This        types.ManagedObjectReference `xml:"_this"`
+	Id          types.ID                     `xml:"id"`
+	SnapshotId  types.ID                     `xml:"snapshotId"`
+	StartOffset int64                        `xml:"startOffset"`
+	ChangeId    string                       `xml:"changeId"`
+}
+
+func init() {
+	types.Add("vslm:VslmQueryChangedDiskAreasRequestType", reflect.TypeOf((*VslmQueryChangedDiskAreasRequestType)(nil)).Elem())
+}
+
+type VslmQueryChangedDiskAreasResponse struct {
+	Returnval types.DiskChangeInfo `xml:"returnval"`
+}
+
+type VslmQueryDatastoreInfo VslmQueryDatastoreInfoRequestType
+
+func init() {
+	types.Add("vslm:VslmQueryDatastoreInfo", reflect.TypeOf((*VslmQueryDatastoreInfo)(nil)).Elem())
+}
+
+type VslmQueryDatastoreInfoRequestType struct {
+	This         types.ManagedObjectReference `xml:"_this"`
+	DatastoreUrl string                       `xml:"datastoreUrl"`
+}
+
+func init() {
+	types.Add("vslm:VslmQueryDatastoreInfoRequestType", reflect.TypeOf((*VslmQueryDatastoreInfoRequestType)(nil)).Elem())
+}
+
+type VslmQueryDatastoreInfoResponse struct {
+	Returnval []VslmQueryDatastoreInfoResult `xml:"returnval,omitempty"`
+}
+
+type VslmQueryDatastoreInfoResult struct {
+	types.DynamicData
+
+	Datacenter types.ManagedObjectReference `xml:"datacenter"`
+	Datastore  types.ManagedObjectReference `xml:"datastore"`
+}
+
+func init() {
+	types.Add("vslm:VslmQueryDatastoreInfoResult", reflect.TypeOf((*VslmQueryDatastoreInfoResult)(nil)).Elem())
+}
+
+type VslmQueryGlobalCatalogSyncStatus VslmQueryGlobalCatalogSyncStatusRequestType
+
+func init() {
+	types.Add("vslm:VslmQueryGlobalCatalogSyncStatus", reflect.TypeOf((*VslmQueryGlobalCatalogSyncStatus)(nil)).Elem())
+}
+
+type VslmQueryGlobalCatalogSyncStatusForDatastore VslmQueryGlobalCatalogSyncStatusForDatastoreRequestType
+
+func init() {
+	types.Add("vslm:VslmQueryGlobalCatalogSyncStatusForDatastore", reflect.TypeOf((*VslmQueryGlobalCatalogSyncStatusForDatastore)(nil)).Elem())
+}
+
+type VslmQueryGlobalCatalogSyncStatusForDatastoreRequestType struct {
+	This         types.ManagedObjectReference `xml:"_this"`
+	DatastoreURL string                       `xml:"datastoreURL"`
+}
+
+func init() {
+	types.Add("vslm:VslmQueryGlobalCatalogSyncStatusForDatastoreRequestType", reflect.TypeOf((*VslmQueryGlobalCatalogSyncStatusForDatastoreRequestType)(nil)).Elem())
+}
+
+type VslmQueryGlobalCatalogSyncStatusForDatastoreResponse struct {
+	Returnval *VslmDatastoreSyncStatus `xml:"returnval,omitempty"`
+}
+
+type VslmQueryGlobalCatalogSyncStatusRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("vslm:VslmQueryGlobalCatalogSyncStatusRequestType", reflect.TypeOf((*VslmQueryGlobalCatalogSyncStatusRequestType)(nil)).Elem())
+}
+
+type VslmQueryGlobalCatalogSyncStatusResponse struct {
+	Returnval []VslmDatastoreSyncStatus `xml:"returnval,omitempty"`
+}
+
+type VslmQueryInfo VslmQueryInfoRequestType
+
+func init() {
+	types.Add("vslm:VslmQueryInfo", reflect.TypeOf((*VslmQueryInfo)(nil)).Elem())
+}
+
+type VslmQueryInfoRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("vslm:VslmQueryInfoRequestType", reflect.TypeOf((*VslmQueryInfoRequestType)(nil)).Elem())
+}
+
+type VslmQueryInfoResponse struct {
+	Returnval VslmTaskInfo `xml:"returnval"`
+}
+
+type VslmQueryTaskResult VslmQueryTaskResultRequestType
+
+func init() {
+	types.Add("vslm:VslmQueryTaskResult", reflect.TypeOf((*VslmQueryTaskResult)(nil)).Elem())
+}
+
+type VslmQueryTaskResultRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("vslm:VslmQueryTaskResultRequestType", reflect.TypeOf((*VslmQueryTaskResultRequestType)(nil)).Elem())
+}
+
+type VslmQueryTaskResultResponse struct {
+	Returnval types.AnyType `xml:"returnval,omitempty,typeattr"`
+}
+
+type VslmReconcileDatastoreInventoryRequestType struct {
+	This      types.ManagedObjectReference `xml:"_this"`
+	Datastore types.ManagedObjectReference `xml:"datastore"`
+}
+
+func init() {
+	types.Add("vslm:VslmReconcileDatastoreInventoryRequestType", reflect.TypeOf((*VslmReconcileDatastoreInventoryRequestType)(nil)).Elem())
+}
+
+type VslmReconcileDatastoreInventory_Task VslmReconcileDatastoreInventoryRequestType
+
+func init() {
+	types.Add("vslm:VslmReconcileDatastoreInventory_Task", reflect.TypeOf((*VslmReconcileDatastoreInventory_Task)(nil)).Elem())
+}
+
+type VslmReconcileDatastoreInventory_TaskResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type VslmRegisterDisk VslmRegisterDiskRequestType
+
+func init() {
+	types.Add("vslm:VslmRegisterDisk", reflect.TypeOf((*VslmRegisterDisk)(nil)).Elem())
+}
+
+type VslmRegisterDiskRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+	Path string                       `xml:"path"`
+	Name string                       `xml:"name,omitempty"`
+}
+
+func init() {
+	types.Add("vslm:VslmRegisterDiskRequestType", reflect.TypeOf((*VslmRegisterDiskRequestType)(nil)).Elem())
+}
+
+type VslmRegisterDiskResponse struct {
+	Returnval types.VStorageObject `xml:"returnval"`
+}
+
+type VslmRelocateVStorageObjectRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+	Id   types.ID                     `xml:"id"`
+	Spec types.VslmRelocateSpec       `xml:"spec"`
+}
+
+func init() {
+	types.Add("vslm:VslmRelocateVStorageObjectRequestType", reflect.TypeOf((*VslmRelocateVStorageObjectRequestType)(nil)).Elem())
+}
+
+type VslmRelocateVStorageObject_Task VslmRelocateVStorageObjectRequestType
+
+func init() {
+	types.Add("vslm:VslmRelocateVStorageObject_Task", reflect.TypeOf((*VslmRelocateVStorageObject_Task)(nil)).Elem())
+}
+
+type VslmRelocateVStorageObject_TaskResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type VslmRenameVStorageObject VslmRenameVStorageObjectRequestType
+
+func init() {
+	types.Add("vslm:VslmRenameVStorageObject", reflect.TypeOf((*VslmRenameVStorageObject)(nil)).Elem())
+}
+
+type VslmRenameVStorageObjectRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+	Id   types.ID                     `xml:"id"`
+	Name string                       `xml:"name"`
+}
+
+func init() {
+	types.Add("vslm:VslmRenameVStorageObjectRequestType", reflect.TypeOf((*VslmRenameVStorageObjectRequestType)(nil)).Elem())
+}
+
+type VslmRenameVStorageObjectResponse struct {
+}
+
+type VslmRetrieveSnapshotDetails VslmRetrieveSnapshotDetailsRequestType
+
+func init() {
+	types.Add("vslm:VslmRetrieveSnapshotDetails", reflect.TypeOf((*VslmRetrieveSnapshotDetails)(nil)).Elem())
+}
+
+type VslmRetrieveSnapshotDetailsRequestType struct {
+	This       types.ManagedObjectReference `xml:"_this"`
+	Id         types.ID                     `xml:"id"`
+	SnapshotId types.ID                     `xml:"snapshotId"`
+}
+
+func init() {
+	types.Add("vslm:VslmRetrieveSnapshotDetailsRequestType", reflect.TypeOf((*VslmRetrieveSnapshotDetailsRequestType)(nil)).Elem())
+}
+
+type VslmRetrieveSnapshotDetailsResponse struct {
+	Returnval types.VStorageObjectSnapshotDetails `xml:"returnval"`
+}
+
+type VslmRetrieveSnapshotInfo VslmRetrieveSnapshotInfoRequestType
+
+func init() {
+	types.Add("vslm:VslmRetrieveSnapshotInfo", reflect.TypeOf((*VslmRetrieveSnapshotInfo)(nil)).Elem())
+}
+
+type VslmRetrieveSnapshotInfoRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+	Id   types.ID                     `xml:"id"`
+}
+
+func init() {
+	types.Add("vslm:VslmRetrieveSnapshotInfoRequestType", reflect.TypeOf((*VslmRetrieveSnapshotInfoRequestType)(nil)).Elem())
+}
+
+type VslmRetrieveSnapshotInfoResponse struct {
+	Returnval types.VStorageObjectSnapshotInfo `xml:"returnval"`
+}
+
+type VslmRetrieveVStorageInfrastructureObjectPolicy VslmRetrieveVStorageInfrastructureObjectPolicyRequestType
+
+func init() {
+	types.Add("vslm:VslmRetrieveVStorageInfrastructureObjectPolicy", reflect.TypeOf((*VslmRetrieveVStorageInfrastructureObjectPolicy)(nil)).Elem())
+}
+
+type VslmRetrieveVStorageInfrastructureObjectPolicyRequestType struct {
+	This      types.ManagedObjectReference `xml:"_this"`
+	Datastore types.ManagedObjectReference `xml:"datastore"`
+}
+
+func init() {
+	types.Add("vslm:VslmRetrieveVStorageInfrastructureObjectPolicyRequestType", reflect.TypeOf((*VslmRetrieveVStorageInfrastructureObjectPolicyRequestType)(nil)).Elem())
+}
+
+type VslmRetrieveVStorageInfrastructureObjectPolicyResponse struct {
+	Returnval []types.VslmInfrastructureObjectPolicy `xml:"returnval,omitempty"`
+}
+
+type VslmRetrieveVStorageObject VslmRetrieveVStorageObjectRequestType
+
+func init() {
+	types.Add("vslm:VslmRetrieveVStorageObject", reflect.TypeOf((*VslmRetrieveVStorageObject)(nil)).Elem())
+}
+
+type VslmRetrieveVStorageObjectAssociations VslmRetrieveVStorageObjectAssociationsRequestType
+
+func init() {
+	types.Add("vslm:VslmRetrieveVStorageObjectAssociations", reflect.TypeOf((*VslmRetrieveVStorageObjectAssociations)(nil)).Elem())
+}
+
+type VslmRetrieveVStorageObjectAssociationsRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+	Ids  []types.ID                   `xml:"ids,omitempty"`
+}
+
+func init() {
+	types.Add("vslm:VslmRetrieveVStorageObjectAssociationsRequestType", reflect.TypeOf((*VslmRetrieveVStorageObjectAssociationsRequestType)(nil)).Elem())
+}
+
+type VslmRetrieveVStorageObjectAssociationsResponse struct {
+	Returnval []VslmVsoVStorageObjectAssociations `xml:"returnval,omitempty"`
+}
+
+type VslmRetrieveVStorageObjectMetadata VslmRetrieveVStorageObjectMetadataRequestType
+
+func init() {
+	types.Add("vslm:VslmRetrieveVStorageObjectMetadata", reflect.TypeOf((*VslmRetrieveVStorageObjectMetadata)(nil)).Elem())
+}
+
+type VslmRetrieveVStorageObjectMetadataRequestType struct {
+	This       types.ManagedObjectReference `xml:"_this"`
+	Id         types.ID                     `xml:"id"`
+	SnapshotId *types.ID                    `xml:"snapshotId,omitempty"`
+	Prefix     string                       `xml:"prefix,omitempty"`
+}
+
+func init() {
+	types.Add("vslm:VslmRetrieveVStorageObjectMetadataRequestType", reflect.TypeOf((*VslmRetrieveVStorageObjectMetadataRequestType)(nil)).Elem())
+}
+
+type VslmRetrieveVStorageObjectMetadataResponse struct {
+	Returnval []types.KeyValue `xml:"returnval,omitempty"`
+}
+
+type VslmRetrieveVStorageObjectMetadataValue VslmRetrieveVStorageObjectMetadataValueRequestType
+
+func init() {
+	types.Add("vslm:VslmRetrieveVStorageObjectMetadataValue", reflect.TypeOf((*VslmRetrieveVStorageObjectMetadataValue)(nil)).Elem())
+}
+
+type VslmRetrieveVStorageObjectMetadataValueRequestType struct {
+	This       types.ManagedObjectReference `xml:"_this"`
+	Id         types.ID                     `xml:"id"`
+	SnapshotId *types.ID                    `xml:"snapshotId,omitempty"`
+	Key        string                       `xml:"key"`
+}
+
+func init() {
+	types.Add("vslm:VslmRetrieveVStorageObjectMetadataValueRequestType", reflect.TypeOf((*VslmRetrieveVStorageObjectMetadataValueRequestType)(nil)).Elem())
+}
+
+type VslmRetrieveVStorageObjectMetadataValueResponse struct {
+	Returnval string `xml:"returnval"`
+}
+
+type VslmRetrieveVStorageObjectRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+	Id   types.ID                     `xml:"id"`
+}
+
+func init() {
+	types.Add("vslm:VslmRetrieveVStorageObjectRequestType", reflect.TypeOf((*VslmRetrieveVStorageObjectRequestType)(nil)).Elem())
+}
+
+type VslmRetrieveVStorageObjectResponse struct {
+	Returnval types.VStorageObject `xml:"returnval"`
+}
+
+type VslmRetrieveVStorageObjectState VslmRetrieveVStorageObjectStateRequestType
+
+func init() {
+	types.Add("vslm:VslmRetrieveVStorageObjectState", reflect.TypeOf((*VslmRetrieveVStorageObjectState)(nil)).Elem())
+}
+
+type VslmRetrieveVStorageObjectStateRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+	Id   types.ID                     `xml:"id"`
+}
+
+func init() {
+	types.Add("vslm:VslmRetrieveVStorageObjectStateRequestType", reflect.TypeOf((*VslmRetrieveVStorageObjectStateRequestType)(nil)).Elem())
+}
+
+type VslmRetrieveVStorageObjectStateResponse struct {
+	Returnval types.VStorageObjectStateInfo `xml:"returnval"`
+}
+
+type VslmRetrieveVStorageObjects VslmRetrieveVStorageObjectsRequestType
+
+func init() {
+	types.Add("vslm:VslmRetrieveVStorageObjects", reflect.TypeOf((*VslmRetrieveVStorageObjects)(nil)).Elem())
+}
+
+type VslmRetrieveVStorageObjectsRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+	Ids  []types.ID                   `xml:"ids,omitempty"`
+}
+
+func init() {
+	types.Add("vslm:VslmRetrieveVStorageObjectsRequestType", reflect.TypeOf((*VslmRetrieveVStorageObjectsRequestType)(nil)).Elem())
+}
+
+type VslmRetrieveVStorageObjectsResponse struct {
+	Returnval []VslmVsoVStorageObjectResult `xml:"returnval,omitempty"`
+}
+
+type VslmRevertVStorageObjectRequestType struct {
+	This       types.ManagedObjectReference `xml:"_this"`
+	Id         types.ID                     `xml:"id"`
+	SnapshotId types.ID                     `xml:"snapshotId"`
+}
+
+func init() {
+	types.Add("vslm:VslmRevertVStorageObjectRequestType", reflect.TypeOf((*VslmRevertVStorageObjectRequestType)(nil)).Elem())
+}
+
+type VslmRevertVStorageObject_Task VslmRevertVStorageObjectRequestType
+
+func init() {
+	types.Add("vslm:VslmRevertVStorageObject_Task", reflect.TypeOf((*VslmRevertVStorageObject_Task)(nil)).Elem())
+}
+
+type VslmRevertVStorageObject_TaskResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type VslmScheduleReconcileDatastoreInventory VslmScheduleReconcileDatastoreInventoryRequestType
+
+func init() {
+	types.Add("vslm:VslmScheduleReconcileDatastoreInventory", reflect.TypeOf((*VslmScheduleReconcileDatastoreInventory)(nil)).Elem())
+}
+
+type VslmScheduleReconcileDatastoreInventoryRequestType struct {
+	This      types.ManagedObjectReference `xml:"_this"`
+	Datastore types.ManagedObjectReference `xml:"datastore"`
+}
+
+func init() {
+	types.Add("vslm:VslmScheduleReconcileDatastoreInventoryRequestType", reflect.TypeOf((*VslmScheduleReconcileDatastoreInventoryRequestType)(nil)).Elem())
+}
+
+type VslmScheduleReconcileDatastoreInventoryResponse struct {
+}
+
+type VslmServiceInstanceContent struct {
+	types.DynamicData
+
+	AboutInfo               VslmAboutInfo                `xml:"aboutInfo"`
+	SessionManager          types.ManagedObjectReference `xml:"sessionManager"`
+	VStorageObjectManager   types.ManagedObjectReference `xml:"vStorageObjectManager"`
+	StorageLifecycleManager types.ManagedObjectReference `xml:"storageLifecycleManager"`
+}
+
+func init() {
+	types.Add("vslm:VslmServiceInstanceContent", reflect.TypeOf((*VslmServiceInstanceContent)(nil)).Elem())
+}
+
+type VslmSetVStorageObjectControlFlags VslmSetVStorageObjectControlFlagsRequestType
+
+func init() {
+	types.Add("vslm:VslmSetVStorageObjectControlFlags", reflect.TypeOf((*VslmSetVStorageObjectControlFlags)(nil)).Elem())
+}
+
+type VslmSetVStorageObjectControlFlagsRequestType struct {
+	This         types.ManagedObjectReference `xml:"_this"`
+	Id           types.ID                     `xml:"id"`
+	ControlFlags []string                     `xml:"controlFlags,omitempty"`
+}
+
+func init() {
+	types.Add("vslm:VslmSetVStorageObjectControlFlagsRequestType", reflect.TypeOf((*VslmSetVStorageObjectControlFlagsRequestType)(nil)).Elem())
+}
+
+type VslmSetVStorageObjectControlFlagsResponse struct {
+}
+
+type VslmSyncDatastore VslmSyncDatastoreRequestType
+
+func init() {
+	types.Add("vslm:VslmSyncDatastore", reflect.TypeOf((*VslmSyncDatastore)(nil)).Elem())
+}
+
+type VslmSyncDatastoreRequestType struct {
+	This         types.ManagedObjectReference `xml:"_this"`
+	DatastoreUrl string                       `xml:"datastoreUrl"`
+	FullSync     bool                         `xml:"fullSync"`
+}
+
+func init() {
+	types.Add("vslm:VslmSyncDatastoreRequestType", reflect.TypeOf((*VslmSyncDatastoreRequestType)(nil)).Elem())
+}
+
+type VslmSyncDatastoreResponse struct {
+}
+
+type VslmSyncFault struct {
+	VslmFault
+}
+
+func init() {
+	types.Add("vslm:VslmSyncFault", reflect.TypeOf((*VslmSyncFault)(nil)).Elem())
+}
+
+type VslmSyncFaultFault VslmSyncFault
+
+func init() {
+	types.Add("vslm:VslmSyncFaultFault", reflect.TypeOf((*VslmSyncFaultFault)(nil)).Elem())
+}
+
+type VslmTaskInfo struct {
+	types.DynamicData
+
+	Key           string                         `xml:"key"`
+	Task          types.ManagedObjectReference   `xml:"task"`
+	Description   *types.LocalizableMessage      `xml:"description,omitempty"`
+	Name          string                         `xml:"name,omitempty"`
+	DescriptionId string                         `xml:"descriptionId"`
+	Entity        *types.ManagedObjectReference  `xml:"entity,omitempty"`
+	EntityName    string                         `xml:"entityName,omitempty"`
+	Locked        []types.ManagedObjectReference `xml:"locked,omitempty"`
+	State         VslmTaskInfoState              `xml:"state"`
+	Cancelled     bool                           `xml:"cancelled"`
+	Cancelable    bool                           `xml:"cancelable"`
+	Error         *types.LocalizedMethodFault    `xml:"error,omitempty"`
+	Result        types.AnyType                  `xml:"result,omitempty,typeattr"`
+	Progress      int32                          `xml:"progress,omitempty"`
+	Reason        BaseVslmTaskReason             `xml:"reason,typeattr"`
+	QueueTime     time.Time                      `xml:"queueTime"`
+	StartTime     *time.Time                     `xml:"startTime"`
+	CompleteTime  *time.Time                     `xml:"completeTime"`
+	EventChainId  int32                          `xml:"eventChainId"`
+	ChangeTag     string                         `xml:"changeTag,omitempty"`
+	ParentTaskKey string                         `xml:"parentTaskKey,omitempty"`
+	RootTaskKey   string                         `xml:"rootTaskKey,omitempty"`
+	ActivationId  string                         `xml:"activationId,omitempty"`
+}
+
+func init() {
+	types.Add("vslm:VslmTaskInfo", reflect.TypeOf((*VslmTaskInfo)(nil)).Elem())
+}
+
+type VslmTaskReason struct {
+	types.DynamicData
+}
+
+func init() {
+	types.Add("vslm:VslmTaskReason", reflect.TypeOf((*VslmTaskReason)(nil)).Elem())
+}
+
+type VslmTaskReasonAlarm struct {
+	VslmTaskReason
+
+	AlarmName  string                       `xml:"alarmName"`
+	Alarm      types.ManagedObjectReference `xml:"alarm"`
+	EntityName string                       `xml:"entityName"`
+	Entity     types.ManagedObjectReference `xml:"entity"`
+}
+
+func init() {
+	types.Add("vslm:VslmTaskReasonAlarm", reflect.TypeOf((*VslmTaskReasonAlarm)(nil)).Elem())
+}
+
+type VslmTaskReasonSchedule struct {
+	VslmTaskReason
+
+	Name          string                       `xml:"name"`
+	ScheduledTask types.ManagedObjectReference `xml:"scheduledTask"`
+}
+
+func init() {
+	types.Add("vslm:VslmTaskReasonSchedule", reflect.TypeOf((*VslmTaskReasonSchedule)(nil)).Elem())
+}
+
+type VslmTaskReasonSystem struct {
+	VslmTaskReason
+}
+
+func init() {
+	types.Add("vslm:VslmTaskReasonSystem", reflect.TypeOf((*VslmTaskReasonSystem)(nil)).Elem())
+}
+
+type VslmTaskReasonUser struct {
+	VslmTaskReason
+
+	UserName string `xml:"userName"`
+}
+
+func init() {
+	types.Add("vslm:VslmTaskReasonUser", reflect.TypeOf((*VslmTaskReasonUser)(nil)).Elem())
+}
+
+type VslmUpdateVStorageInfrastructureObjectPolicyRequestType struct {
+	This types.ManagedObjectReference             `xml:"_this"`
+	Spec types.VslmInfrastructureObjectPolicySpec `xml:"spec"`
+}
+
+func init() {
+	types.Add("vslm:VslmUpdateVStorageInfrastructureObjectPolicyRequestType", reflect.TypeOf((*VslmUpdateVStorageInfrastructureObjectPolicyRequestType)(nil)).Elem())
+}
+
+type VslmUpdateVStorageInfrastructureObjectPolicy_Task VslmUpdateVStorageInfrastructureObjectPolicyRequestType
+
+func init() {
+	types.Add("vslm:VslmUpdateVStorageInfrastructureObjectPolicy_Task", reflect.TypeOf((*VslmUpdateVStorageInfrastructureObjectPolicy_Task)(nil)).Elem())
+}
+
+type VslmUpdateVStorageInfrastructureObjectPolicy_TaskResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type VslmUpdateVStorageObjectMetadataRequestType struct {
+	This       types.ManagedObjectReference `xml:"_this"`
+	Id         types.ID                     `xml:"id"`
+	Metadata   []types.KeyValue             `xml:"metadata,omitempty"`
+	DeleteKeys []string                     `xml:"deleteKeys,omitempty"`
+}
+
+func init() {
+	types.Add("vslm:VslmUpdateVStorageObjectMetadataRequestType", reflect.TypeOf((*VslmUpdateVStorageObjectMetadataRequestType)(nil)).Elem())
+}
+
+type VslmUpdateVStorageObjectMetadata_Task VslmUpdateVStorageObjectMetadataRequestType
+
+func init() {
+	types.Add("vslm:VslmUpdateVStorageObjectMetadata_Task", reflect.TypeOf((*VslmUpdateVStorageObjectMetadata_Task)(nil)).Elem())
+}
+
+type VslmUpdateVStorageObjectMetadata_TaskResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type VslmUpdateVstorageObjectPolicyRequestType struct {
+	This    types.ManagedObjectReference      `xml:"_this"`
+	Id      types.ID                          `xml:"id"`
+	Profile []types.VirtualMachineProfileSpec `xml:"profile,omitempty"`
+}
+
+func init() {
+	types.Add("vslm:VslmUpdateVstorageObjectPolicyRequestType", reflect.TypeOf((*VslmUpdateVstorageObjectPolicyRequestType)(nil)).Elem())
+}
+
+type VslmUpdateVstorageObjectPolicy_Task VslmUpdateVstorageObjectPolicyRequestType
+
+func init() {
+	types.Add("vslm:VslmUpdateVstorageObjectPolicy_Task", reflect.TypeOf((*VslmUpdateVstorageObjectPolicy_Task)(nil)).Elem())
+}
+
+type VslmUpdateVstorageObjectPolicy_TaskResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type VslmVsoVStorageObjectAssociations struct {
+	types.DynamicData
+
+	Id                types.ID                                             `xml:"id"`
+	VmDiskAssociation []VslmVsoVStorageObjectAssociationsVmDiskAssociation `xml:"vmDiskAssociation,omitempty"`
+	Fault             *types.LocalizedMethodFault                          `xml:"fault,omitempty"`
+}
+
+func init() {
+	types.Add("vslm:VslmVsoVStorageObjectAssociations", reflect.TypeOf((*VslmVsoVStorageObjectAssociations)(nil)).Elem())
+}
+
+type VslmVsoVStorageObjectAssociationsVmDiskAssociation struct {
+	types.DynamicData
+
+	VmId    string `xml:"vmId"`
+	DiskKey int32  `xml:"diskKey"`
+}
+
+func init() {
+	types.Add("vslm:VslmVsoVStorageObjectAssociationsVmDiskAssociation", reflect.TypeOf((*VslmVsoVStorageObjectAssociationsVmDiskAssociation)(nil)).Elem())
+}
+
+type VslmVsoVStorageObjectQueryResult struct {
+	types.DynamicData
+
+	AllRecordsReturned bool                          `xml:"allRecordsReturned"`
+	Id                 []types.ID                    `xml:"id,omitempty"`
+	QueryResults       []VslmVsoVStorageObjectResult `xml:"queryResults,omitempty"`
+}
+
+func init() {
+	types.Add("vslm:VslmVsoVStorageObjectQueryResult", reflect.TypeOf((*VslmVsoVStorageObjectQueryResult)(nil)).Elem())
+}
+
+type VslmVsoVStorageObjectQuerySpec struct {
+	types.DynamicData
+
+	QueryField    string   `xml:"queryField"`
+	QueryOperator string   `xml:"queryOperator"`
+	QueryValue    []string `xml:"queryValue,omitempty"`
+}
+
+func init() {
+	types.Add("vslm:VslmVsoVStorageObjectQuerySpec", reflect.TypeOf((*VslmVsoVStorageObjectQuerySpec)(nil)).Elem())
+}
+
+type VslmVsoVStorageObjectResult struct {
+	types.DynamicData
+
+	Id              types.ID                              `xml:"id"`
+	Name            string                                `xml:"name,omitempty"`
+	CapacityInMB    int64                                 `xml:"capacityInMB"`
+	CreateTime      *time.Time                            `xml:"createTime"`
+	DatastoreUrl    string                                `xml:"datastoreUrl,omitempty"`
+	BackingObjectId *types.ID                             `xml:"backingObjectId,omitempty"`
+	SnapshotInfo    []VslmVsoVStorageObjectSnapshotResult `xml:"snapshotInfo,omitempty"`
+	Metadata        []types.KeyValue                      `xml:"metadata,omitempty"`
+	Error           *types.LocalizedMethodFault           `xml:"error,omitempty"`
+}
+
+func init() {
+	types.Add("vslm:VslmVsoVStorageObjectResult", reflect.TypeOf((*VslmVsoVStorageObjectResult)(nil)).Elem())
+}
+
+type VslmVsoVStorageObjectSnapshotResult struct {
+	types.DynamicData
+
+	BackingObjectId types.ID `xml:"backingObjectId"`
+}
+
+func init() {
+	types.Add("vslm:VslmVsoVStorageObjectSnapshotResult", reflect.TypeOf((*VslmVsoVStorageObjectSnapshotResult)(nil)).Elem())
+}
+
+type VersionURI string
+
+func init() {
+	types.Add("vslm:versionURI", reflect.TypeOf((*VersionURI)(nil)).Elem())
+}


### PR DESCRIPTION
With this I can `ko create -f tags.yaml` to create tags with `govc` in a Job
against the simulator where the credentials are bound in with `VSphereBinding`:
```
kubectl logs vcsim-setup-tags-zmd2w-tvsf8 --all-containers
urn:vmomi:InventoryServiceTag:f6fa3432-ad70-4474-8564-b7500b789142:GLOBAL
urn:vmomi:InventoryServiceCategory:7a62b349-affd-4237-a641-3357ad442851:GLOBAL
```

This also creates `vsphere.NewREST` for creating a client suitable for doing the
same through the govmomi libraries.

Fixes: https://github.com/mattmoor/vmware-sources/issues/15